### PR TITLE
Fix AI import URL prompt flow

### DIFF
--- a/src/app/api/ai/generate/route.ts
+++ b/src/app/api/ai/generate/route.ts
@@ -1,9 +1,11 @@
 import { generateText } from 'ai';
 import { NextRequest, NextResponse } from 'next/server';
 import { resolveApiKey, resolveModel } from '@/lib/ai-model';
+import { parseAIJson } from '@/lib/parse-ai-json';
 import { enforcePlatformRateLimit } from '@/lib/platform-provider';
 import { ProviderResolutionError, resolveProviderForCapability } from '@/lib/provider-resolver';
 import { type ProviderConfig, type ProviderId } from '@/lib/providers';
+import { extractFirstUrl, fetchWebPageContent, removeUrlFromPrompt } from '@/lib/web-page';
 
 export const runtime = 'nodejs';
 export const maxDuration = 60;
@@ -11,20 +13,23 @@ export const maxDuration = 60;
 export async function POST(req: NextRequest) {
   try {
     const {
+      prompt,
       topic,
       difficulty,
       contentType,
       provider = 'groq',
       providerConfigs = {},
     }: {
-      topic: string;
+      prompt?: string;
+      topic?: string;
       difficulty: string;
       contentType: string;
       provider?: ProviderId;
       providerConfigs?: Partial<Record<ProviderId, Partial<ProviderConfig>>>;
     } = await req.json();
 
-    if (!topic || !difficulty || !contentType) {
+    const userPrompt = prompt?.trim() || topic?.trim() || '';
+    if (!userPrompt || !difficulty || !contentType) {
       return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
     }
 
@@ -62,25 +67,58 @@ export async function POST(req: NextRequest) {
     });
 
     const typeInstructions: Record<string, string> = {
-      word: 'Generate 10-15 vocabulary words, each on a new line in the format: word - brief definition',
-      sentence: 'Generate 5-8 practice sentences, each on a new line',
-      article: 'Generate a 150-200 word article',
+      word: 'Generate 10-15 vocabulary words, each on a new line in the format: word - brief definition.',
+      sentence: 'Generate 5-8 practice sentences, each on a new line.',
+      article: 'Generate a 150-200 word article.',
     };
 
     const instruction = typeInstructions[contentType] || typeInstructions.article;
+    const sourceUrl = extractFirstUrl(userPrompt);
+    const instructionWithoutUrl = sourceUrl ? removeUrlFromPrompt(userPrompt, sourceUrl) : userPrompt;
+    const sourcePage = sourceUrl ? await fetchWebPageContent(sourceUrl) : null;
+
+    const sourceBlock = sourcePage
+      ? `Source URL: ${sourcePage.url}
+Source title: ${sourcePage.title}
+Source text:
+${sourcePage.text.slice(0, 12000)}`
+      : '';
+
+    const generationRequest = sourcePage
+      ? instructionWithoutUrl || `Use the source page to create ${difficulty} ${contentType} practice content.`
+      : userPrompt;
 
     const { text } = await generateText({
       model,
-      system: `You are an English learning content generator. Generate content for ${difficulty} level students about the topic: ${topic}. ${instruction}. Return only the content, no explanations or headers.`,
-      prompt: `Generate ${contentType} content about: ${topic}`,
+      system: `You are an English learning content generator.
+Generate ${contentType} content for ${difficulty} English learners.
+${instruction}
+Return ONLY valid JSON with this exact shape:
+{"title":"short concise title","text":"generated content"}
+Do not wrap the JSON in markdown.`,
+      prompt: sourcePage
+        ? `User request:
+${generationRequest}
+
+${sourceBlock}`
+        : `User request:
+${generationRequest}`,
     });
 
-    const title = `${topic.charAt(0).toUpperCase() + topic.slice(1)} (${difficulty})`;
+    const parsed = parseAIJson<{ title?: string; text?: string }>(text);
+    const titleFallback = sourcePage?.title || `${contentType} practice`;
+    const contentText = parsed.data?.text?.trim() || text.trim();
+    const title = parsed.data?.title?.trim() || `${titleFallback} (${difficulty})`;
+
+    if (!contentText) {
+      return NextResponse.json({ error: 'AI returned empty content' }, { status: 502 });
+    }
 
     return NextResponse.json({
       title,
-      text,
+      text: contentText,
       type: contentType === 'word' ? 'word' : contentType === 'sentence' ? 'sentence' : 'article',
+      sourceUrl: sourcePage?.url,
       providerId: resolution.providerId,
       credentialSource: resolution.credentialSource,
       fallbackApplied: resolution.fallbackApplied,

--- a/src/components/import/ai-generate.tsx
+++ b/src/components/import/ai-generate.tsx
@@ -21,17 +21,19 @@ export function AIGenerate() {
   const activeProviderId = useProviderStore((s) => s.activeProviderId);
   const activeConfig = useProviderStore((s) => s.getActiveConfig());
   const providers = useProviderStore((s) => s.providers);
-  const [topic, setTopic] = useState('');
+  const [prompt, setPrompt] = useState('');
   const [difficulty, setDifficulty] = useState<Difficulty>('beginner');
   const [contentType, setContentType] = useState<ContentType>('sentence');
   const [generating, setGenerating] = useState(false);
   const [error, setError] = useState('');
-  const [result, setResult] = useState<{ title: string; text: string; type: ContentType } | null>(null);
+  const [result, setResult] = useState<{ title: string; text: string; type: ContentType; sourceUrl?: string } | null>(
+    null,
+  );
   const [saving, setSaving] = useState(false);
   const [tags, setTags] = useState('');
 
   const handleGenerate = async () => {
-    if (!topic.trim()) return;
+    if (!prompt.trim()) return;
     setGenerating(true);
     setError('');
     setResult(null);
@@ -44,7 +46,7 @@ export function AIGenerate() {
         method: 'POST',
         headers,
         body: JSON.stringify({
-          topic: topic.trim(),
+          prompt: prompt.trim(),
           difficulty,
           contentType,
           provider: activeProviderId,
@@ -73,9 +75,10 @@ export function AIGenerate() {
       title: result.title,
       text: result.text,
       type: result.type,
-      tags: [...new Set([...normalizeTags(tags), topic.trim().toLowerCase()])].filter(Boolean),
+      tags: normalizeTags(tags),
       source: 'ai-generated',
       difficulty,
+      metadata: result.sourceUrl ? { sourceUrl: result.sourceUrl } : undefined,
       createdAt: now,
       updatedAt: now,
     };
@@ -87,17 +90,18 @@ export function AIGenerate() {
   return (
     <div className="space-y-4">
       <p className="text-sm text-indigo-500">
-        Generate English learning content using AI. Choose a topic, difficulty, and content type.
+        Generate English learning content with a prompt, topic, or webpage URL. You can also add instructions in Chinese
+        or English.
       </p>
       <div>
-        <label htmlFor="ai-generate-topic" className="text-sm font-medium text-indigo-700 mb-1 block">
-          Topic
+        <label htmlFor="ai-generate-prompt" className="text-sm font-medium text-indigo-700 mb-1 block">
+          Prompt
         </label>
         <Input
-          id="ai-generate-topic"
-          value={topic}
-          onChange={(e) => setTopic(e.target.value)}
-          placeholder="e.g. technology, travel, daily conversation, business..."
+          id="ai-generate-prompt"
+          value={prompt}
+          onChange={(e) => setPrompt(e.target.value)}
+          placeholder="e.g. Explain this article for beginners: https://example.com/article"
           className="bg-white border-slate-200"
         />
       </div>
@@ -155,11 +159,11 @@ export function AIGenerate() {
           placeholder="e.g. ai-generated, grammar"
           className="bg-white border-slate-200"
         />
-        <p className="text-xs text-indigo-400 mt-1">Topic is auto-added as a tag</p>
+        <p className="text-xs text-indigo-400 mt-1">Optional tags for organizing the generated content</p>
       </div>
       <Button
         onClick={handleGenerate}
-        disabled={!topic.trim() || generating}
+        disabled={!prompt.trim() || generating}
         className="w-full bg-indigo-600 hover:bg-indigo-700 cursor-pointer"
       >
         {generating ? (

--- a/src/lib/provider-resolver.test.ts
+++ b/src/lib/provider-resolver.test.ts
@@ -75,6 +75,25 @@ describe('provider resolver', () => {
     expect(resolution.credentialSource).toBe('stored');
   });
 
+  it('uses another configured provider when the requested chain is unavailable', () => {
+    const resolution = resolveProviderForCapability({
+      capability: 'generate',
+      requestedProviderId: 'groq',
+      availableProviderConfigs: {
+        anthropic: {
+          providerId: 'anthropic',
+          auth: { type: 'api-key', apiKey: 'anthropic-key' },
+          selectedModelId: 'claude-sonnet-4-5-20251001',
+        },
+      },
+    });
+
+    expect(resolution.providerId).toBe('anthropic');
+    expect(resolution.fallbackApplied).toBe(true);
+    expect(resolution.credentialSource).toBe('stored');
+    expect(resolution.fallbackReason).toContain('using configured provider anthropic');
+  });
+
   it('throws a structured error when no provider is available', () => {
     expect(() =>
       resolveProviderForCapability({

--- a/src/lib/provider-resolver.ts
+++ b/src/lib/provider-resolver.ts
@@ -6,6 +6,7 @@ import {
 } from './provider-capabilities';
 import {
   getDefaultModelId,
+  PROVIDER_IDS,
   PROVIDER_REGISTRY,
   type ProviderAuthState,
   type ProviderConfig,
@@ -97,6 +98,46 @@ function uniqueChain(requestedProviderId: ProviderId, capability: ProviderCapabi
   );
 }
 
+function resolveConfiguredProvider(
+  capability: ProviderCapability,
+  availableProviderConfigs: Partial<Record<ProviderId, Partial<ProviderConfig>>>,
+  headers: Headers,
+  excludedProviderIds: Set<ProviderId>,
+): ProviderResolution | null {
+  for (const providerId of PROVIDER_IDS) {
+    if (excludedProviderIds.has(providerId)) {
+      continue;
+    }
+
+    if (!providerSupportsCapability(providerId, capability)) {
+      continue;
+    }
+
+    const providerConfig = availableProviderConfigs[providerId];
+    const credentials = resolveCredentials(providerId, headers, providerConfig);
+    if (!credentials.available || !credentials.source) {
+      continue;
+    }
+
+    const modelId =
+      providerConfig?.modelOverrides?.[capability] ||
+      getRecommendedModelForCapability(providerId, capability)?.modelId ||
+      providerConfig?.selectedModelId ||
+      getDefaultModelId(providerId);
+
+    return {
+      providerId,
+      modelId,
+      fallbackApplied: true,
+      credentialSource: credentials.source,
+      baseUrl: providerConfig?.baseUrl || PROVIDER_REGISTRY[providerId].baseUrl,
+      apiPath: providerConfig?.apiPath || PROVIDER_REGISTRY[providerId].apiPath,
+    };
+  }
+
+  return null;
+}
+
 export function resolveProviderForCapability({
   capability,
   requestedProviderId,
@@ -104,8 +145,11 @@ export function resolveProviderForCapability({
   headers = new Headers(),
 }: ProviderResolverInput): ProviderResolution {
   const fallbackNotes: string[] = [];
+  const attemptedProviders = new Set<ProviderId>();
 
   for (const providerId of uniqueChain(requestedProviderId, capability)) {
+    attemptedProviders.add(providerId);
+
     if (!providerSupportsCapability(providerId, capability)) {
       fallbackNotes.push(`${providerId} does not support ${capability}`);
       continue;
@@ -132,6 +176,19 @@ export function resolveProviderForCapability({
       credentialSource: credentials.source,
       baseUrl: providerConfig?.baseUrl || PROVIDER_REGISTRY[providerId].baseUrl,
       apiPath: providerConfig?.apiPath || PROVIDER_REGISTRY[providerId].apiPath,
+    };
+  }
+
+  const configuredProvider = resolveConfiguredProvider(
+    capability,
+    availableProviderConfigs,
+    headers,
+    attemptedProviders,
+  );
+  if (configuredProvider) {
+    return {
+      ...configuredProvider,
+      fallbackReason: [...fallbackNotes, `using configured provider ${configuredProvider.providerId}`].join('; '),
     };
   }
 

--- a/src/lib/web-page.test.ts
+++ b/src/lib/web-page.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { extractFirstUrl, fetchWebPageContent, htmlToText, removeUrlFromPrompt } from './web-page';
+
+describe('web-page helpers', () => {
+  it('extracts the first URL from a prompt', () => {
+    expect(extractFirstUrl('Explain https://example.com/article in Chinese')).toBe('https://example.com/article');
+  });
+
+  it('removes the extracted URL and preserves the rest of the prompt', () => {
+    expect(removeUrlFromPrompt('Explain https://example.com/article in Chinese', 'https://example.com/article')).toBe(
+      'Explain in Chinese',
+    );
+  });
+
+  it('extracts readable text from article-like html', () => {
+    const result = htmlToText(`
+      <html>
+        <head><title>Sample Article</title></head>
+        <body>
+          <article>
+            <h1>Heading</h1>
+            <p>First paragraph.</p>
+            <p>Second paragraph.</p>
+          </article>
+        </body>
+      </html>
+    `);
+
+    expect(result.title).toBe('Sample Article');
+    expect(result.text).toContain('Heading');
+    expect(result.text).toContain('First paragraph.');
+    expect(result.text).toContain('Second paragraph.');
+  });
+
+  it('rejects localhost and private network URLs', async () => {
+    await expect(fetchWebPageContent('http://localhost:3000/test')).rejects.toThrow('Private or local URLs are not allowed');
+    await expect(fetchWebPageContent('http://192.168.1.20/test')).rejects.toThrow('Private or local URLs are not allowed');
+  });
+});

--- a/src/lib/web-page.ts
+++ b/src/lib/web-page.ts
@@ -1,0 +1,169 @@
+const URL_REGEX = /https?:\/\/[^\s]+/i;
+
+function isPrivateHostname(hostname: string): boolean {
+  const normalized = hostname.toLowerCase();
+
+  if (normalized === 'localhost' || normalized === '0.0.0.0' || normalized === '::1') {
+    return true;
+  }
+
+  if (normalized.endsWith('.local') || normalized.endsWith('.internal')) {
+    return true;
+  }
+
+  if (
+    /^127\./.test(normalized) ||
+    /^10\./.test(normalized) ||
+    /^192\.168\./.test(normalized) ||
+    /^169\.254\./.test(normalized)
+  ) {
+    return true;
+  }
+
+  const private172Match = normalized.match(/^172\.(\d{1,3})\./);
+  if (private172Match) {
+    const secondOctet = Number(private172Match[1]);
+    if (secondOctet >= 16 && secondOctet <= 31) {
+      return true;
+    }
+  }
+
+  if (normalized.startsWith('[') && normalized.endsWith(']')) {
+    const ipv6 = normalized.slice(1, -1);
+    if (ipv6 === '::1' || ipv6.startsWith('fc') || ipv6.startsWith('fd') || ipv6.startsWith('fe80:')) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function stripTags(html: string): string {
+  return html
+    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<noscript[\s\S]*?<\/noscript>/gi, ' ')
+    .replace(/<svg[\s\S]*?<\/svg>/gi, ' ')
+    .replace(/<\/(p|div|section|article|main|h1|h2|h3|h4|h5|h6|li|blockquote|pre)>/gi, '$&\n')
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<[^>]+>/g, ' ');
+}
+
+function decodeHtmlEntities(text: string): string {
+  return text
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'")
+    .replace(/&#x27;/gi, "'")
+    .replace(/&#x2F;/gi, '/')
+    .replace(/&#(\d+);/g, (_, code) => String.fromCharCode(Number(code)));
+}
+
+function normalizeWhitespace(text: string): string {
+  return text
+    .split('\n')
+    .map((line) => line.replace(/\s+/g, ' ').trim())
+    .filter(Boolean)
+    .join('\n')
+    .trim();
+}
+
+function pickContentContainer(html: string): string {
+  const articleMatch = html.match(/<article[\s\S]*?<\/article>/i);
+  if (articleMatch) return articleMatch[0];
+
+  const mainMatch = html.match(/<main[\s\S]*?<\/main>/i);
+  if (mainMatch) return mainMatch[0];
+
+  const bodyMatch = html.match(/<body[\s\S]*?<\/body>/i);
+  if (bodyMatch) return bodyMatch[0];
+
+  return html;
+}
+
+function extractTitle(html: string, fallbackUrl: string): string {
+  const titleMatch = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+  if (titleMatch?.[1]) {
+    const title = normalizeWhitespace(decodeHtmlEntities(stripTags(titleMatch[1])));
+    if (title) return title;
+  }
+
+  try {
+    const url = new URL(fallbackUrl);
+    return url.hostname.replace(/^www\./, '');
+  } catch {
+    return 'Imported article';
+  }
+}
+
+export function extractFirstUrl(input: string): string | null {
+  const match = input.match(URL_REGEX);
+  return match?.[0] ?? null;
+}
+
+export function removeUrlFromPrompt(input: string, url: string): string {
+  return normalizeWhitespace(input.replace(url, ' '));
+}
+
+export function htmlToText(html: string): { title: string; text: string } {
+  const title = extractTitle(html, '');
+  const container = pickContentContainer(html);
+  const text = normalizeWhitespace(decodeHtmlEntities(stripTags(container)));
+  return { title, text };
+}
+
+export async function fetchWebPageContent(url: string): Promise<{ title: string; text: string; url: string }> {
+  const parsedUrl = new URL(url);
+  if (!['http:', 'https:'].includes(parsedUrl.protocol)) {
+    throw new Error(`Unsupported URL protocol: ${parsedUrl.protocol}`);
+  }
+
+  if (isPrivateHostname(parsedUrl.hostname)) {
+    throw new Error('Private or local URLs are not allowed');
+  }
+
+  const response = await fetch(url, {
+    headers: {
+      'User-Agent':
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36',
+      Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,text/plain;q=0.8,*/*;q=0.7',
+    },
+    signal: AbortSignal.timeout(15_000),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch page (${response.status})`);
+  }
+
+  const contentType = response.headers.get('content-type') || '';
+  if (!contentType.includes('text/html') && !contentType.includes('text/plain')) {
+    throw new Error(`Unsupported page type: ${contentType || 'unknown'}`);
+  }
+
+  const raw = await response.text();
+  if (!raw.trim()) {
+    throw new Error('Fetched page is empty');
+  }
+
+  if (contentType.includes('text/plain')) {
+    return {
+      title: new URL(url).hostname.replace(/^www\./, ''),
+      text: normalizeWhitespace(raw),
+      url,
+    };
+  }
+
+  const extracted = htmlToText(raw);
+  if (!extracted.text) {
+    throw new Error('Could not extract readable text from the page');
+  }
+
+  return {
+    title: extractTitle(raw, url),
+    text: extracted.text,
+    url,
+  };
+}


### PR DESCRIPTION
## Summary
- rename the AI Generate input from topic to prompt and support URL-based article generation
- fetch and extract public webpage content server-side for AI generation, with local/private URL blocking
- improve provider resolution so AI generate can fall back to any configured compatible provider
- add tests for provider fallback and webpage prompt parsing

## Verification
- pnpm vitest run src/lib/provider-resolver.test.ts src/lib/web-page.test.ts
- pnpm typecheck
- pnpm lint
- browser test on http://localhost:3000/library/import using https://ejholmes.github.io/2026/02/28/mcp-is-dead-long-live-the-cli.html: generation succeeded and saved to Library