### PR TITLE
Add keyboard shortcuts and Kokoro listen enhancements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,7 @@ GOOGLE_CLIENT_SECRET=
 # Local-only providers; not suitable for Vercel production deployment.
 OLLAMA_BASE_URL=http://localhost:11434
 LMSTUDIO_API_KEY=
+NEXT_PUBLIC_KOKORO_SERVER_URL=xxxx
 
 ZAI_API_KEY=your-zai-api-key
 

--- a/docs/plans/2026-03-18-keyboard-shortcut-bugs.md
+++ b/docs/plans/2026-03-18-keyboard-shortcut-bugs.md
@@ -1,0 +1,29 @@
+# Keyboard Shortcut Feature — Bug Report
+
+**Date:** 2026-03-18
+**Branch:** feat/keyboard
+
+## Bug #1: Orphaned `global:command-palette` shortcut (High)
+
+**File:** `src/lib/shortcut-definitions.ts:24-30`
+
+The shortcut `global:command-palette` (mod+k) is defined in `SHORTCUT_DEFINITIONS` but has **no handler** registered in `src/app/(app)/layout.tsx`. There is no command palette component in the codebase. Pressing Cmd+K / Ctrl+K does nothing.
+
+**Fix:** Remove the definition from `SHORTCUT_DEFINITIONS` since the feature doesn't exist yet.
+
+## Bug #2: Deprecated `navigator.platform` usage (Low)
+
+**Files:**
+- `src/hooks/use-shortcuts.ts:26`
+- `src/components/settings/shortcut-settings.tsx:24`
+
+Both files use `navigator.platform` to detect macOS, which is [deprecated](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/platform). Browsers may remove it in the future.
+
+**Fix:** Replace with a helper that uses `navigator.userAgentData?.platform` (preferred) with fallback to `navigator.userAgent`.
+
+## Summary
+
+| # | Bug | Severity | Status |
+|---|-----|----------|--------|
+| 1 | Orphaned command-palette shortcut | High | Pending |
+| 2 | Deprecated navigator.platform | Low | Pending |

--- a/docs/plans/2026-03-18-kokoro-tts-integration.md
+++ b/docs/plans/2026-03-18-kokoro-tts-integration.md
@@ -1,0 +1,121 @@
+# Kokoro TTS Integration Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add Kokoro as a fully supported TTS provider in EchoType, wired through settings, voice selection, playback, and fallback behavior.
+
+**Architecture:** Reuse the existing server-side Kokoro proxy routes and complete the client-side provider integration in the shared TTS store and hook. Treat Kokoro as a cloud provider similar to Fish Audio for chat and quick playback, while preserving browser fallback for Listen/read flows that depend on word-boundary events.
+
+**Tech Stack:** Next.js App Router, React 19, Zustand, Vitest, existing TTS routes under `src/app/api/tts`
+
+---
+
+### Task 1: Define Kokoro defaults and provider resolution
+
+**Files:**
+- Modify: `src/stores/tts-store.ts`
+- Modify: `src/lib/fish-audio-shared.ts`
+- Test: `src/__tests__/tts-store.test.ts`
+- Test: `src/lib/fish-audio.test.ts`
+
+**Step 1: Write/update failing tests**
+
+- Cover persisted Kokoro settings and source switching in `src/__tests__/tts-store.test.ts`
+- Cover `resolveTTSSource()` behavior for Kokoro config and boundary-event fallback in `src/lib/fish-audio.test.ts`
+
+**Step 2: Implement minimal state changes**
+
+- Add a shared default Kokoro server URL to the TTS store defaults
+- Extend `resolveTTSSource()` to understand Kokoro credentials, selected voice, and boundary fallback messaging
+
+**Step 3: Run focused tests**
+
+Run: `pnpm vitest src/__tests__/tts-store.test.ts src/lib/fish-audio.test.ts`
+
+**Step 4: Commit**
+
+```bash
+git add src/stores/tts-store.ts src/lib/fish-audio-shared.ts src/__tests__/tts-store.test.ts src/lib/fish-audio.test.ts
+git commit -m "feat: add kokoro tts source resolution"
+```
+
+### Task 2: Wire Kokoro playback into the shared TTS hook
+
+**Files:**
+- Modify: `src/hooks/use-tts.ts`
+- Modify: `src/lib/kokoro.ts`
+- Modify: `src/lib/kokoro-shared.ts`
+- Test: `src/lib/kokoro.test.ts`
+
+**Step 1: Write/update failing tests**
+
+- Add `src/lib/kokoro.test.ts` for voice listing and speech synthesis request shaping
+
+**Step 2: Implement minimal playback support**
+
+- Normalize Kokoro voices into `VoiceOption`
+- Load Kokoro voices when Kokoro is selected and a server URL is present
+- Add Kokoro speech playback and preview through `/api/tts/kokoro/speak`
+- Expose Kokoro loading/error state through `useTTS()`
+
+**Step 3: Run focused tests**
+
+Run: `pnpm vitest src/lib/kokoro.test.ts`
+
+**Step 4: Commit**
+
+```bash
+git add src/hooks/use-tts.ts src/lib/kokoro.ts src/lib/kokoro-shared.ts src/lib/kokoro.test.ts
+git commit -m "feat: connect kokoro playback in tts hook"
+```
+
+### Task 3: Expose Kokoro in settings and voice picker
+
+**Files:**
+- Modify: `src/app/(app)/settings/page.tsx`
+- Modify: `src/components/voice-picker.tsx`
+
+**Step 1: Add Kokoro provider UI**
+
+- Add a third source option in settings
+- Add fields for Kokoro server URL and optional API key
+- Show Kokoro-specific guidance and boundary fallback notice
+
+**Step 2: Update voice picker behavior**
+
+- Handle Kokoro loading, empty states, search text, selection, and preview
+- Make selection logic work across browser, Fish, and Kokoro
+
+**Step 3: Verify manually**
+
+Run the app and confirm Kokoro voices load from `http://54.166.253.41:8880/v1/audio/voices`, preview works, and browser fallback notice still appears in Listen/read.
+
+**Step 4: Commit**
+
+```bash
+git add src/app/'(app)'/settings/page.tsx src/components/voice-picker.tsx
+git commit -m "feat: add kokoro tts settings ui"
+```
+
+### Task 4: Add route coverage and final verification
+
+**Files:**
+- Create: `src/app/api/tts/kokoro/voices/route.test.ts`
+- Create: `src/app/api/tts/kokoro/speak/route.test.ts`
+
+**Step 1: Add route tests**
+
+- Mirror Fish route coverage for request validation, success cases, and error propagation
+
+**Step 2: Run verification**
+
+Run: `pnpm vitest src/lib/kokoro.test.ts src/lib/fish-audio.test.ts src/__tests__/tts-store.test.ts src/app/api/tts/kokoro/voices/route.test.ts src/app/api/tts/kokoro/speak/route.test.ts`
+
+Run: `pnpm typecheck`
+
+**Step 3: Commit**
+
+```bash
+git add src/app/api/tts/kokoro/voices/route.test.ts src/app/api/tts/kokoro/speak/route.test.ts
+git commit -m "test: cover kokoro tts routes"
+```

--- a/docs/plans/2026-03-19-listen-kokoro-mode.md
+++ b/docs/plans/2026-03-19-listen-kokoro-mode.md
@@ -1,0 +1,80 @@
+# Listen Kokoro Sentence Highlight Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Let the Listen detail page support two playback modes: browser speech with word highlighting, and Kokoro playback with estimated sentence highlighting when Kokoro is selected as the voice source.
+
+**Architecture:** Keep the existing browser `SpeechSynthesisUtterance.onboundary` flow for highlighted reading. On the Listen page only, detect when Kokoro is the selected voice source and route full-text playback through `useTTS().speak()` instead of the boundary-based browser utterance. While Kokoro audio is playing, estimate sentence timing from sentence word counts and playback speed so the page can highlight the active sentence without adding a slower server-side alignment step.
+
+**Tech Stack:** Next.js App Router, React 19, Zustand, existing `useTTS()` hook, Playwright/Vitest coverage
+
+---
+
+### Task 1: Encode Listen-page dual playback behavior
+
+**Files:**
+- Modify: `src/app/(app)/listen/[id]/page.tsx`
+
+**Step 1: Define the Listen page mode switch**
+
+- Treat `voiceSource === 'kokoro'` as cloud playback mode on the Listen page.
+- Treat every other source as the existing boundary-highlight mode.
+
+**Step 2: Update playback handlers**
+
+- Keep browser `createUtterance()` flow for highlighted playback.
+- Route Kokoro full-text playback and single-word preview through `useTTS().speak()`.
+- Ensure local `isPlaying` state resets correctly after Kokoro playback ends.
+- Preserve listen session persistence only for full-content playback.
+
+### Task 2: Add estimated sentence highlighting for Kokoro mode
+
+**Files:**
+- Modify: `src/app/(app)/listen/[id]/page.tsx`
+
+**Step 1: Build sentence ranges from content**
+
+- Reuse translated sentence boundaries when available.
+- Fall back to local sentence splitting when translations are unavailable.
+
+**Step 2: Schedule sentence highlight timing**
+
+- Estimate total playback duration from word count and selected speed.
+- Allocate that duration across sentences by word-count ratio.
+- Clear timers on stop, restart, and unmount.
+
+**Step 3: Update rendering**
+
+- Keep per-word highlight only in browser mode.
+- Highlight the active sentence across its words and translation block in Kokoro mode.
+
+### Task 3: Keep header and copy aligned with the active mode
+
+**Files:**
+- Modify: `src/app/(app)/listen/[id]/page.tsx`
+
+**Step 1: Show the active voice correctly**
+
+- Use the resolved/current TTS voice instead of only browser voice metadata in the Listen header.
+
+**Step 2: Update page messaging**
+
+- Replace the old boundary-fallback notice with mode-specific guidance.
+- Explain that Kokoro sentence highlighting is estimated rather than word-accurate.
+
+### Task 4: Add lightweight regression coverage
+
+**Files:**
+- Modify: `e2e/listen.spec.ts`
+
+**Step 1: Add Kokoro mode UI coverage**
+
+- Seed Listen detail page.
+- Set stored TTS voice source to Kokoro before page load.
+- Assert the Listen page shows Kokoro-specific guidance and estimated sentence highlight mode copy.
+
+**Step 2: Run focused verification**
+
+Run: `pnpm typecheck`
+
+Run: `pnpm exec playwright test e2e/listen.spec.ts`

--- a/e2e/listen.spec.ts
+++ b/e2e/listen.spec.ts
@@ -71,6 +71,25 @@ test.describe('Listen Module', () => {
     expect(count).toBeGreaterThan(0);
   });
 
+  test('listen detail shows Kokoro estimated sentence highlighting mode when Kokoro is selected', async ({ page }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem(
+        'echotype_tts_settings',
+        JSON.stringify({
+          voiceSource: 'kokoro',
+          kokoroServerUrl: 'http://example.invalid:8880',
+          kokoroVoiceId: 'af_heart',
+          kokoroVoiceName: 'Heart',
+        }),
+      );
+    });
+
+    await navigateToContentDetail(page, 'listen');
+
+    await expect(page.getByText('Kokoro playback is active on this page.')).toBeVisible();
+    await expect(page.getByText('Mode: Kokoro audio with estimated sentence highlighting')).toBeVisible();
+  });
+
   test('listen detail back button returns to list', async ({ page }) => {
     await navigateToContentDetail(page, 'listen');
 

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import './.next/types/routes.d.ts';
+import './.next/dev/types/routes.d.ts';
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/__tests__/tts-store.test.ts
+++ b/src/__tests__/tts-store.test.ts
@@ -32,6 +32,10 @@ const DEFAULT_STATE = {
   fishVoiceId: '',
   fishVoiceName: '',
   fishModel: 's2-pro',
+  kokoroServerUrl: 'http://54.166.253.41:8880',
+  kokoroApiKey: '',
+  kokoroVoiceId: 'af_heart',
+  kokoroVoiceName: 'Heart',
   targetLang: 'zh-CN',
   showTranslation: true,
   recommendationsEnabled: true,
@@ -54,6 +58,8 @@ describe('tts-store', () => {
     expect(state.voiceSource).toBe('browser');
     expect(state.fishModel).toBe('s2-pro');
     expect(state.fishVoiceId).toBe('');
+    expect(state.kokoroServerUrl).toBe('http://54.166.253.41:8880');
+    expect(state.kokoroVoiceId).toBe('af_heart');
   });
 
   it('persists Fish settings to localStorage', () => {
@@ -92,6 +98,44 @@ describe('tts-store', () => {
     expect(state.fishVoiceId).toBe('voice-abc');
     expect(state.fishVoiceName).toBe('Tutor Voice');
     expect(state.fishModel).toBe('s1');
+  });
+
+  it('persists Kokoro settings to localStorage', () => {
+    const store = useTTSStore.getState();
+
+    store.setVoiceSource('kokoro');
+    store.setKokoroServerUrl('http://localhost:8880');
+    store.setKokoroApiKey('kokoro-secret');
+    store.setKokoroVoice('bf_emma', 'Emma');
+
+    const saved = JSON.parse(storage.get('echotype_tts_settings') ?? '{}');
+    expect(saved.voiceSource).toBe('kokoro');
+    expect(saved.kokoroServerUrl).toBe('http://localhost:8880');
+    expect(saved.kokoroApiKey).toBe('kokoro-secret');
+    expect(saved.kokoroVoiceId).toBe('bf_emma');
+    expect(saved.kokoroVoiceName).toBe('Emma');
+  });
+
+  it('hydrates persisted Kokoro settings', () => {
+    storage.set(
+      'echotype_tts_settings',
+      JSON.stringify({
+        voiceSource: 'kokoro',
+        kokoroServerUrl: 'http://localhost:8880',
+        kokoroApiKey: 'persisted-kokoro-key',
+        kokoroVoiceId: 'bm_daniel',
+        kokoroVoiceName: 'Daniel',
+      }),
+    );
+
+    useTTSStore.getState().hydrate();
+
+    const state = useTTSStore.getState();
+    expect(state.voiceSource).toBe('kokoro');
+    expect(state.kokoroServerUrl).toBe('http://localhost:8880');
+    expect(state.kokoroApiKey).toBe('persisted-kokoro-key');
+    expect(state.kokoroVoiceId).toBe('bm_daniel');
+    expect(state.kokoroVoiceName).toBe('Daniel');
   });
 
   it('auto-saves Fish API key on change', () => {
@@ -167,6 +211,15 @@ describe('tts-store', () => {
 
     const saved = JSON.parse(storage.get('echotype_tts_settings') ?? '{}');
     expect(saved.voiceSource).toBe('browser');
+  });
+
+  it('switches voice source to kokoro and persists it', () => {
+    useTTSStore.getState().setVoiceSource('kokoro');
+
+    expect(useTTSStore.getState().voiceSource).toBe('kokoro');
+
+    const saved = JSON.parse(storage.get('echotype_tts_settings') ?? '{}');
+    expect(saved.voiceSource).toBe('kokoro');
   });
 
   it('persists full configuration roundtrip', () => {

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,21 +1,60 @@
 'use client';
 
+import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { ChatFab } from '@/components/chat/chat-fab';
+import { CommandPalette } from '@/components/layout/command-palette';
 import { Sidebar } from '@/components/layout/sidebar';
+import { useShortcuts } from '@/hooks/use-shortcuts';
 import { seedDatabase } from '@/lib/seed';
 import { useAssessmentStore } from '@/stores/assessment-store';
+import { useChatStore } from '@/stores/chat-store';
 import { useDailyPlanStore } from '@/stores/daily-plan-store';
 import { useProviderStore } from '@/stores/provider-store';
+import { useShortcutStore } from '@/stores/shortcut-store';
+import { useTTSStore } from '@/stores/tts-store';
 
 export default function AppLayout({ children }: { children: React.ReactNode }) {
   const [seeded, setSeeded] = useState(false);
+  const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
+  const router = useRouter();
+
+  const adjustTTSSetting = (
+    key: 'speed' | 'pitch' | 'volume',
+    delta: number,
+    min: number,
+    max: number,
+    setter: (value: number) => void,
+  ) => {
+    const currentValue = useTTSStore.getState()[key];
+    const nextValue = Math.max(min, Math.min(max, Number((currentValue + delta).toFixed(1))));
+    if (nextValue !== currentValue) setter(nextValue);
+  };
+
   useEffect(() => {
     seedDatabase().then(() => setSeeded(true));
     void useProviderStore.getState().hydrate();
     useAssessmentStore.getState().hydrate();
     useDailyPlanStore.getState().hydrate();
+    useShortcutStore.getState().hydrate();
   }, []);
+
+  useShortcuts('global', {
+    'global:command-palette': () => setCommandPaletteOpen((open) => !open),
+    'global:open-settings': () => router.push('/settings'),
+    'global:toggle-chat': () => useChatStore.getState().toggleOpen(),
+    'global:nav-listen': () => router.push('/listen'),
+    'global:nav-speak': () => router.push('/speak'),
+    'global:nav-read': () => router.push('/read'),
+    'global:nav-write': () => router.push('/write'),
+    'global:speed-down': () => adjustTTSSetting('speed', -0.1, 0.5, 2, useTTSStore.getState().setSpeed),
+    'global:speed-up': () => adjustTTSSetting('speed', 0.1, 0.5, 2, useTTSStore.getState().setSpeed),
+    'global:pitch-down': () => adjustTTSSetting('pitch', -0.1, 0.5, 2, useTTSStore.getState().setPitch),
+    'global:pitch-up': () => adjustTTSSetting('pitch', 0.1, 0.5, 2, useTTSStore.getState().setPitch),
+    'global:volume-down': () => adjustTTSSetting('volume', -0.1, 0, 1, useTTSStore.getState().setVolume),
+    'global:volume-up': () => adjustTTSSetting('volume', 0.1, 0, 1, useTTSStore.getState().setVolume),
+    'global:stop-tts': () => window.dispatchEvent(new Event('echotype:stop-tts')),
+  });
 
   return (
     <div className="flex h-screen overflow-hidden bg-slate-50">
@@ -24,6 +63,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
         <div className="min-h-full p-6 md:p-8">{children}</div>
       </main>
       <ChatFab />
+      <CommandPalette open={commandPaletteOpen} onOpenChange={setCommandPaletteOpen} />
     </div>
   );
 }

--- a/src/app/(app)/listen/[id]/page.tsx
+++ b/src/app/(app)/listen/[id]/page.tsx
@@ -11,13 +11,54 @@ import { TranslationDisplay } from '@/components/translation/translation-display
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import type { Recommendation } from '@/hooks/use-recommendations';
-import { useTranslation } from '@/hooks/use-translation';
+import { useShortcuts } from '@/hooks/use-shortcuts';
+import { type SentenceTranslation, useTranslation } from '@/hooks/use-translation';
 import { estimateListenDuration, formatDuration, useTTS } from '@/hooks/use-tts';
 import { savePracticeSession } from '@/lib/daily-plan-progress';
 import { db } from '@/lib/db';
+import { estimateSentenceHighlightTimings } from '@/lib/listen-highlight';
+import { splitSentences } from '@/lib/sentence-split';
 import { useContentStore } from '@/stores/content-store';
 import { useTTSStore } from '@/stores/tts-store';
 import type { ContentItem } from '@/types/content';
+
+interface SentenceSpan {
+  text: string;
+  translation: string;
+  startWordIndex: number;
+  endWordIndex: number;
+  wordCount: number;
+}
+
+function buildSentenceSpans(text: string, sentenceTranslations: SentenceTranslation[] | null): SentenceSpan[] {
+  const sentences =
+    sentenceTranslations && sentenceTranslations.length > 0
+      ? sentenceTranslations.map((sentence) => ({
+          text: sentence.original,
+          translation: sentence.translation,
+        }))
+      : splitSentences(text).map((sentence) => ({
+          text: sentence,
+          translation: '',
+        }));
+
+  let startWordIndex = 0;
+
+  return sentences
+    .map(({ text: sentenceText, translation }) => {
+      const wordCount = sentenceText.split(/\s+/).filter(Boolean).length;
+      const span = {
+        text: sentenceText,
+        translation,
+        startWordIndex,
+        endWordIndex: startWordIndex + wordCount - 1,
+        wordCount,
+      };
+      startWordIndex += wordCount;
+      return span;
+    })
+    .filter((span) => span.wordCount > 0);
+}
 
 export default function ListenDetailPage() {
   const params = useParams();
@@ -25,9 +66,22 @@ export default function ListenDetailPage() {
   const [content, setContent] = useState<ContentItem | null>(null);
   const [isPlaying, setIsPlaying] = useState(false);
   const [currentWordIndex, setCurrentWordIndex] = useState(-1);
+  const [currentSentenceIndex, setCurrentSentenceIndex] = useState(-1);
   const listenStartRef = useRef<number | null>(null);
-  const { createUtterance, stop, browserVoices, boundaryPlaybackNotice } = useTTS();
-  const { speed, setSpeed, voiceURI } = useTTSStore();
+  const kokoroPlaybackStartedRef = useRef(false);
+  const kokoroShouldPersistCompletionRef = useRef(false);
+  const sentenceHighlightTimersRef = useRef<number[]>([]);
+  const {
+    createUtterance,
+    stop,
+    speak: speakWithSelectedVoice,
+    isSpeaking: isTTSPlaying,
+    browserVoices,
+    currentVoice,
+    boundaryPlaybackNotice,
+    voiceSource,
+  } = useTTS();
+  const { speed, setSpeed, voiceURI, kokoroVoiceName } = useTTSStore();
   const showTranslation = useTTSStore((s) => s.showTranslation);
   const targetLang = useTTSStore((s) => s.targetLang);
   const recommendationsEnabled = useTTSStore((s) => s.recommendationsEnabled);
@@ -82,28 +136,75 @@ export default function ListenDetailPage() {
     }
   }, [params.id, shadowReadingEnabled, setActiveContentId]);
 
+  useEffect(() => {
+    function handleGlobalStop() {
+      setIsPlaying(false);
+      setCurrentWordIndex(-1);
+      kokoroPlaybackStartedRef.current = false;
+    }
+
+    window.addEventListener('echotype:stop-tts', handleGlobalStop);
+    return () => window.removeEventListener('echotype:stop-tts', handleGlobalStop);
+  }, []);
+
   const words = content?.text.split(/\s+/) || [];
   const wordCount = words.length;
   const duration = content ? estimateListenDuration(content.text, speed) : 0;
 
-  const sentenceBoundaryMap = useMemo(() => {
-    const map = new Map<number, number>();
-    if (!sentenceTranslations || !content) return map;
-    let wordIdx = 0;
-    for (let si = 0; si < sentenceTranslations.length; si++) {
-      const sentenceWords = sentenceTranslations[si].original.split(/\s+/).filter(Boolean);
-      wordIdx += sentenceWords.length;
-      map.set(wordIdx - 1, si);
-    }
-    return map;
-  }, [sentenceTranslations, content]);
-  const currentVoice = browserVoices.find((voice) => voice.voiceURI === voiceURI);
+  const sentenceSpans = useMemo(
+    () => buildSentenceSpans(content?.text || '', sentenceTranslations),
+    [content?.text, sentenceTranslations],
+  );
 
-  const speak = useCallback(
+  const wordToSentenceMap = useMemo(() => {
+    const map = new Map<number, number>();
+    sentenceSpans.forEach((span, sentenceIndex) => {
+      for (let wordIndex = span.startWordIndex; wordIndex <= span.endWordIndex; wordIndex += 1) {
+        map.set(wordIndex, sentenceIndex);
+      }
+    });
+    return map;
+  }, [sentenceSpans]);
+
+  const browserVoice = browserVoices.find((voice) => voice.voiceURI === voiceURI);
+  const isKokoroListenMode = voiceSource === 'kokoro';
+  const activeListenVoiceName = isKokoroListenMode
+    ? currentVoice?.name || kokoroVoiceName || 'Kokoro'
+    : browserVoice?.name;
+  const playbackNotice = isKokoroListenMode
+    ? 'Kokoro playback is active on this page. The page estimates sentence timing for sentence-level highlighting, so it will feel less precise than browser word highlighting.'
+    : boundaryPlaybackNotice;
+
+  const clearSentenceHighlightTimers = useCallback(() => {
+    sentenceHighlightTimersRef.current.forEach((timerId) => window.clearTimeout(timerId));
+    sentenceHighlightTimersRef.current = [];
+  }, []);
+
+  const persistListenSession = useCallback(() => {
+    if (!content) return;
+    const savedWordCount = content.text.split(/\s+/).filter(Boolean).length;
+    void savePracticeSession({
+      id: nanoid(),
+      contentId: content.id,
+      module: 'listen',
+      startTime: listenStartRef.current || Date.now(),
+      endTime: Date.now(),
+      totalChars: content.text.length,
+      correctChars: 0,
+      wrongChars: 0,
+      totalWords: savedWordCount,
+      wpm: 0,
+      accuracy: 0,
+      completed: true,
+    });
+  }, [content]);
+
+  const speakWithWordHighlight = useCallback(
     (text: string, rate: number) => {
       window.speechSynthesis.cancel();
       const utterance = createUtterance(text, { rate });
       listenStartRef.current = Date.now();
+      setCurrentSentenceIndex(-1);
 
       let wordIdx = 0;
       utterance.onboundary = (event) => {
@@ -115,54 +216,157 @@ export default function ListenDetailPage() {
       utterance.onend = () => {
         setIsPlaying(false);
         setCurrentWordIndex(-1);
-        if (content) {
-          const wordCount = content.text.split(/\s+/).filter(Boolean).length;
-          void savePracticeSession({
-            id: nanoid(),
-            contentId: content.id,
-            module: 'listen',
-            startTime: listenStartRef.current || Date.now(),
-            endTime: Date.now(),
-            totalChars: content.text.length,
-            correctChars: 0,
-            wrongChars: 0,
-            totalWords: wordCount,
-            wpm: 0,
-            accuracy: 0,
-            completed: true,
-          });
-        }
+        persistListenSession();
       };
       window.speechSynthesis.speak(utterance);
       setIsPlaying(true);
     },
-    [createUtterance, content],
+    [createUtterance, persistListenSession],
   );
+
+  const startKokoroSentenceHighlight = useCallback(
+    (rate: number) => {
+      clearSentenceHighlightTimers();
+      if (sentenceSpans.length === 0) {
+        setCurrentSentenceIndex(-1);
+        return;
+      }
+
+      const timings = estimateSentenceHighlightTimings(
+        sentenceSpans.map((sentence) => ({
+          text: sentence.text,
+          wordCount: sentence.wordCount,
+        })),
+        rate,
+      );
+
+      setCurrentSentenceIndex(0);
+
+      timings.forEach((timing, sentenceIndex) => {
+        if (sentenceIndex > 0) {
+          const timerId = window.setTimeout(() => {
+            setCurrentSentenceIndex(sentenceIndex);
+          }, timing.startMs);
+          sentenceHighlightTimersRef.current.push(timerId);
+        }
+      });
+    },
+    [clearSentenceHighlightTimers, sentenceSpans],
+  );
+
+  useEffect(() => {
+    if (!isKokoroListenMode) return;
+
+    if (isTTSPlaying) {
+      kokoroPlaybackStartedRef.current = true;
+      if (!isPlaying) {
+        setIsPlaying(true);
+      }
+      return;
+    }
+
+    if (isPlaying && kokoroPlaybackStartedRef.current) {
+      setIsPlaying(false);
+      setCurrentWordIndex(-1);
+      setCurrentSentenceIndex(-1);
+      clearSentenceHighlightTimers();
+      if (kokoroShouldPersistCompletionRef.current) {
+        persistListenSession();
+      }
+      kokoroPlaybackStartedRef.current = false;
+      kokoroShouldPersistCompletionRef.current = false;
+    }
+  }, [clearSentenceHighlightTimers, isKokoroListenMode, isPlaying, isTTSPlaying, persistListenSession]);
+
+  useEffect(() => {
+    return () => clearSentenceHighlightTimers();
+  }, [clearSentenceHighlightTimers]);
 
   const handlePlay = () => {
     if (!content) return;
     if (isPlaying) {
+      kokoroShouldPersistCompletionRef.current = false;
+      clearSentenceHighlightTimers();
       stop();
       setIsPlaying(false);
       setCurrentWordIndex(-1);
+      setCurrentSentenceIndex(-1);
+      kokoroPlaybackStartedRef.current = false;
     } else {
-      speak(content.text, speed);
+      if (isKokoroListenMode) {
+        listenStartRef.current = Date.now();
+        setCurrentWordIndex(-1);
+        kokoroShouldPersistCompletionRef.current = true;
+        setIsPlaying(true);
+        startKokoroSentenceHighlight(speed);
+        kokoroPlaybackStartedRef.current = false;
+        void speakWithSelectedVoice(content.text, { rate: speed });
+        return;
+      }
+
+      speakWithWordHighlight(content.text, speed);
     }
   };
 
   const handleWordClick = (word: string) => {
+    kokoroShouldPersistCompletionRef.current = false;
+    clearSentenceHighlightTimers();
     stop();
     setIsPlaying(false);
+    setCurrentSentenceIndex(-1);
+    kokoroPlaybackStartedRef.current = false;
+    if (isKokoroListenMode) {
+      void speakWithSelectedVoice(word, { rate: speed });
+      return;
+    }
     const u = createUtterance(word, { rate: speed });
     window.speechSynthesis.speak(u);
   };
 
   const handleRestart = () => {
     if (!content) return;
+    kokoroShouldPersistCompletionRef.current = false;
+    clearSentenceHighlightTimers();
     stop();
     setCurrentWordIndex(-1);
-    speak(content.text, speed);
+    setCurrentSentenceIndex(-1);
+    kokoroPlaybackStartedRef.current = false;
+    if (isKokoroListenMode) {
+      listenStartRef.current = Date.now();
+      kokoroShouldPersistCompletionRef.current = true;
+      setIsPlaying(true);
+      startKokoroSentenceHighlight(speed);
+      void speakWithSelectedVoice(content.text, { rate: speed });
+      return;
+    }
+    speakWithWordHighlight(content.text, speed);
   };
+
+  const SPEED_STEPS = [0.5, 0.75, 1, 1.25, 1.5];
+
+  const getPreviousSpeedStep = (currentSpeed: number) => {
+    const previous = [...SPEED_STEPS].reverse().find((step) => step < currentSpeed);
+    return previous ?? SPEED_STEPS[0];
+  };
+
+  const getNextSpeedStep = (currentSpeed: number) => {
+    const next = SPEED_STEPS.find((step) => step > currentSpeed);
+    return next ?? SPEED_STEPS[SPEED_STEPS.length - 1];
+  };
+
+  useShortcuts('listen', {
+    'listen:play-pause': handlePlay,
+    'listen:restart': handleRestart,
+    'listen:toggle-translation': () => useTTSStore.getState().toggleTranslation(),
+    'listen:speed-down': () => {
+      const nextSpeed = getPreviousSpeedStep(speed);
+      if (nextSpeed !== speed) setSpeed(nextSpeed);
+    },
+    'listen:speed-up': () => {
+      const nextSpeed = getNextSpeedStep(speed);
+      if (nextSpeed !== speed) setSpeed(nextSpeed);
+    },
+  });
 
   if (!content) {
     return <div className="flex items-center justify-center h-64 text-indigo-400">Loading...</div>;
@@ -191,10 +395,10 @@ export default function ListenDetailPage() {
             <span className="flex items-center gap-1">
               <Clock className="w-3.5 h-3.5" />~{formatDuration(duration)}
             </span>
-            {currentVoice && (
+            {activeListenVoiceName && (
               <span className="flex items-center gap-1">
                 <Volume2 className="w-3.5 h-3.5" />
-                {currentVoice.name}
+                {activeListenVoiceName}
               </span>
             )}
           </div>
@@ -204,35 +408,43 @@ export default function ListenDetailPage() {
 
       <Card className="bg-white border-slate-100 shadow-sm">
         <CardContent className="p-6 space-y-5">
-          {boundaryPlaybackNotice && (
+          {playbackNotice && (
             <div className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
-              {boundaryPlaybackNotice}
+              {playbackNotice}
             </div>
           )}
 
           {/* Player controls */}
           <div className="flex items-center justify-between gap-3 pb-4 border-b border-slate-100">
-            <div className="flex items-center gap-2">
-              <Button
-                onClick={handlePlay}
-                className={`cursor-pointer font-semibold transition-all duration-200 ${
-                  isPlaying
-                    ? 'bg-slate-800 hover:bg-slate-900 text-white'
-                    : 'bg-indigo-600 hover:bg-indigo-700 text-white'
-                }`}
-                size="lg"
-              >
-                {isPlaying ? <Pause className="w-5 h-5 mr-2" /> : <Play className="w-5 h-5 mr-2" />}
-                {isPlaying ? 'Pause' : 'Play'}
-              </Button>
-              <Button
-                onClick={handleRestart}
-                variant="ghost"
-                size="icon"
-                className="text-slate-400 hover:text-slate-700 hover:bg-slate-100 cursor-pointer rounded-xl"
-              >
-                <RotateCcw className="w-4 h-4" />
-              </Button>
+            <div className="space-y-2">
+              <div className="flex items-center gap-2">
+                <Button
+                  onClick={handlePlay}
+                  className={`cursor-pointer font-semibold transition-all duration-200 ${
+                    isPlaying
+                      ? 'bg-slate-800 hover:bg-slate-900 text-white'
+                      : 'bg-indigo-600 hover:bg-indigo-700 text-white'
+                  }`}
+                  size="lg"
+                >
+                  {isPlaying ? <Pause className="w-5 h-5 mr-2" /> : <Play className="w-5 h-5 mr-2" />}
+                  {isPlaying ? 'Pause' : 'Play'}
+                </Button>
+                <Button
+                  onClick={handleRestart}
+                  variant="ghost"
+                  size="icon"
+                  className="text-slate-400 hover:text-slate-700 hover:bg-slate-100 cursor-pointer rounded-xl"
+                >
+                  <RotateCcw className="w-4 h-4" />
+                </Button>
+              </div>
+              <p className="text-xs text-slate-500">
+                Mode:{' '}
+                {isKokoroListenMode
+                  ? 'Kokoro audio with estimated sentence highlighting'
+                  : 'Browser speech with word highlighting'}
+              </p>
             </div>
 
             {/* Speed selector */}
@@ -258,23 +470,32 @@ export default function ListenDetailPage() {
           {/* Content text */}
           <div className="leading-8 text-[17px] whitespace-pre-wrap">
             {words.map((word, idx) => {
-              const boundaryIdx = sentenceBoundaryMap.get(idx);
+              const sentenceIndex = wordToSentenceMap.get(idx);
+              const sentenceSpan = sentenceIndex !== undefined ? sentenceSpans[sentenceIndex] : undefined;
+              const isActiveSentence = isKokoroListenMode && sentenceIndex === currentSentenceIndex;
+              const isSentenceBoundary = sentenceSpan?.endWordIndex === idx;
               return (
                 <span key={idx} className="contents">
                   <button
                     type="button"
                     onClick={() => handleWordClick(word)}
                     className={`inline-block px-0.5 py-0.5 rounded-md cursor-pointer transition-colors duration-150 ${
-                      idx === currentWordIndex
+                      !isKokoroListenMode && idx === currentWordIndex
                         ? 'bg-indigo-100 text-indigo-900 font-semibold'
-                        : 'text-slate-700 hover:bg-slate-100 hover:text-slate-900'
+                        : isActiveSentence
+                          ? 'bg-emerald-50 text-emerald-900 font-medium'
+                          : 'text-slate-700 hover:bg-slate-100 hover:text-slate-900'
                     }`}
                   >
                     {word}{' '}
                   </button>
-                  {showTranslation && boundaryIdx !== undefined && sentenceTranslations?.[boundaryIdx] && (
-                    <div className="w-full text-sm text-indigo-400 leading-relaxed py-1 pl-0.5 whitespace-pre-wrap">
-                      {sentenceTranslations[boundaryIdx].translation}
+                  {showTranslation && isSentenceBoundary && sentenceSpan?.translation && (
+                    <div
+                      className={`w-full text-sm leading-relaxed py-1 pl-0.5 whitespace-pre-wrap transition-colors duration-150 ${
+                        isActiveSentence ? 'text-emerald-600' : 'text-indigo-400'
+                      }`}
+                    >
+                      {sentenceSpan.translation}
                     </div>
                   )}
                 </span>

--- a/src/app/(app)/read/[id]/page.tsx
+++ b/src/app/(app)/read/[id]/page.tsx
@@ -6,6 +6,7 @@ import { nanoid } from 'nanoid';
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { flushSync } from 'react-dom';
 import { RecommendationPanel } from '@/components/shared/recommendation-panel';
 import { PronunciationFeedback } from '@/components/speak/pronunciation-feedback';
 import { SpeechStats } from '@/components/speak/speech-stats';
@@ -14,12 +15,15 @@ import { TranslationDisplay } from '@/components/translation/translation-display
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import type { Recommendation } from '@/hooks/use-recommendations';
+import { useShortcuts } from '@/hooks/use-shortcuts';
 import { useTranslation } from '@/hooks/use-translation';
 import { useTTS } from '@/hooks/use-tts';
 import { savePracticeSession } from '@/lib/daily-plan-progress';
 import { db } from '@/lib/db';
 import { compareWords, type WordResult } from '@/lib/levenshtein';
+import { matchesShortcutEvent } from '@/lib/shortcut-utils';
 import { useContentStore } from '@/stores/content-store';
+import { useShortcutStore } from '@/stores/shortcut-store';
 import { useTTSStore } from '@/stores/tts-store';
 import type { ContentItem } from '@/types/content';
 
@@ -33,6 +37,7 @@ export default function ReadDetailPage() {
   const [results, setResults] = useState<WordResult[] | null>(null);
   const recognitionRef = useRef<SpeechRecognition | null>(null);
   const speakStartRef = useRef<number | null>(null);
+  const resetButtonRef = useRef<HTMLButtonElement | null>(null);
   const transcriptRef = useRef('');
   const interimTranscriptRef = useRef('');
   const hasPersistedResultRef = useRef(false);
@@ -203,13 +208,48 @@ export default function ReadDetailPage() {
   );
 
   const handleReset = () => {
+    recognitionRef.current?.abort();
+    setIsListening(false);
     transcriptRef.current = '';
     interimTranscriptRef.current = '';
     hasPersistedResultRef.current = false;
-    setTranscript('');
-    setInterimTranscript('');
-    setResults(null);
+    flushSync(() => {
+      setTranscript('');
+      setInterimTranscript('');
+      setResults(null);
+    });
   };
+
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      const effectiveKey = useShortcutStore.getState().getKey('read:reset');
+      const matchesEffectiveKey = effectiveKey ? matchesShortcutEvent(event, effectiveKey) : false;
+      const matchesDefaultKey =
+        !event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey && event.key.toLowerCase() === 'r';
+
+      if (!matchesEffectiveKey && !matchesDefaultKey) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+      resetButtonRef.current?.click();
+    }
+
+    window.addEventListener('keydown', onKeyDown, true);
+    return () => window.removeEventListener('keydown', onKeyDown, true);
+  }, [handleReset]);
+
+  useShortcuts('read', {
+    'read:toggle-recording': () => {
+      if (isListening) {
+        stopListening();
+      } else {
+        startListening();
+      }
+    },
+    'read:toggle-translation': () => useTTSStore.getState().toggleTranslation(),
+    'read:listen': handlePlayTTS,
+    'read:reset': () => resetButtonRef.current?.click(),
+  });
 
   if (!content) {
     return <div className="flex items-center justify-center h-64 text-indigo-400">Loading...</div>;
@@ -291,7 +331,12 @@ export default function ReadDetailPage() {
             {isListening ? <MicOff className="w-7 h-7" /> : <Mic className="w-7 h-7" />}
           </Button>
         </motion.div>
-        <Button variant="outline" onClick={handleReset} className="border-indigo-200 text-indigo-600 cursor-pointer">
+        <Button
+          ref={resetButtonRef}
+          variant="outline"
+          onClick={handleReset}
+          className="border-indigo-200 text-indigo-600 cursor-pointer"
+        >
           <RotateCcw className="w-4 h-4 mr-2" /> Reset
         </Button>
       </div>

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -8,6 +8,7 @@ import {
   ExternalLink,
   Eye,
   EyeOff,
+  Keyboard,
   KeyRound,
   Languages,
   Loader2,
@@ -27,6 +28,7 @@ import { type FormEvent, Suspense, useCallback, useEffect, useState } from 'reac
 import { AssessmentSection } from '@/components/assessment/assessment-section';
 import { OllamaWarningBanner } from '@/components/ollama/ollama-warning-banner';
 import { DataBackup } from '@/components/settings/data-backup';
+import { ShortcutSettings } from '@/components/settings/shortcut-settings';
 import { TagManagement } from '@/components/settings/tag-management';
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion';
 import { Button } from '@/components/ui/button';
@@ -860,6 +862,10 @@ function SettingsContent() {
     setFishApiKey,
     fishModel,
     setFishModel,
+    kokoroServerUrl,
+    setKokoroServerUrl,
+    kokoroApiKey,
+    setKokoroApiKey,
     targetLang,
     setTargetLang,
     showTranslation,
@@ -876,6 +882,7 @@ function SettingsContent() {
   const [authSuccess, setAuthSuccess] = useState<string | null>(null);
   const [oauthSuccessProvider, setOauthSuccessProvider] = useState<ProviderId | undefined>();
   const [showFishKey, setShowFishKey] = useState(false);
+  const [showKokoroKey, setShowKokoroKey] = useState(false);
 
   useEffect(() => {
     void hydrateProviders();
@@ -984,7 +991,7 @@ function SettingsContent() {
         <div className="space-y-5">
           <div className="space-y-2">
             <p className="text-sm font-medium text-slate-700">Voice source</p>
-            <div className="grid grid-cols-2 gap-2">
+            <div className="grid gap-2 md:grid-cols-3">
               {[
                 {
                   id: 'browser' as const,
@@ -995,6 +1002,11 @@ function SettingsContent() {
                   id: 'fish' as const,
                   title: 'Fish Audio',
                   description: 'Loads a much larger cloud voice library for richer narration styles.',
+                },
+                {
+                  id: 'kokoro' as const,
+                  title: 'Kokoro TTS',
+                  description: 'Uses your remote Kokoro server for fast cloud narration with curated voices.',
                 },
               ].map((option) => (
                 <button
@@ -1147,6 +1159,68 @@ function SettingsContent() {
             </div>
           )}
 
+          {voiceSource === 'kokoro' && (
+            <div className="space-y-4 rounded-2xl border border-indigo-100 bg-indigo-50/60 p-4">
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <p className="text-sm font-semibold text-indigo-950">Kokoro remote voices</p>
+                  <p className="mt-1 text-xs leading-relaxed text-indigo-700">
+                    EchoType will call your hosted Kokoro server through local proxy routes, so the browser never talks
+                    to the remote TTS endpoint directly.
+                  </p>
+                </div>
+                <a
+                  href={`${kokoroServerUrl.replace(/\/+$/, '')}/v1/audio/voices`}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex items-center gap-1 rounded-lg border border-indigo-200 bg-white px-2.5 py-1.5 text-xs font-medium text-indigo-700 hover:bg-indigo-100"
+                >
+                  Voices API
+                  <ExternalLink className="h-3 w-3" />
+                </a>
+              </div>
+
+              <div className="space-y-2">
+                <p className="text-sm font-medium text-slate-700">Kokoro server URL</p>
+                <Input
+                  value={kokoroServerUrl}
+                  onChange={(e) => setKokoroServerUrl(e.target.value)}
+                  placeholder="http://54.166.253.41:8880"
+                  className="bg-white border-indigo-200"
+                />
+                <p className="text-[11px] text-indigo-700">
+                  Defaults to your current AWS Kokoro deployment and can be replaced with another compatible endpoint.
+                </p>
+              </div>
+
+              <div className="space-y-2">
+                <p className="text-sm font-medium text-slate-700">Optional API key</p>
+                <div className="relative">
+                  <Input
+                    type={showKokoroKey ? 'text' : 'password'}
+                    value={kokoroApiKey}
+                    onChange={(e) => setKokoroApiKey(e.target.value)}
+                    placeholder="Leave empty if your Kokoro server does not require auth"
+                    className="pr-10 bg-white border-indigo-200"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowKokoroKey((value) => !value)}
+                    className="absolute inset-y-0 right-0 flex items-center px-3 text-slate-400 hover:text-slate-600 cursor-pointer"
+                    aria-label={showKokoroKey ? 'Hide Kokoro API key' : 'Show Kokoro API key'}
+                  >
+                    {showKokoroKey ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                  </button>
+                </div>
+              </div>
+
+              <div className="rounded-xl border border-amber-200 bg-amber-50 px-3 py-2.5 text-xs leading-relaxed text-amber-800">
+                Listen and wordbook screens still rely on browser speech for per-word boundary highlighting. When Kokoro
+                is selected, those views will automatically fall back to browser voices.
+              </div>
+            </div>
+          )}
+
           <VoicePicker />
           <div>
             <div className="flex items-center justify-between mb-2">
@@ -1266,6 +1340,11 @@ function SettingsContent() {
             </p>
           </div>
         </div>
+      </Section>
+
+      {/* Keyboard Shortcuts */}
+      <Section title="Keyboard Shortcuts" icon={Keyboard}>
+        <ShortcutSettings />
       </Section>
 
       {/* Data Backup */}

--- a/src/app/(app)/speak/[scenarioId]/page.tsx
+++ b/src/app/(app)/speak/[scenarioId]/page.tsx
@@ -11,6 +11,7 @@ import { VoiceInputButton } from '@/components/speak/voice-input-button';
 import { TranslationBar } from '@/components/translation/translation-bar';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { useShortcuts } from '@/hooks/use-shortcuts';
 import { useTTS } from '@/hooks/use-tts';
 import { useVoiceRecognition } from '@/hooks/use-voice-recognition';
 import { PROVIDER_REGISTRY } from '@/lib/providers';
@@ -329,6 +330,50 @@ export default function ConversationPage() {
       startListening();
     }
   }, [isRecording, isStreaming, stopListening, startListening, setIsRecording, addMessage, stop]);
+
+  const handleReplayLastAssistant = useCallback(() => {
+    const lastAssistantMessage = [...useSpeakStore.getState().messages]
+      .reverse()
+      .find((message) => message.role === 'assistant' && message.content.trim());
+
+    if (!lastAssistantMessage) return;
+    handlePlayVoice(lastAssistantMessage.content, lastAssistantMessage.id);
+  }, [handlePlayVoice]);
+
+  const handleResetConversation = useCallback(() => {
+    abortRef.current?.abort();
+    stopListening();
+    stop();
+    clearAllPlaying();
+    setIsStreaming(false);
+    setIsRecording(false);
+    resetConversation();
+
+    if (!scenario) return;
+
+    addMessage({
+      id: nanoid(),
+      role: 'assistant',
+      content: scenario.openingMessage,
+      timestamp: Date.now(),
+    });
+  }, [addMessage, clearAllPlaying, resetConversation, scenario, setIsRecording, setIsStreaming, stop, stopListening]);
+
+  useEffect(() => {
+    function handleGlobalStop() {
+      clearAllPlaying();
+    }
+
+    window.addEventListener('echotype:stop-tts', handleGlobalStop);
+    return () => window.removeEventListener('echotype:stop-tts', handleGlobalStop);
+  }, [clearAllPlaying]);
+
+  useShortcuts('speak', {
+    'speak:toggle-recording': handleToggleRecording,
+    'speak:toggle-translation': () => useTTSStore.getState().toggleTranslation(),
+    'speak:replay-last-assistant': handleReplayLastAssistant,
+    'speak:reset-conversation': handleResetConversation,
+  });
 
   const handleSendText = useCallback(() => {
     const text = textInput.trim();

--- a/src/app/(app)/write/[id]/page.tsx
+++ b/src/app/(app)/write/[id]/page.tsx
@@ -15,7 +15,9 @@ import { useTranslation } from '@/hooks/use-translation';
 import { getInitialState, typingReducer } from '@/hooks/use-typing-reducer';
 import { savePracticeSession } from '@/lib/daily-plan-progress';
 import { db } from '@/lib/db';
+import { matchesShortcutEvent } from '@/lib/shortcut-utils';
 import { useContentStore } from '@/stores/content-store';
+import { useShortcutStore } from '@/stores/shortcut-store';
 import { useTTSStore } from '@/stores/tts-store';
 import type { ContentItem } from '@/types/content';
 
@@ -203,6 +205,29 @@ export default function WriteDetailPage() {
   const focusInput = () => {
     inputRef.current?.focus();
   };
+
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      const toggleTranslationKey = useShortcutStore.getState().getKey('write:toggle-translation');
+      const resetKey = useShortcutStore.getState().getKey('write:reset');
+
+      if (toggleTranslationKey && matchesShortcutEvent(event, toggleTranslationKey)) {
+        event.preventDefault();
+        event.stopPropagation();
+        useTTSStore.getState().toggleTranslation();
+        return;
+      }
+
+      if (resetKey && matchesShortcutEvent(event, resetKey)) {
+        event.preventDefault();
+        event.stopPropagation();
+        handleReset();
+      }
+    }
+
+    window.addEventListener('keydown', onKeyDown, true);
+    return () => window.removeEventListener('keydown', onKeyDown, true);
+  }, [handleReset]);
 
   if (!content) {
     return <div className="flex items-center justify-center h-64 text-indigo-400">Loading...</div>;

--- a/src/app/api/tts/kokoro/speak/route.test.ts
+++ b/src/app/api/tts/kokoro/speak/route.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const synthesizeMock = vi.fn();
+
+vi.mock('@/lib/kokoro', () => ({
+  synthesizeKokoroSpeech: synthesizeMock,
+}));
+
+const { POST } = await import('./route');
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest('http://localhost/api/tts/kokoro/speak', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/tts/kokoro/speak', () => {
+  beforeEach(() => {
+    synthesizeMock.mockReset();
+  });
+
+  it('returns 400 when serverUrl is missing', async () => {
+    const res = await POST(makeRequest({ text: 'Hello', voice: 'af_heart' }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/server url/i);
+  });
+
+  it('returns 400 when text is missing', async () => {
+    const res = await POST(makeRequest({ serverUrl: 'http://localhost:8880', voice: 'af_heart' }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/text/i);
+  });
+
+  it('returns 400 when voice is missing', async () => {
+    const res = await POST(makeRequest({ serverUrl: 'http://localhost:8880', text: 'Hello' }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/voice/i);
+  });
+
+  it('returns audio bytes on successful synthesis', async () => {
+    const audioBuffer = new Uint8Array([1, 2, 3, 4]).buffer;
+    synthesizeMock.mockResolvedValue({
+      audioBuffer,
+      contentType: 'audio/mpeg',
+    });
+
+    const res = await POST(
+      makeRequest({
+        serverUrl: 'http://localhost:8880',
+        apiKey: 'kokoro-key',
+        text: 'Hello there',
+        voice: 'af_heart',
+        speed: 1,
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('audio/mpeg');
+    expect(res.headers.get('Cache-Control')).toBe('no-store');
+
+    const buffer = await res.arrayBuffer();
+    expect(new Uint8Array(buffer)).toEqual(new Uint8Array([1, 2, 3, 4]));
+    expect(synthesizeMock).toHaveBeenCalledWith({
+      serverUrl: 'http://localhost:8880',
+      apiKey: 'kokoro-key',
+      text: 'Hello there',
+      voice: 'af_heart',
+      speed: 1,
+    });
+  });
+
+  it('returns 500 with error message on synthesis failure', async () => {
+    synthesizeMock.mockRejectedValue(new Error('Server unavailable'));
+
+    const res = await POST(makeRequest({ serverUrl: 'http://localhost:8880', text: 'Hello', voice: 'af_heart' }));
+
+    expect(res.status).toBe(500);
+    const data = await res.json();
+    expect(data.error).toBe('Server unavailable');
+  });
+
+  it('returns generic error message for non-Error exceptions', async () => {
+    synthesizeMock.mockRejectedValue('unknown error');
+
+    const res = await POST(makeRequest({ serverUrl: 'http://localhost:8880', text: 'Hello', voice: 'af_heart' }));
+
+    expect(res.status).toBe(500);
+    const data = await res.json();
+    expect(data.error).toBe('Kokoro speech synthesis failed.');
+  });
+});

--- a/src/app/api/tts/kokoro/speak/route.ts
+++ b/src/app/api/tts/kokoro/speak/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest } from 'next/server';
+import { synthesizeKokoroSpeech } from '@/lib/kokoro';
+
+export async function POST(req: NextRequest) {
+  const {
+    serverUrl,
+    apiKey,
+    text,
+    voice,
+    speed,
+  }: {
+    serverUrl?: string;
+    apiKey?: string;
+    text?: string;
+    voice?: string;
+    speed?: number;
+  } = await req.json();
+
+  if (!serverUrl?.trim()) {
+    return Response.json({ error: 'Kokoro server URL is required.' }, { status: 400 });
+  }
+
+  if (!text?.trim()) {
+    return Response.json({ error: 'Text is required.' }, { status: 400 });
+  }
+
+  if (!voice) {
+    return Response.json({ error: 'A Kokoro voice is required.' }, { status: 400 });
+  }
+
+  try {
+    const { audioBuffer, contentType } = await synthesizeKokoroSpeech({
+      serverUrl,
+      apiKey: apiKey || undefined,
+      text,
+      voice,
+      speed,
+    });
+
+    return new Response(audioBuffer, {
+      headers: {
+        'Content-Type': contentType,
+        'Cache-Control': 'no-store',
+      },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Kokoro speech synthesis failed.';
+    return Response.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/tts/kokoro/voices/route.test.ts
+++ b/src/app/api/tts/kokoro/voices/route.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const listVoicesMock = vi.fn();
+
+vi.mock('@/lib/kokoro', () => ({
+  listKokoroVoices: listVoicesMock,
+}));
+
+const { POST } = await import('./route');
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest('http://localhost/api/tts/kokoro/voices', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/tts/kokoro/voices', () => {
+  beforeEach(() => {
+    listVoicesMock.mockReset();
+  });
+
+  it('returns 400 when serverUrl is missing', async () => {
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/server url/i);
+  });
+
+  it('returns voices on success', async () => {
+    const mockVoices = [{ id: 'af_heart', name: 'Heart', language: 'American English', langCode: 'en-US' }];
+    listVoicesMock.mockResolvedValue(mockVoices);
+
+    const res = await POST(makeRequest({ serverUrl: 'http://localhost:8880', apiKey: 'kokoro-key' }));
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.voices).toEqual(mockVoices);
+    expect(listVoicesMock).toHaveBeenCalledWith('http://localhost:8880', 'kokoro-key');
+  });
+
+  it('returns 500 with error message on API failure', async () => {
+    listVoicesMock.mockRejectedValue(new Error('Unauthorized'));
+
+    const res = await POST(makeRequest({ serverUrl: 'http://localhost:8880' }));
+
+    expect(res.status).toBe(500);
+    const data = await res.json();
+    expect(data.error).toBe('Unauthorized');
+  });
+
+  it('returns generic error message for non-Error exceptions', async () => {
+    listVoicesMock.mockRejectedValue('network error');
+
+    const res = await POST(makeRequest({ serverUrl: 'http://localhost:8880' }));
+
+    expect(res.status).toBe(500);
+    const data = await res.json();
+    expect(data.error).toBe('Failed to load Kokoro voices.');
+  });
+});

--- a/src/app/api/tts/kokoro/voices/route.ts
+++ b/src/app/api/tts/kokoro/voices/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { listKokoroVoices } from '@/lib/kokoro';
+
+export async function POST(req: NextRequest) {
+  const { serverUrl, apiKey }: { serverUrl?: string; apiKey?: string } = await req.json();
+
+  if (!serverUrl?.trim()) {
+    return NextResponse.json({ error: 'Kokoro server URL is required.' }, { status: 400 });
+  }
+
+  try {
+    const voices = await listKokoroVoices(serverUrl, apiKey || undefined);
+    return NextResponse.json({ voices });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to load Kokoro voices.';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/components/layout/command-palette.tsx
+++ b/src/components/layout/command-palette.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import { BookOpen, Headphones, MessageCircle, Settings2, SquarePen } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { useEffect, useMemo } from 'react';
+import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from '@/components/ui/command';
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog';
+import { formatKeyCombo } from '@/hooks/use-shortcuts';
+import { isMac } from '@/lib/utils';
+import { useChatStore } from '@/stores/chat-store';
+import { useShortcutStore } from '@/stores/shortcut-store';
+
+interface CommandPaletteProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
+  const router = useRouter();
+  const getKey = useShortcutStore((s) => s.getKey);
+  const setPaused = useShortcutStore((s) => s.setPaused);
+  const searchKey = formatKeyCombo(getKey('global:command-palette'));
+  const defaultSearchKey = isMac() ? 'Command+K' : 'Ctrl+K';
+
+  useEffect(() => {
+    setPaused(open);
+
+    return () => {
+      setPaused(false);
+    };
+  }, [open, setPaused]);
+
+  const items = useMemo(
+    () => [
+      {
+        id: 'global:open-settings',
+        label: 'Open Settings',
+        icon: Settings2,
+        action: () => router.push('/settings'),
+      },
+      {
+        id: 'global:toggle-chat',
+        label: 'Toggle Chat',
+        icon: MessageCircle,
+        action: () => useChatStore.getState().toggleOpen(),
+      },
+      {
+        id: 'global:nav-listen',
+        label: 'Go to Listen',
+        icon: Headphones,
+        action: () => router.push('/listen'),
+      },
+      {
+        id: 'global:nav-speak',
+        label: 'Go to Speak',
+        icon: MessageCircle,
+        action: () => router.push('/speak'),
+      },
+      {
+        id: 'global:nav-read',
+        label: 'Go to Read',
+        icon: BookOpen,
+        action: () => router.push('/read'),
+      },
+      {
+        id: 'global:nav-write',
+        label: 'Go to Write',
+        icon: SquarePen,
+        action: () => router.push('/write'),
+      },
+    ],
+    [router],
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-xl overflow-hidden p-0" showCloseButton={false}>
+        <DialogTitle className="sr-only">Command Palette</DialogTitle>
+        <DialogDescription className="sr-only">
+          Search and run global navigation and workspace actions.
+        </DialogDescription>
+        <Command shouldFilter={true}>
+          <CommandInput placeholder="Search actions..." autoFocus />
+          <div className="border-b border-slate-100 bg-slate-50/80 px-4 py-3 text-xs text-slate-500">
+            Open search with <span className="font-medium text-slate-700">{searchKey}</span>
+            {searchKey !== defaultSearchKey ? <span className="ml-1">(default: {defaultSearchKey})</span> : null}
+          </div>
+          <CommandList className="max-h-[380px] p-2">
+            <CommandEmpty className="text-slate-500">No matching actions.</CommandEmpty>
+            <CommandGroup heading="Actions">
+              {items.map((item) => {
+                const Icon = item.icon;
+                return (
+                  <CommandItem
+                    key={item.id}
+                    value={item.label}
+                    onSelect={() => {
+                      onOpenChange(false);
+                      item.action();
+                    }}
+                    className="justify-between rounded-lg px-3 py-2"
+                  >
+                    <span className="flex items-center gap-3">
+                      <Icon className="h-4 w-4 text-slate-500" />
+                      <span>{item.label}</span>
+                    </span>
+                    <span className="rounded-md border border-slate-200 bg-slate-50 px-2 py-1 text-xs text-slate-500">
+                      {formatKeyCombo(getKey(item.id))}
+                    </span>
+                  </CommandItem>
+                );
+              })}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/settings/shortcut-settings.tsx
+++ b/src/components/settings/shortcut-settings.tsx
@@ -1,0 +1,607 @@
+'use client';
+
+import { AlertTriangle, CheckCircle2, Keyboard, RotateCcw, Sparkles, Wand2, X } from 'lucide-react';
+import { usePathname } from 'next/navigation';
+import { type ReactNode, useEffect, useMemo, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import {
+  getActiveShortcutScopes,
+  getScopeAvailabilityDescription,
+  SCOPE_LABELS,
+  SHORTCUT_DEFINITIONS,
+  type ShortcutDefinition,
+  type ShortcutScope,
+} from '@/lib/shortcut-definitions';
+import { getNormalizedShortcutKey } from '@/lib/shortcut-utils';
+import { isMac } from '@/lib/utils';
+import { useShortcutStore } from '@/stores/shortcut-store';
+
+type ConflictState = {
+  conflictingId: string;
+  message: string;
+} | null;
+
+function eventToCombo(e: KeyboardEvent): string | null {
+  const parts: string[] = [];
+  const mac = isMac();
+
+  if (mac ? e.metaKey : e.ctrlKey) parts.push('mod');
+  if (e.shiftKey) parts.push('shift');
+  if (e.altKey) parts.push('alt');
+
+  const key = e.key.toLowerCase();
+  if (['meta', 'control', 'shift', 'alt'].includes(key)) return null;
+
+  parts.push(getNormalizedShortcutKey(e));
+  return parts.join('+');
+}
+
+function Kbd({ combo, active = false }: { combo: string; active?: boolean }) {
+  const mac = isMac();
+  const parts = combo
+    .toLowerCase()
+    .split('+')
+    .map((part) => {
+      switch (part) {
+        case 'mod':
+          return mac ? '⌘' : 'Ctrl';
+        case 'shift':
+          return mac ? '⇧' : 'Shift';
+        case 'alt':
+          return mac ? '⌥' : 'Alt';
+        case 'space':
+          return 'Space';
+        case 'arrowleft':
+          return '←';
+        case 'arrowright':
+          return '→';
+        case 'arrowup':
+          return '↑';
+        case 'arrowdown':
+          return '↓';
+        case 'escape':
+          return 'Esc';
+        case 'enter':
+          return '↵';
+        default:
+          return part.toUpperCase();
+      }
+    });
+
+  return (
+    <span className="inline-flex flex-wrap items-center gap-1.5">
+      {parts.map((part, i) => (
+        <kbd
+          key={`${combo}-${i}`}
+          className={`inline-flex h-8 min-w-[32px] items-center justify-center rounded-xl border px-2.5 text-xs font-semibold shadow-sm transition-colors ${
+            active
+              ? 'border-indigo-500 bg-indigo-600 text-white shadow-indigo-200'
+              : 'border-slate-200 bg-white text-slate-700'
+          }`}
+        >
+          {part}
+        </kbd>
+      ))}
+    </span>
+  );
+}
+
+function ScopeAvailabilityPill({ isCurrentlyAvailable }: { isCurrentlyAvailable: boolean }) {
+  return (
+    <span
+      className={`inline-flex items-center rounded-full border px-2.5 py-1 text-[11px] font-medium ${
+        isCurrentlyAvailable
+          ? 'border-emerald-200 bg-emerald-50 text-emerald-700'
+          : 'border-slate-200 bg-slate-100 text-slate-500'
+      }`}
+    >
+      {isCurrentlyAvailable ? 'Available on this page' : 'Unavailable on this page'}
+    </span>
+  );
+}
+
+function ScopeSection({
+  scope,
+  isCurrentlyAvailable,
+  children,
+}: {
+  scope: ShortcutScope;
+  isCurrentlyAvailable: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <section className="space-y-3">
+      <div className="rounded-2xl border border-slate-200/80 bg-gradient-to-r from-slate-50 via-white to-indigo-50/60 p-4 shadow-sm">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="space-y-1">
+            <div className="flex items-center gap-3">
+              <h3 className="text-xs font-semibold uppercase tracking-[0.22em] text-indigo-500">
+                {SCOPE_LABELS[scope]}
+              </h3>
+              <div className="h-px w-10 bg-gradient-to-r from-indigo-200 to-transparent" />
+            </div>
+            <p className="text-sm text-slate-600">{getScopeAvailabilityDescription(scope)}</p>
+          </div>
+          <div className="shrink-0">
+            <ScopeAvailabilityPill isCurrentlyAvailable={isCurrentlyAvailable} />
+          </div>
+        </div>
+      </div>
+      <div className="space-y-2">{children}</div>
+    </section>
+  );
+}
+
+function ShortcutRow({
+  def,
+  effectiveKey,
+  isOverridden,
+  isActive,
+  hasConflict,
+  wasRecentlySaved,
+  onRebind,
+  onReset,
+  onCancelRebind,
+}: {
+  def: ShortcutDefinition;
+  effectiveKey: string;
+  isOverridden: boolean;
+  isActive: boolean;
+  hasConflict: boolean;
+  wasRecentlySaved: boolean;
+  onRebind: (id: string) => void;
+  onReset: (id: string) => void;
+  onCancelRebind: () => void;
+}) {
+  return (
+    <div
+      className={`rounded-2xl border transition-all duration-200 ${
+        hasConflict
+          ? 'border-red-200 bg-red-50/70 shadow-sm shadow-red-100/60'
+          : isActive
+            ? 'border-indigo-300 bg-gradient-to-r from-white via-indigo-50/50 to-white shadow-lg shadow-indigo-100/70 ring-1 ring-indigo-100'
+            : 'border-slate-200/80 bg-white hover:border-indigo-200 hover:shadow-sm'
+      }`}
+    >
+      <div className="flex flex-col gap-3 p-3 sm:flex-row sm:items-stretch sm:p-4">
+        <button
+          type="button"
+          onClick={() => onRebind(def.id)}
+          className="flex min-w-0 flex-1 flex-col gap-4 rounded-xl text-left outline-none transition-colors focus-visible:ring-2 focus-visible:ring-indigo-400/60 sm:flex-row sm:items-center sm:justify-between"
+          aria-pressed={isActive}
+          aria-label={isActive ? `Editing ${def.label} shortcut` : `Edit ${def.label} shortcut`}
+          title={isActive ? `Editing ${def.label} shortcut` : `Edit ${def.label} shortcut`}
+        >
+          <div className="min-w-0 flex-1 space-y-2">
+            <div className="flex flex-wrap items-center gap-2.5">
+              <p className="text-sm font-semibold text-slate-900">{def.label}</p>
+              <span
+                className={`inline-flex items-center rounded-full border px-2.5 py-1 text-[11px] font-medium ${
+                  isActive
+                    ? 'border-indigo-200 bg-indigo-600 text-white'
+                    : isOverridden
+                      ? 'border-indigo-200 bg-indigo-50 text-indigo-700'
+                      : 'border-slate-200 bg-slate-100 text-slate-600'
+                }`}
+              >
+                {isActive ? 'Editing' : isOverridden ? 'Custom' : 'Default'}
+              </span>
+              {wasRecentlySaved && !isActive && (
+                <span className="inline-flex items-center gap-1 rounded-full border border-emerald-200 bg-emerald-50 px-2.5 py-1 text-[11px] font-medium text-emerald-700">
+                  <CheckCircle2 className="h-3 w-3" />
+                  Saved
+                </span>
+              )}
+            </div>
+            <p className="max-w-[62ch] text-sm leading-6 text-slate-600">{def.description}</p>
+            {isActive ? (
+              <p className="text-xs font-medium text-indigo-600">
+                Capturing a new shortcut. Press <span className="font-medium">Esc</span> to cancel.
+              </p>
+            ) : hasConflict ? (
+              <p className="text-xs font-medium text-red-600">This binding conflicts with another shortcut.</p>
+            ) : def.requiresMod ? (
+              <p className="text-xs text-slate-400">Requires {isMac() ? 'Cmd' : 'Ctrl'} as a modifier.</p>
+            ) : null}
+          </div>
+
+          <div className="w-full shrink-0 sm:w-auto">
+            {isActive ? (
+              <div className="flex min-h-[88px] w-full items-center justify-center rounded-2xl border border-dashed border-indigo-300 bg-white px-4 py-4 text-center shadow-sm sm:min-w-[188px] sm:w-auto">
+                <div className="space-y-1.5">
+                  <div className="flex items-center justify-center gap-2 text-indigo-700">
+                    <Keyboard className="h-4 w-4 animate-pulse" />
+                    <span className="text-xs font-semibold uppercase tracking-[0.2em]">Capturing</span>
+                  </div>
+                  <p className="text-xs text-indigo-500">Press keys</p>
+                </div>
+              </div>
+            ) : (
+              <div className="flex min-h-[88px] w-full items-center justify-between rounded-2xl border border-slate-200 bg-slate-50/80 px-4 py-3 shadow-sm sm:min-w-[188px] sm:w-auto sm:justify-end">
+                <div className="sm:hidden">
+                  <p className="text-[11px] font-medium uppercase tracking-[0.2em] text-slate-400">Current</p>
+                </div>
+                <Kbd combo={effectiveKey} />
+              </div>
+            )}
+          </div>
+        </button>
+
+        <div className="flex shrink-0 flex-row items-center justify-end gap-2 sm:flex-col sm:items-end sm:justify-between">
+          <button
+            type="button"
+            onClick={() => {
+              if (isActive) {
+                onCancelRebind();
+                return;
+              }
+
+              onRebind(def.id);
+            }}
+            className={`cursor-pointer rounded-xl border p-2.5 transition-colors focus-visible:ring-2 focus-visible:ring-indigo-400/60 focus-visible:outline-none ${
+              isActive
+                ? 'border-indigo-200 bg-indigo-100 text-indigo-700'
+                : 'border-slate-200 text-slate-400 hover:bg-slate-100 hover:text-slate-600'
+            }`}
+            aria-label={isActive ? `Cancel editing ${def.label} shortcut` : `Edit ${def.label} shortcut`}
+            title={isActive ? 'Cancel editing' : 'Edit shortcut'}
+          >
+            {isActive ? <X className="h-4 w-4" /> : <Wand2 className="h-4 w-4" />}
+          </button>
+
+          {isOverridden ? (
+            <button
+              type="button"
+              onClick={() => onReset(def.id)}
+              className="cursor-pointer rounded-xl border border-slate-200 p-2.5 text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-600 focus-visible:ring-2 focus-visible:ring-indigo-400/60 focus-visible:outline-none"
+              aria-label={`Reset ${def.label} to default`}
+              title="Reset to default"
+            >
+              <RotateCcw className="h-4 w-4" />
+            </button>
+          ) : (
+            <span className="h-8 w-8" aria-hidden="true" />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ShortcutListContent({
+  rebindingId,
+  conflict,
+  recentlySavedId,
+  onStartRebind,
+  onReset,
+  onCancelRebind,
+}: {
+  rebindingId: string | null;
+  conflict: ConflictState;
+  recentlySavedId: string | null;
+  onStartRebind: (id: string) => void;
+  onReset: (id: string) => void;
+  onCancelRebind: () => void;
+}) {
+  const { overrides, getKey } = useShortcutStore();
+  const scopes: ShortcutScope[] = ['global', 'listen', 'speak', 'read', 'write'];
+  const pathname = usePathname();
+  const activeScopes = useMemo(() => getActiveShortcutScopes(pathname), [pathname]);
+
+  return (
+    <div className="space-y-6">
+      {scopes.map((scope) => {
+        const defs = SHORTCUT_DEFINITIONS.filter((d) => d.scope === scope);
+        if (defs.length === 0) return null;
+
+        return (
+          <ScopeSection key={scope} scope={scope} isCurrentlyAvailable={activeScopes.includes(scope)}>
+            {defs.map((def) => (
+              <ShortcutRow
+                key={def.id}
+                def={def}
+                effectiveKey={getKey(def.id)}
+                isOverridden={!!overrides[def.id]}
+                isActive={rebindingId === def.id}
+                hasConflict={conflict?.conflictingId === def.id}
+                wasRecentlySaved={recentlySavedId === def.id}
+                onRebind={onStartRebind}
+                onReset={onReset}
+                onCancelRebind={onCancelRebind}
+              />
+            ))}
+          </ScopeSection>
+        );
+      })}
+    </div>
+  );
+}
+
+function RebindingBanner({
+  activeDefinition,
+  currentKey,
+  conflict,
+  onCancel,
+}: {
+  activeDefinition: ShortcutDefinition | null;
+  currentKey: string;
+  conflict: ConflictState;
+  onCancel: () => void;
+}) {
+  if (!activeDefinition) {
+    return (
+      <div className="grid gap-3 rounded-3xl border border-indigo-100 bg-gradient-to-br from-indigo-50 via-white to-slate-50 p-4 shadow-sm sm:grid-cols-[minmax(0,1.4fr)_minmax(220px,0.8fr)] sm:items-center">
+        <div className="flex min-w-0 items-start gap-3">
+          <div className="rounded-2xl bg-indigo-600 p-2.5 text-white shadow-sm shadow-indigo-200">
+            <Keyboard className="h-4 w-4" />
+          </div>
+          <div className="min-w-0">
+            <p className="text-sm font-semibold text-slate-900">Customize shortcuts inline</p>
+            <p className="mt-1 text-sm leading-6 text-slate-600">
+              Click a row, press your key combo, and the new binding is saved immediately.
+            </p>
+          </div>
+        </div>
+        <div className="grid grid-cols-2 gap-2">
+          <div className="rounded-2xl border border-white/80 bg-white/80 p-3 shadow-sm">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">Search</p>
+            <p className="mt-2 text-sm font-semibold text-slate-900">{isMac() ? 'Command+K' : 'Ctrl+K'}</p>
+          </div>
+          <div className="rounded-2xl border border-white/80 bg-white/80 p-3 shadow-sm">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">Editing</p>
+            <p className="mt-2 text-sm font-semibold text-slate-900">Tap any row</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={`grid gap-3 rounded-3xl border p-4 shadow-sm sm:grid-cols-[minmax(0,1.4fr)_auto] sm:items-center ${
+        conflict
+          ? 'border-red-200 bg-red-50'
+          : 'border-indigo-200 bg-gradient-to-br from-indigo-50 via-white to-slate-50'
+      }`}
+    >
+      <div className="min-w-0">
+        <div className="flex flex-wrap items-center gap-2">
+          {conflict ? (
+            <AlertTriangle className="h-4 w-4 text-red-500" />
+          ) : (
+            <Keyboard className="h-4 w-4 text-indigo-600" />
+          )}
+          <p className={`text-sm font-semibold ${conflict ? 'text-red-700' : 'text-slate-800'}`}>
+            {activeDefinition.label}
+          </p>
+        </div>
+        <p className={`mt-1 text-sm leading-6 ${conflict ? 'text-red-600' : 'text-slate-600'}`}>
+          {conflict
+            ? conflict.message
+            : `Press the new key combination now. ${activeDefinition.requiresMod ? `This action must include ${isMac() ? 'Cmd' : 'Ctrl'}.` : 'Press Esc to cancel.'}`}
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-2 self-start sm:items-end">
+        {!conflict && (
+          <div className="rounded-2xl border border-indigo-200 bg-white/90 px-3 py-2 shadow-sm">
+            <p className="mb-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-indigo-400">
+              Current Binding
+            </p>
+            <Kbd combo={currentKey} active />
+          </div>
+        )}
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={onCancel}
+          className="cursor-pointer border-slate-200 bg-white text-slate-600 hover:bg-slate-50"
+        >
+          <X className="mr-1.5 h-3.5 w-3.5" />
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function ShortcutSettings() {
+  const [open, setOpen] = useState(false);
+  const [rebindingId, setRebindingId] = useState<string | null>(null);
+  const [conflict, setConflict] = useState<ConflictState>(null);
+  const [recentlySavedId, setRecentlySavedId] = useState<string | null>(null);
+  const { overrides, setOverride, clearOverride, resetAll, setPaused } = useShortcutStore();
+  const commandPaletteKey = useShortcutStore((state) => state.getKey('global:command-palette'));
+  const defaultSearchKeyLabel = isMac() ? 'Command+K' : 'Ctrl+K';
+
+  const activeDefinition = useMemo(() => SHORTCUT_DEFINITIONS.find((d) => d.id === rebindingId) ?? null, [rebindingId]);
+
+  useEffect(() => {
+    setPaused(open);
+    return () => {
+      setPaused(false);
+    };
+  }, [open, setPaused]);
+
+  useEffect(() => {
+    if (open) return;
+    setRebindingId(null);
+    setConflict(null);
+    setRecentlySavedId(null);
+  }, [open]);
+
+  useEffect(() => {
+    if (!recentlySavedId) return;
+    const timer = window.setTimeout(() => setRecentlySavedId(null), 1800);
+    return () => window.clearTimeout(timer);
+  }, [recentlySavedId]);
+
+  useEffect(() => {
+    if (!rebindingId) return;
+
+    const targetDef = SHORTCUT_DEFINITIONS.find((d) => d.id === rebindingId);
+    if (!targetDef) return;
+    const activeTarget = targetDef;
+
+    function onKeyDown(e: KeyboardEvent) {
+      e.preventDefault();
+      e.stopPropagation();
+
+      if (e.key === 'Escape') {
+        setRebindingId(null);
+        setConflict(null);
+        return;
+      }
+
+      const combo = eventToCombo(e);
+      if (!combo) return;
+
+      if (activeTarget.requiresMod && !combo.split('+').includes('mod')) {
+        setConflict({
+          conflictingId: activeTarget.id,
+          message: `“${activeTarget.label}” must include ${isMac() ? 'Cmd' : 'Ctrl'}.`,
+        });
+        return;
+      }
+
+      const conflicting = SHORTCUT_DEFINITIONS.find((definition) => {
+        if (definition.id === activeTarget.id) return false;
+        if (
+          definition.scope !== activeTarget.scope &&
+          definition.scope !== 'global' &&
+          activeTarget.scope !== 'global'
+        ) {
+          return false;
+        }
+        return useShortcutStore.getState().getKey(definition.id) === combo;
+      });
+
+      if (conflicting) {
+        setConflict({
+          conflictingId: conflicting.id,
+          message: `Conflicts with “${conflicting.label}” in ${SCOPE_LABELS[conflicting.scope]}.`,
+        });
+        return;
+      }
+
+      if (combo === activeTarget.defaultKey) {
+        clearOverride(activeTarget.id);
+      } else {
+        setOverride(activeTarget.id, combo);
+      }
+
+      setRecentlySavedId(activeTarget.id);
+      setRebindingId(null);
+      setConflict(null);
+    }
+
+    window.addEventListener('keydown', onKeyDown, true);
+    return () => window.removeEventListener('keydown', onKeyDown, true);
+  }, [rebindingId, setOverride, clearOverride]);
+
+  const handleStartRebind = (id: string) => {
+    setRebindingId(id);
+    setConflict(null);
+    setRecentlySavedId(null);
+  };
+
+  const handleResetSingle = (id: string) => {
+    clearOverride(id);
+    setConflict(null);
+    setRecentlySavedId(id);
+    if (rebindingId === id) {
+      setRebindingId(null);
+    }
+  };
+
+  const handleCancelRebind = () => {
+    setRebindingId(null);
+    setConflict(null);
+  };
+
+  const currentActiveKey = activeDefinition ? useShortcutStore.getState().getKey(activeDefinition.id) : '';
+
+  return (
+    <>
+      <div className="flex items-center justify-between gap-4 rounded-2xl border border-slate-200 bg-white/80 p-4 shadow-sm">
+        <div className="min-w-0">
+          <p className="text-sm font-semibold text-slate-900">Keyboard shortcuts</p>
+          <p className="mt-1 text-sm leading-6 text-slate-600">
+            Search defaults to {defaultSearchKeyLabel}. Open the editor to customize bindings and check which scopes are
+            active on the current page.
+          </p>
+        </div>
+        <Button
+          variant="outline"
+          onClick={() => setOpen(true)}
+          className="cursor-pointer border-indigo-200 bg-indigo-50 text-indigo-700 hover:bg-indigo-100"
+        >
+          <Keyboard className="w-4 h-4 mr-2" />
+          Configure Shortcuts
+        </Button>
+      </div>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="flex max-h-[88vh] flex-col overflow-hidden border border-indigo-100 bg-gradient-to-b from-white via-white to-slate-50 p-0 shadow-2xl sm:max-w-4xl">
+          <DialogHeader className="shrink-0 border-b border-slate-100 px-6 pt-6 pb-5">
+            <DialogTitle className="text-xl font-semibold text-slate-900">Keyboard Shortcuts</DialogTitle>
+            <DialogDescription className="max-w-2xl text-sm leading-6 text-slate-600">
+              Search opens with {defaultSearchKeyLabel} by default on this device. Current binding:{' '}
+              {commandPaletteKey === 'mod+k'
+                ? defaultSearchKeyLabel
+                : commandPaletteKey.replaceAll('mod', isMac() ? 'Command' : 'Ctrl')}
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="shrink-0 px-6 py-4">
+            <RebindingBanner
+              activeDefinition={activeDefinition}
+              currentKey={currentActiveKey}
+              conflict={conflict}
+              onCancel={() => {
+                setRebindingId(null);
+                setConflict(null);
+              }}
+            />
+          </div>
+
+          <div className="min-h-0 flex-1 overflow-y-auto px-6 pb-5">
+            <ShortcutListContent
+              rebindingId={rebindingId}
+              conflict={conflict}
+              recentlySavedId={recentlySavedId}
+              onStartRebind={handleStartRebind}
+              onReset={handleResetSingle}
+              onCancelRebind={handleCancelRebind}
+            />
+          </div>
+
+          <div className="flex shrink-0 flex-col gap-3 border-t border-slate-100 bg-white/80 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
+            <p className="text-xs leading-5 text-slate-500">
+              Global shortcuts may overlap with their module equivalents, but conflicting bindings inside the same
+              active scope are blocked.
+            </p>
+            {Object.keys(overrides).length > 0 && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => {
+                  resetAll();
+                  setConflict(null);
+                  setRebindingId(null);
+                  setRecentlySavedId(null);
+                }}
+                className="cursor-pointer border-slate-200 bg-white text-slate-600 hover:bg-slate-100"
+              >
+                <RotateCcw className="mr-1.5 h-3.5 w-3.5" />
+                Reset All
+              </Button>
+            )}
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/components/voice-picker.tsx
+++ b/src/components/voice-picker.tsx
@@ -39,6 +39,13 @@ const LANG_FLAGS: Record<string, string> = {
   'en-ZA': '🇿🇦 ZA',
   'en-IE': '🇮🇪 IE',
   'en-SG': '🇸🇬 SG',
+  'ja-JP': '🇯🇵 JP',
+  'zh-CN': '🇨🇳 CN',
+  'es-ES': '🇪🇸 ES',
+  'fr-FR': '🇫🇷 FR',
+  'hi-IN': '🇮🇳 HI',
+  'it-IT': '🇮🇹 IT',
+  'pt-BR': '🇧🇷 BR',
 };
 
 const PROVIDER_BADGES: Record<string, string> = {
@@ -46,6 +53,7 @@ const PROVIDER_BADGES: Record<string, string> = {
   google: 'Google',
   microsoft: 'Microsoft',
   'browser-cloud': 'Cloud',
+  kokoro: 'Kokoro',
   other: 'Other',
 };
 
@@ -189,9 +197,29 @@ function VoiceCard({
 }
 
 export function VoicePicker() {
-  const { voices, isReady, isSpeaking, isFishLoading, fishError, previewingURI, previewVoice, stop, voiceSource } =
-    useTTS();
-  const { voiceURI, fishVoiceId, setVoiceURI, setFishVoice, fishApiKey } = useTTSStore();
+  const {
+    voices,
+    isReady,
+    isSpeaking,
+    isFishLoading,
+    isKokoroLoading,
+    fishError,
+    kokoroError,
+    previewingURI,
+    previewVoice,
+    stop,
+    voiceSource,
+  } = useTTS();
+  const {
+    voiceURI,
+    fishVoiceId,
+    kokoroVoiceId,
+    setVoiceURI,
+    setFishVoice,
+    setKokoroVoice,
+    fishApiKey,
+    kokoroServerUrl,
+  } = useTTSStore();
   const [tab, setTab] = useState<BrowserVoicePickerTab>('english');
   const [searchQuery, setSearchQuery] = useState('');
 
@@ -202,7 +230,7 @@ export function VoicePicker() {
   const browserVoiceGroups = useMemo(() => getBrowserVoicePickerGroups(voices), [voices]);
 
   const visibleVoices = useMemo(() => {
-    if (voiceSource === 'fish') return voices;
+    if (voiceSource === 'fish' || voiceSource === 'kokoro') return voices;
     return filterBrowserVoicesByTab(voices, tab);
   }, [voiceSource, voices, tab]);
 
@@ -225,7 +253,7 @@ export function VoicePicker() {
     return result;
   }, [visibleVoices, searchQuery]);
 
-  if (!isReady || isFishLoading) {
+  if (!isReady || isFishLoading || isKokoroLoading) {
     return <div className="flex items-center justify-center py-8 text-sm text-indigo-400">Loading voices...</div>;
   }
 
@@ -240,6 +268,20 @@ export function VoicePicker() {
   if (voiceSource === 'fish' && fishError) {
     return (
       <div className="rounded-xl border border-rose-200 bg-rose-50 px-4 py-6 text-sm text-rose-700">{fishError}</div>
+    );
+  }
+
+  if (voiceSource === 'kokoro' && !kokoroServerUrl.trim()) {
+    return (
+      <div className="rounded-xl border border-dashed border-indigo-200 bg-indigo-50/70 px-4 py-6 text-sm text-indigo-700">
+        Add your Kokoro server URL below to load the remote voice library.
+      </div>
+    );
+  }
+
+  if (voiceSource === 'kokoro' && kokoroError) {
+    return (
+      <div className="rounded-xl border border-rose-200 bg-rose-50 px-4 py-6 text-sm text-rose-700">{kokoroError}</div>
     );
   }
 
@@ -268,7 +310,9 @@ export function VoicePicker() {
           placeholder={
             voiceSource === 'fish'
               ? 'Search voices by name, author, or tag...'
-              : 'Search voices by name, accent, or provider...'
+              : voiceSource === 'kokoro'
+                ? 'Search voices by name, language, or gender...'
+                : 'Search voices by name, accent, or provider...'
           }
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
@@ -306,11 +350,20 @@ export function VoicePicker() {
               <div key={v.voiceURI} className="space-y-1.5">
                 <VoiceCard
                   voice={v}
-                  isSelected={v.voiceURI === (voiceSource === 'fish' ? fishVoiceId : voiceURI || voices[0]?.voiceURI)}
+                  isSelected={
+                    v.voiceURI ===
+                    (voiceSource === 'fish'
+                      ? fishVoiceId
+                      : voiceSource === 'kokoro'
+                        ? kokoroVoiceId
+                        : voiceURI || voices[0]?.voiceURI)
+                  }
                   isPreviewing={isSpeaking && previewingURI === v.voiceURI}
                   onSelect={() => {
                     if (voiceSource === 'fish') {
                       setFishVoice(v.voiceURI, v.name);
+                    } else if (voiceSource === 'kokoro') {
+                      setKokoroVoice(v.voiceURI, v.name);
                     } else {
                       setVoiceURI(v.voiceURI);
                     }
@@ -318,7 +371,7 @@ export function VoicePicker() {
                   onPreview={() => previewVoice(v.voiceURI)}
                   onStop={stop}
                 />
-                {voiceSource === 'fish' && (
+                {(voiceSource === 'fish' || voiceSource === 'kokoro') && (
                   <div className="space-y-1 px-1 text-[11px] text-slate-500">
                     {v.authorName && <p className="truncate">By {v.authorName}</p>}
                     {v.description && <p className="line-clamp-2 text-slate-400">{v.description}</p>}

--- a/src/hooks/use-shortcuts.ts
+++ b/src/hooks/use-shortcuts.ts
@@ -1,0 +1,136 @@
+import { useEffect, useRef } from 'react';
+
+import type { ShortcutScope } from '@/lib/shortcut-definitions';
+import { SHORTCUT_DEFINITIONS } from '@/lib/shortcut-definitions';
+import { matchesShortcutEvent, parseShortcutCombo } from '@/lib/shortcut-utils';
+import { isMac } from '@/lib/utils';
+import { useShortcutStore } from '@/stores/shortcut-store';
+
+/** Map of shortcut id → handler callback */
+export type ShortcutHandlers = Record<string, () => void>;
+
+/**
+ * Returns true if the active element is a text input where bare keys should not fire.
+ */
+function isTextInput(target: EventTarget | null): boolean {
+  if (!target || !(target instanceof HTMLElement)) return false;
+  const tag = target.tagName;
+  if (tag === 'INPUT') {
+    const type = (target as HTMLInputElement).type;
+    return ['text', 'search', 'email', 'password', 'url', 'tel', 'number'].includes(type);
+  }
+  if (tag === 'TEXTAREA') return true;
+  if (target.isContentEditable) return true;
+  return false;
+}
+
+/**
+ * Core keyboard shortcuts hook.
+ *
+ * @param scope - The scope this hook instance manages ('global', 'listen', 'speak', 'read')
+ * @param handlers - Map of shortcut id → callback. Only IDs matching the scope will fire.
+ *
+ * Usage:
+ * ```
+ * useShortcuts('listen', {
+ *   'listen:play-pause': () => togglePlay(),
+ *   'listen:speed-up': () => speedUp(),
+ * });
+ * ```
+ */
+export function useShortcuts(scope: ShortcutScope, handlers: ShortcutHandlers) {
+  const handlersRef = useRef(handlers);
+  handlersRef.current = handlers;
+
+  useEffect(() => {
+    const scopeDefs = SHORTCUT_DEFINITIONS.filter((d) => d.scope === scope);
+
+    function onKeyDown(e: KeyboardEvent) {
+      if (useShortcutStore.getState().isPaused) return;
+
+      const inTextInput = isTextInput(e.target);
+
+      for (const def of scopeDefs) {
+        // Get effective key (user override or default)
+        const effectiveKey = useShortcutStore.getState().getKey(def.id);
+        if (!effectiveKey) continue;
+
+        const combo = parseShortcutCombo(effectiveKey);
+
+        // If focused on a text input, only fire modifier-required shortcuts
+        if (inTextInput && !combo.mod) continue;
+
+        if (matchesShortcutEvent(e, effectiveKey)) {
+          const handler = handlersRef.current[def.id];
+          if (handler) {
+            e.preventDefault();
+            e.stopPropagation();
+            handler();
+            return;
+          }
+        }
+      }
+    }
+
+    const shortcutWindow = window as Window & {
+      __echotypeShortcutListeners?: Partial<Record<ShortcutScope, (event: KeyboardEvent) => void>>;
+    };
+
+    shortcutWindow.__echotypeShortcutListeners ??= {};
+
+    const existingListener = shortcutWindow.__echotypeShortcutListeners[scope];
+    if (existingListener) {
+      window.removeEventListener('keydown', existingListener);
+    }
+
+    shortcutWindow.__echotypeShortcutListeners[scope] = onKeyDown;
+    window.addEventListener('keydown', onKeyDown);
+
+    return () => {
+      const registeredListener = shortcutWindow.__echotypeShortcutListeners?.[scope];
+      if (registeredListener === onKeyDown) {
+        delete shortcutWindow.__echotypeShortcutListeners?.[scope];
+      }
+      window.removeEventListener('keydown', onKeyDown);
+    };
+  }, [scope]);
+}
+
+/**
+ * Format a key combo for display.
+ * e.g. "mod+k" → "⌘K" (Mac) or "Ctrl+K" (Windows)
+ */
+export function formatKeyCombo(combo: string): string {
+  const mac = isMac();
+  const parts = combo.toLowerCase().split('+');
+  return parts
+    .map((part) => {
+      switch (part) {
+        case 'mod':
+          return mac ? '⌘' : 'Ctrl';
+        case 'shift':
+          return mac ? '⇧' : 'Shift';
+        case 'alt':
+          return mac ? '⌥' : 'Alt';
+        case 'space':
+          return 'Space';
+        case 'arrowleft':
+          return '←';
+        case 'arrowright':
+          return '→';
+        case 'arrowup':
+          return '↑';
+        case 'arrowdown':
+          return '↓';
+        case 'escape':
+          return 'Esc';
+        case 'enter':
+          return '↵';
+        case ',':
+          return ',';
+        default:
+          return part.toUpperCase();
+      }
+    })
+    .join(mac ? '' : '+');
+}

--- a/src/hooks/use-translation.ts
+++ b/src/hooks/use-translation.ts
@@ -1,16 +1,11 @@
 import { useCallback, useRef, useState } from 'react';
 import { PROVIDER_REGISTRY } from '@/lib/providers';
+import { splitSentences } from '@/lib/sentence-split';
 import { useProviderStore } from '@/stores/provider-store';
 
 export interface SentenceTranslation {
   original: string;
   translation: string;
-}
-
-function splitSentences(text: string): string[] {
-  // Split on sentence-ending punctuation followed by space or end of string
-  const parts = text.split(/(?<=[.?!])\s+/);
-  return parts.map((s) => s.trim()).filter(Boolean);
 }
 
 export function useTranslation(text: string, targetLang: string, enabled: boolean = true) {

--- a/src/hooks/use-tts.ts
+++ b/src/hooks/use-tts.ts
@@ -4,10 +4,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { getBrowserVoiceMetadata } from '@/lib/browser-voice-metadata';
 import type { FishVoice } from '@/lib/fish-audio-shared';
 import { resolveTTSSource } from '@/lib/fish-audio-shared';
+import type { KokoroVoice } from '@/lib/kokoro-shared';
 import { useTTSStore } from '@/stores/tts-store';
 
 export interface VoiceOption {
-  source: 'browser' | 'fish';
+  source: 'browser' | 'fish' | 'kokoro';
   voiceURI: string;
   name: string;
   lang: string;
@@ -23,7 +24,7 @@ export interface VoiceOption {
   tags?: string[];
   taskCount?: number;
   likeCount?: number;
-  provider?: 'apple' | 'google' | 'microsoft' | 'browser-cloud' | 'other';
+  provider?: 'apple' | 'google' | 'microsoft' | 'browser-cloud' | 'other' | 'kokoro';
   voiceType?: 'natural' | 'standard' | 'novelty';
   accent?: 'us' | 'uk' | 'au' | 'ca' | 'in' | 'ie' | 'za' | 'nz' | 'sg' | 'other-english' | 'non-english';
   isEnglish?: boolean;
@@ -75,6 +76,35 @@ function normalizeFishVoiceToOption(voice: FishVoice): VoiceOption {
   };
 }
 
+function normalizeKokoroVoiceToOption(voice: KokoroVoice): VoiceOption {
+  const accent =
+    voice.langCode === 'en-US'
+      ? 'us'
+      : voice.langCode === 'en-GB'
+        ? 'uk'
+        : voice.langCode.startsWith('en')
+          ? 'other-english'
+          : 'non-english';
+
+  return {
+    source: 'kokoro',
+    voiceURI: voice.id,
+    name: voice.name,
+    lang: voice.langCode,
+    localService: false,
+    isPremium: true,
+    label: `${voice.name} (${voice.language})`,
+    description: `${voice.language} • ${voice.gender === 'female' ? 'Female' : 'Male'} voice`,
+    languages: [voice.langCode],
+    tags: [voice.language, voice.gender],
+    provider: 'kokoro',
+    voiceType: 'natural',
+    accent,
+    isEnglish: voice.langCode.startsWith('en'),
+    isFeatured: voice.langCode.startsWith('en'),
+  };
+}
+
 export function estimateListenDuration(text: string, rate: number = 1): number {
   const words = text.trim().split(/\s+/).length;
   const wpm = 150 * rate;
@@ -89,12 +119,27 @@ export function formatDuration(seconds: number): string {
 }
 
 export function useTTS() {
-  const { voiceSource, voiceURI, speed, pitch, volume, fishApiKey, fishVoiceId, fishModel } = useTTSStore();
+  const {
+    voiceSource,
+    voiceURI,
+    speed,
+    pitch,
+    volume,
+    fishApiKey,
+    fishVoiceId,
+    fishModel,
+    kokoroServerUrl,
+    kokoroApiKey,
+    kokoroVoiceId,
+  } = useTTSStore();
   const [browserVoices, setBrowserVoices] = useState<VoiceOption[]>([]);
   const [fishVoices, setFishVoices] = useState<VoiceOption[]>([]);
+  const [kokoroVoices, setKokoroVoices] = useState<VoiceOption[]>([]);
   const [isBrowserReady, setIsBrowserReady] = useState(false);
   const [isFishLoading, setIsFishLoading] = useState(false);
+  const [isKokoroLoading, setIsKokoroLoading] = useState(false);
   const [fishError, setFishError] = useState<string | null>(null);
+  const [kokoroError, setKokoroError] = useState<string | null>(null);
   const [isSpeaking, setIsSpeaking] = useState(false);
   const [previewingURI, setPreviewingURI] = useState<string | null>(null);
   const utteranceRef = useRef<SpeechSynthesisUtterance | null>(null);
@@ -252,6 +297,50 @@ export function useTTS() {
     return () => controller.abort();
   }, [fishApiKey, voiceSource]);
 
+  useEffect(() => {
+    if (voiceSource !== 'kokoro') return;
+    if (!kokoroServerUrl.trim()) {
+      setKokoroVoices([]);
+      setKokoroError(null);
+      setIsKokoroLoading(false);
+      return;
+    }
+
+    const controller = new AbortController();
+    setIsKokoroLoading(true);
+    setKokoroError(null);
+
+    void fetch('/api/tts/kokoro/voices', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        serverUrl: kokoroServerUrl,
+        apiKey: kokoroApiKey || undefined,
+      }),
+      signal: controller.signal,
+    })
+      .then(async (response) => {
+        const data = (await response.json()) as { voices?: KokoroVoice[]; error?: string };
+        if (!response.ok) {
+          throw new Error(data.error || 'Failed to load Kokoro voices.');
+        }
+
+        setKokoroVoices((data.voices ?? []).map(normalizeKokoroVoiceToOption));
+      })
+      .catch((error) => {
+        if (error instanceof DOMException && error.name === 'AbortError') return;
+        setKokoroVoices([]);
+        setKokoroError(error instanceof Error ? error.message : 'Failed to load Kokoro voices.');
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) {
+          setIsKokoroLoading(false);
+        }
+      });
+
+    return () => controller.abort();
+  }, [kokoroApiKey, kokoroServerUrl, voiceSource]);
+
   const stop = useCallback(() => {
     requestAbortRef.current?.abort();
     requestAbortRef.current = null;
@@ -267,6 +356,15 @@ export function useTTS() {
   }, []);
 
   useEffect(() => stop, [stop]);
+
+  useEffect(() => {
+    function handleGlobalStop() {
+      stop();
+    }
+
+    window.addEventListener('echotype:stop-tts', handleGlobalStop);
+    return () => window.removeEventListener('echotype:stop-tts', handleGlobalStop);
+  }, [stop]);
 
   const getVoice = useCallback((): SpeechSynthesisVoice | null => {
     if (!voiceURI) return null;
@@ -357,14 +455,65 @@ export function useTTS() {
     [fishApiKey, fishModel, speed, stop],
   );
 
+  const playKokoroSpeech = useCallback(
+    async (text: string, voiceId: string, overrides?: { rate?: number }) => {
+      stop();
+      const controller = new AbortController();
+      requestAbortRef.current = controller;
+
+      const response = await fetch('/api/tts/kokoro/speak', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          serverUrl: kokoroServerUrl,
+          apiKey: kokoroApiKey || undefined,
+          text,
+          voice: voiceId,
+          speed: overrides?.rate ?? speed,
+        }),
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        const data = (await response.json().catch(() => ({}))) as { error?: string };
+        throw new Error(data.error || 'Kokoro speech synthesis failed.');
+      }
+
+      const blob = await response.blob();
+      const objectUrl = URL.createObjectURL(blob);
+      const audio = new Audio(objectUrl);
+      objectUrlRef.current = objectUrl;
+      audioRef.current = audio;
+
+      audio.onplay = () => setIsSpeaking(true);
+      audio.onended = () => {
+        setIsSpeaking(false);
+        setPreviewingURI(null);
+        if (objectUrlRef.current) {
+          URL.revokeObjectURL(objectUrlRef.current);
+          objectUrlRef.current = null;
+        }
+      };
+      audio.onerror = () => {
+        setIsSpeaking(false);
+        setPreviewingURI(null);
+      };
+
+      await audio.play();
+    },
+    [kokoroApiKey, kokoroServerUrl, speed, stop],
+  );
+
   const resolvedPlayback = useMemo(
     () =>
       resolveTTSSource({
         requestedSource: voiceSource,
         hasFishCredentials: Boolean(fishApiKey.trim()),
         hasFishVoice: Boolean(fishVoiceId.trim()),
+        hasKokoroServerUrl: Boolean(kokoroServerUrl.trim()),
+        hasKokoroVoice: Boolean(kokoroVoiceId.trim()),
       }),
-    [voiceSource, fishApiKey, fishVoiceId],
+    [voiceSource, fishApiKey, fishVoiceId, kokoroServerUrl, kokoroVoiceId],
   );
 
   const boundaryPlayback = useMemo(
@@ -373,9 +522,11 @@ export function useTTS() {
         requestedSource: voiceSource,
         hasFishCredentials: Boolean(fishApiKey.trim()),
         hasFishVoice: Boolean(fishVoiceId.trim()),
+        hasKokoroServerUrl: Boolean(kokoroServerUrl.trim()),
+        hasKokoroVoice: Boolean(kokoroVoiceId.trim()),
         requiresBoundaryEvents: true,
       }),
-    [voiceSource, fishApiKey, fishVoiceId],
+    [voiceSource, fishApiKey, fishVoiceId, kokoroServerUrl, kokoroVoiceId],
   );
 
   const speak = useCallback(
@@ -389,9 +540,18 @@ export function useTTS() {
         }
       }
 
+      if (resolvedPlayback.source === 'kokoro') {
+        try {
+          await playKokoroSpeech(text, kokoroVoiceId, overrides);
+          return;
+        } catch {
+          return playBrowserSpeech(text, overrides);
+        }
+      }
+
       return playBrowserSpeech(text, overrides);
     },
-    [resolvedPlayback.source, playFishSpeech, fishVoiceId, playBrowserSpeech],
+    [resolvedPlayback.source, playFishSpeech, fishVoiceId, playKokoroSpeech, kokoroVoiceId, playBrowserSpeech],
   );
 
   const preview = useCallback(
@@ -407,6 +567,15 @@ export function useTTS() {
       if (voiceSource === 'fish') {
         try {
           await playFishSpeech(text, uri);
+          return;
+        } catch {
+          setPreviewingURI(null);
+        }
+      }
+
+      if (voiceSource === 'kokoro') {
+        try {
+          await playKokoroSpeech(text, uri);
           return;
         } catch {
           setPreviewingURI(null);
@@ -434,36 +603,48 @@ export function useTTS() {
       };
       window.speechSynthesis.speak(utterance);
     },
-    [voiceSource, speed, pitch, volume, playFishSpeech],
+    [voiceSource, speed, pitch, volume, playFishSpeech, playKokoroSpeech],
   );
 
   const voices = useMemo(() => {
     if (voiceSource === 'fish') {
       return fishVoices;
     }
+    if (voiceSource === 'kokoro') {
+      return kokoroVoices;
+    }
     return browserVoices;
-  }, [voiceSource, fishVoices, browserVoices]);
+  }, [voiceSource, fishVoices, kokoroVoices, browserVoices]);
 
   const currentVoice = useMemo(() => {
     if (voiceSource === 'fish') {
       return fishVoices.find((voice) => voice.voiceURI === fishVoiceId) ?? null;
     }
+    if (voiceSource === 'kokoro') {
+      return kokoroVoices.find((voice) => voice.voiceURI === kokoroVoiceId) ?? null;
+    }
     return browserVoices.find((voice) => voice.voiceURI === voiceURI) ?? null;
-  }, [voiceSource, fishVoices, fishVoiceId, browserVoices, voiceURI]);
+  }, [voiceSource, fishVoices, fishVoiceId, kokoroVoices, kokoroVoiceId, browserVoices, voiceURI]);
+
+  const sourceError = voiceSource === 'fish' ? fishError : voiceSource === 'kokoro' ? kokoroError : null;
+  const isSourceLoading = voiceSource === 'fish' ? isFishLoading : voiceSource === 'kokoro' ? isKokoroLoading : false;
 
   return {
     voices,
     browserVoices,
     fishVoices,
+    kokoroVoices,
     currentVoice,
-    isReady: isBrowserReady && !isFishLoading,
+    isReady: isBrowserReady && !isSourceLoading,
     isSpeaking,
     isFishLoading,
+    isKokoroLoading,
     fishError,
+    kokoroError,
     previewingURI,
     voiceSource,
     resolvedVoiceSource: resolvedPlayback.source,
-    resolvedVoiceSourceReason: resolvedPlayback.reason ?? fishError ?? undefined,
+    resolvedVoiceSourceReason: resolvedPlayback.reason ?? sourceError ?? undefined,
     boundaryVoiceSource: boundaryPlayback.source,
     boundaryPlaybackNotice: boundaryPlayback.reason,
     speak,

--- a/src/lib/fish-audio-shared.ts
+++ b/src/lib/fish-audio-shared.ts
@@ -41,17 +41,26 @@ export function resolveTTSSource({
   requestedSource,
   hasFishCredentials,
   hasFishVoice,
+  hasKokoroServerUrl = false,
+  hasKokoroVoice = false,
   requiresBoundaryEvents = false,
 }: {
   requestedSource: TTSSource;
   hasFishCredentials: boolean;
   hasFishVoice: boolean;
+  hasKokoroServerUrl?: boolean;
+  hasKokoroVoice?: boolean;
   requiresBoundaryEvents?: boolean;
 }): ResolvedTTSSource {
   if (requiresBoundaryEvents) {
     return {
       source: 'browser',
-      reason: requestedSource === 'fish' ? 'Boundary-based highlighting still requires browser speech.' : undefined,
+      reason:
+        requestedSource === 'fish'
+          ? 'Boundary-based highlighting still requires browser speech when Fish Audio is selected.'
+          : requestedSource === 'kokoro'
+            ? 'Boundary-based highlighting still requires browser speech when Kokoro is selected.'
+            : undefined,
     };
   }
 
@@ -66,6 +75,21 @@ export function resolveTTSSource({
       return {
         source: 'browser',
         reason: 'Fish Audio is selected but no cloud voice is chosen yet.',
+      };
+    }
+  }
+
+  if (requestedSource === 'kokoro') {
+    if (!hasKokoroServerUrl) {
+      return {
+        source: 'browser',
+        reason: 'Kokoro is selected but no server URL is configured.',
+      };
+    }
+    if (!hasKokoroVoice) {
+      return {
+        source: 'browser',
+        reason: 'Kokoro is selected but no voice is chosen yet.',
       };
     }
   }

--- a/src/lib/fish-audio.test.ts
+++ b/src/lib/fish-audio.test.ts
@@ -190,7 +190,7 @@ describe('fish-audio helpers', () => {
       }),
     ).toEqual({
       source: 'browser',
-      reason: 'Boundary-based highlighting still requires browser speech.',
+      reason: 'Boundary-based highlighting still requires browser speech when Fish Audio is selected.',
     });
   });
 
@@ -236,6 +236,62 @@ describe('fish-audio helpers', () => {
         requiresBoundaryEvents: true,
       }),
     ).toEqual({ source: 'browser', reason: undefined });
+  });
+
+  it('returns browser fallback when Kokoro is not fully configured', () => {
+    expect(
+      resolveTTSSource({
+        requestedSource: 'kokoro',
+        hasFishCredentials: false,
+        hasFishVoice: false,
+        hasKokoroServerUrl: false,
+        hasKokoroVoice: false,
+      }),
+    ).toEqual({
+      source: 'browser',
+      reason: 'Kokoro is selected but no server URL is configured.',
+    });
+
+    expect(
+      resolveTTSSource({
+        requestedSource: 'kokoro',
+        hasFishCredentials: false,
+        hasFishVoice: false,
+        hasKokoroServerUrl: true,
+        hasKokoroVoice: false,
+      }),
+    ).toEqual({
+      source: 'browser',
+      reason: 'Kokoro is selected but no voice is chosen yet.',
+    });
+  });
+
+  it('returns Kokoro when server URL and voice are present', () => {
+    expect(
+      resolveTTSSource({
+        requestedSource: 'kokoro',
+        hasFishCredentials: false,
+        hasFishVoice: false,
+        hasKokoroServerUrl: true,
+        hasKokoroVoice: true,
+      }),
+    ).toEqual({ source: 'kokoro' });
+  });
+
+  it('falls back to browser for boundary events when Kokoro is selected', () => {
+    expect(
+      resolveTTSSource({
+        requestedSource: 'kokoro',
+        hasFishCredentials: false,
+        hasFishVoice: false,
+        hasKokoroServerUrl: true,
+        hasKokoroVoice: true,
+        requiresBoundaryEvents: true,
+      }),
+    ).toEqual({
+      source: 'browser',
+      reason: 'Boundary-based highlighting still requires browser speech when Kokoro is selected.',
+    });
   });
 
   // --- synthesizeFishSpeech ---

--- a/src/lib/kokoro-shared.ts
+++ b/src/lib/kokoro-shared.ts
@@ -1,0 +1,52 @@
+export interface KokoroVoice {
+  id: string;
+  name: string;
+  language: string;
+  langCode: string;
+  gender: 'male' | 'female';
+}
+
+export interface KokoroSpeechInput {
+  serverUrl: string;
+  apiKey?: string;
+  text: string;
+  voice: string;
+  speed?: number;
+}
+
+export const KOKORO_LANGUAGES: Record<string, string> = {
+  a: 'American English',
+  b: 'British English',
+  j: 'Japanese',
+  z: 'Chinese',
+  e: 'Spanish',
+  f: 'French',
+  h: 'Hindi',
+  i: 'Italian',
+  p: 'Portuguese',
+};
+
+export const KOKORO_LANGUAGE_CODES: Record<string, string> = {
+  a: 'en-US',
+  b: 'en-GB',
+  j: 'ja-JP',
+  z: 'zh-CN',
+  e: 'es-ES',
+  f: 'fr-FR',
+  h: 'hi-IN',
+  i: 'it-IT',
+  p: 'pt-BR',
+};
+
+export const DEFAULT_KOKORO_SERVER_URL =
+  process.env.NEXT_PUBLIC_KOKORO_SERVER_URL?.trim() || 'http://54.166.253.41:8880';
+
+export function parseKokoroVoiceId(id: string): { language: string; langCode: string; gender: 'male' | 'female' } {
+  const langPrefix = id.charAt(0);
+  const genderChar = id.charAt(1);
+  return {
+    language: KOKORO_LANGUAGES[langPrefix] ?? 'Unknown',
+    langCode: KOKORO_LANGUAGE_CODES[langPrefix] ?? 'und',
+    gender: genderChar === 'f' ? 'female' : 'male',
+  };
+}

--- a/src/lib/kokoro.test.ts
+++ b/src/lib/kokoro.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const fetchMock = vi.fn();
+
+vi.stubGlobal('fetch', fetchMock);
+
+const { listKokoroVoices, synthesizeKokoroSpeech } = await import('./kokoro');
+
+describe('kokoro helpers', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('lists and normalizes Kokoro voices', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ voices: ['af_heart', 'bm_daniel', 'zf_xiaoyi'] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const voices = await listKokoroVoices('http://54.166.253.41:8880');
+
+    expect(fetchMock).toHaveBeenCalledWith('http://54.166.253.41:8880/v1/audio/voices', expect.any(Object));
+    expect(voices).toEqual([
+      {
+        id: 'af_heart',
+        name: 'Heart',
+        language: 'American English',
+        langCode: 'en-US',
+        gender: 'female',
+      },
+      {
+        id: 'bm_daniel',
+        name: 'Daniel',
+        language: 'British English',
+        langCode: 'en-GB',
+        gender: 'male',
+      },
+      {
+        id: 'zf_xiaoyi',
+        name: 'Xiaoyi',
+        language: 'Chinese',
+        langCode: 'zh-CN',
+        gender: 'female',
+      },
+    ]);
+  });
+
+  it('sends bearer auth when apiKey is provided', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ voices: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    await listKokoroVoices('http://localhost:8880/', 'kokoro-secret');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://localhost:8880/v1/audio/voices',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer kokoro-secret',
+        }),
+      }),
+    );
+  });
+
+  it('propagates voice listing failures with status details', async () => {
+    fetchMock.mockResolvedValue(new Response('unauthorized', { status: 401 }));
+
+    await expect(listKokoroVoices('http://localhost:8880')).rejects.toThrow(
+      'Kokoro voices request failed (401): unauthorized',
+    );
+  });
+
+  it('synthesizes Kokoro speech and returns audio bytes plus content type', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(new Uint8Array([1, 2, 3]), {
+        status: 200,
+        headers: { 'Content-Type': 'audio/mpeg' },
+      }),
+    );
+
+    const result = await synthesizeKokoroSpeech({
+      serverUrl: 'http://54.166.253.41:8880/',
+      apiKey: 'kokoro-key',
+      text: 'Hello from EchoType',
+      voice: 'af_heart',
+      speed: 1.2,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://54.166.253.41:8880/v1/audio/speech',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer kokoro-key',
+        }),
+        body: JSON.stringify({
+          model: 'kokoro',
+          input: 'Hello from EchoType',
+          voice: 'af_heart',
+          response_format: 'mp3',
+          speed: 1.2,
+        }),
+      }),
+    );
+    expect(result.contentType).toBe('audio/mpeg');
+    expect(Array.from(new Uint8Array(result.audioBuffer))).toEqual([1, 2, 3]);
+  });
+
+  it('falls back to audio/mpeg when content-type header is missing', async () => {
+    fetchMock.mockResolvedValue(new Response(new Uint8Array([1, 2]), { status: 200 }));
+
+    const result = await synthesizeKokoroSpeech({
+      serverUrl: 'http://localhost:8880',
+      text: 'Hello',
+      voice: 'af_heart',
+    });
+
+    expect(result.contentType).toBe('audio/mpeg');
+  });
+
+  it('propagates synthesis failures with status details', async () => {
+    fetchMock.mockResolvedValue(new Response('bad request', { status: 400 }));
+
+    await expect(
+      synthesizeKokoroSpeech({
+        serverUrl: 'http://localhost:8880',
+        text: 'Hello',
+        voice: 'af_heart',
+      }),
+    ).rejects.toThrow('Kokoro speech synthesis failed (400): bad request');
+  });
+});

--- a/src/lib/kokoro.ts
+++ b/src/lib/kokoro.ts
@@ -1,0 +1,74 @@
+import type { KokoroSpeechInput, KokoroVoice } from '@/lib/kokoro-shared';
+import { parseKokoroVoiceId } from '@/lib/kokoro-shared';
+
+function buildHeaders(apiKey?: string): Record<string, string> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+  return headers;
+}
+
+export async function listKokoroVoices(serverUrl: string, apiKey?: string): Promise<KokoroVoice[]> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 30_000);
+
+  try {
+    const url = `${serverUrl.replace(/\/+$/, '')}/v1/audio/voices`;
+    const response = await fetch(url, {
+      headers: buildHeaders(apiKey),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => '');
+      throw new Error(`Kokoro voices request failed (${response.status}): ${text}`);
+    }
+
+    const data = (await response.json()) as { voices?: string[] };
+    const voiceIds = data.voices ?? [];
+
+    return voiceIds.map((id: string) => {
+      const { language, langCode, gender } = parseKokoroVoiceId(id);
+      const name = id
+        .replace(/^[a-z]{2}_/, '')
+        .replace(/_/g, ' ')
+        .replace(/\b\w/g, (c) => c.toUpperCase());
+      return { id, name, language, langCode, gender };
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function synthesizeKokoroSpeech(
+  input: KokoroSpeechInput,
+): Promise<{ audioBuffer: ArrayBuffer; contentType: string }> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 30_000);
+
+  try {
+    const url = `${input.serverUrl.replace(/\/+$/, '')}/v1/audio/speech`;
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: buildHeaders(input.apiKey),
+      body: JSON.stringify({
+        model: 'kokoro',
+        input: input.text,
+        voice: input.voice,
+        response_format: 'mp3',
+        speed: input.speed ?? 1,
+      }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => '');
+      throw new Error(`Kokoro speech synthesis failed (${response.status}): ${text}`);
+    }
+
+    const contentType = response.headers.get('content-type') ?? 'audio/mpeg';
+    const audioBuffer = await response.arrayBuffer();
+    return { audioBuffer, contentType };
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/lib/listen-highlight.test.ts
+++ b/src/lib/listen-highlight.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { estimateSentenceHighlightTimings, estimateSentenceWeight } from './listen-highlight';
+
+describe('listen highlight timing estimation', () => {
+  it('gives more time to sentences with digits and abbreviations', () => {
+    const plain = estimateSentenceWeight({ text: 'I will arrive tomorrow morning.', wordCount: 5 });
+    const weighted = estimateSentenceWeight({ text: 'I will arrive at 10:30 a.m. on U.S. Route 66.', wordCount: 10 });
+
+    expect(weighted).toBeGreaterThan(plain);
+  });
+
+  it('gives more time to sentences with stronger pauses', () => {
+    const plain = estimateSentenceWeight({ text: 'We should leave now.', wordCount: 4 });
+    const paused = estimateSentenceWeight({ text: 'We should leave now, or we will miss the train; hurry up!', wordCount: 11 });
+
+    expect(paused).toBeGreaterThan(plain);
+  });
+
+  it('allocates longer timings to heavier sentences while preserving order', () => {
+    const timings = estimateSentenceHighlightTimings(
+      [
+        { text: 'Hello there.', wordCount: 2 },
+        { text: 'Meet me at 10:30 a.m., please, near Gate 24.', wordCount: 9 },
+        { text: 'Thanks.', wordCount: 1 },
+      ],
+      1,
+    );
+
+    expect(timings).toHaveLength(3);
+    expect(timings[0].startMs).toBe(0);
+    expect(timings[1].startMs).toBeGreaterThanOrEqual(timings[0].durationMs);
+    expect(timings[2].startMs).toBeGreaterThanOrEqual(timings[1].startMs + timings[1].durationMs);
+    expect(timings[1].durationMs).toBeGreaterThan(timings[0].durationMs);
+    expect(timings[1].durationMs).toBeGreaterThan(timings[2].durationMs);
+  });
+
+  it('still gives each sentence a minimum visible highlight window', () => {
+    const timings = estimateSentenceHighlightTimings(
+      [
+        { text: 'Hi.', wordCount: 1 },
+        { text: 'OK.', wordCount: 1 },
+        { text: 'Go.', wordCount: 1 },
+      ],
+      2,
+    );
+
+    expect(timings.every((timing) => timing.durationMs >= 900)).toBe(true);
+  });
+});

--- a/src/lib/listen-highlight.ts
+++ b/src/lib/listen-highlight.ts
@@ -1,0 +1,109 @@
+export interface SentenceTimingInput {
+  text: string;
+  wordCount: number;
+}
+
+export interface SentenceTimingSegment {
+  startMs: number;
+  durationMs: number;
+}
+
+const DEFAULT_MIN_SENTENCE_DURATION_MS = 900;
+const BASE_WPM = 150;
+const COMMA_PAUSE_WEIGHT = 1.8;
+const CLAUSE_PAUSE_WEIGHT = 2.4;
+const END_PAUSE_WEIGHT = 3.2;
+const DIGIT_TOKEN_WEIGHT = 0.65;
+const ALL_CAPS_TOKEN_WEIGHT = 0.35;
+const DECIMAL_TOKEN_WEIGHT = 0.45;
+const ABBREVIATION_TOKEN_WEIGHT = 0.25;
+const LONG_WORD_WEIGHT = 0.08;
+
+function countMatches(text: string, pattern: RegExp): number {
+  return text.match(pattern)?.length ?? 0;
+}
+
+function countWeightedTokens(text: string): number {
+  const tokens = text.match(/[A-Za-z0-9]+(?:[.'/-][A-Za-z0-9]+)*/g) ?? [];
+
+  return tokens.reduce((sum, token) => {
+    let weight = 1;
+
+    if (/\d/.test(token)) {
+      weight += DIGIT_TOKEN_WEIGHT;
+    }
+
+    if (/^\d+[.,:]\d+$/.test(token)) {
+      weight += DECIMAL_TOKEN_WEIGHT;
+    }
+
+    if (/^(?:[A-Za-z]\.){2,}[A-Za-z]?$/i.test(token) || /^(mr|mrs|ms|dr|prof|sr|jr|vs|etc)\.?$/i.test(token)) {
+      weight += ABBREVIATION_TOKEN_WEIGHT;
+    }
+
+    if (/^[A-Z]{2,}$/.test(token)) {
+      weight += ALL_CAPS_TOKEN_WEIGHT;
+    }
+
+    if (token.replace(/[^A-Za-z]/g, '').length >= 9) {
+      weight += LONG_WORD_WEIGHT;
+    }
+
+    return sum + weight;
+  }, 0);
+}
+
+export function estimateSentenceWeight(sentence: SentenceTimingInput): number {
+  const weightedTokens = countWeightedTokens(sentence.text);
+  const fallbackWords = Math.max(sentence.wordCount, 1);
+  const baseWeight = Math.max(weightedTokens, fallbackWords);
+
+  const commaPauseCount = countMatches(sentence.text, /[,،]/g);
+  const clausePauseCount = countMatches(sentence.text, /[;:]/g);
+  const endPauseCount = countMatches(sentence.text, /[.!?]+(?=\s*$)/g);
+
+  return (
+    baseWeight +
+    commaPauseCount * COMMA_PAUSE_WEIGHT +
+    clausePauseCount * CLAUSE_PAUSE_WEIGHT +
+    endPauseCount * END_PAUSE_WEIGHT
+  );
+}
+
+export function estimateSentenceHighlightTimings(
+  sentences: SentenceTimingInput[],
+  rate: number,
+): SentenceTimingSegment[] {
+  if (sentences.length === 0) {
+    return [];
+  }
+
+  const safeRate = Math.max(rate, 0.1);
+  const weights = sentences.map(estimateSentenceWeight);
+  const totalWeight = weights.reduce((sum, weight) => sum + weight, 0);
+  const totalDurationMs = Math.max(1_000, (Math.max(totalWeight, 1) / (BASE_WPM * safeRate)) * 60 * 1_000);
+
+  let elapsedMs = 0;
+
+  return weights.map((weight, index) => {
+    const remainingCount = sentences.length - index;
+    const remainingMs = Math.max(totalDurationMs - elapsedMs, DEFAULT_MIN_SENTENCE_DURATION_MS);
+    const proportionalDuration = (weight / Math.max(totalWeight, 1)) * totalDurationMs;
+    const maxDurationForCurrent = Math.max(
+      DEFAULT_MIN_SENTENCE_DURATION_MS,
+      remainingMs - DEFAULT_MIN_SENTENCE_DURATION_MS * (remainingCount - 1),
+    );
+    const durationMs =
+      index === sentences.length - 1
+        ? Math.max(DEFAULT_MIN_SENTENCE_DURATION_MS, remainingMs)
+        : Math.min(maxDurationForCurrent, Math.max(DEFAULT_MIN_SENTENCE_DURATION_MS, proportionalDuration));
+
+    const segment = {
+      startMs: elapsedMs,
+      durationMs,
+    };
+
+    elapsedMs += durationMs;
+    return segment;
+  });
+}

--- a/src/lib/sentence-split.test.ts
+++ b/src/lib/sentence-split.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { splitSentences } from './sentence-split';
+
+describe('splitSentences', () => {
+  it('keeps common abbreviations inside the same sentence', () => {
+    expect(splitSentences('Meet me at 10:30 a.m. in the U.S. office.')).toEqual([
+      'Meet me at 10:30 a.m. in the U.S. office.',
+    ]);
+  });
+
+  it('splits normal sentence boundaries', () => {
+    expect(splitSentences('Hello there. How are you? I am fine!')).toEqual([
+      'Hello there.',
+      'How are you?',
+      'I am fine!',
+    ]);
+  });
+
+  it('keeps initialisms in the same sentence', () => {
+    expect(splitSentences('The U.N. meeting starts now. Please join quickly.')).toEqual([
+      'The U.N. meeting starts now.',
+      'Please join quickly.',
+    ]);
+  });
+});

--- a/src/lib/sentence-split.ts
+++ b/src/lib/sentence-split.ts
@@ -1,0 +1,43 @@
+const ABBREVIATION_PLACEHOLDER = '__ECHOTYPE_SENTENCE_DOT__';
+
+const ABBREVIATIONS = [
+  'Mr.',
+  'Mrs.',
+  'Ms.',
+  'Dr.',
+  'Prof.',
+  'Sr.',
+  'Jr.',
+  'vs.',
+  'etc.',
+  'a.m.',
+  'p.m.',
+  'e.g.',
+  'i.e.',
+  'U.S.',
+  'U.K.',
+  'U.N.',
+] as const;
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export function splitSentences(text: string): string[] {
+  if (!text.trim()) {
+    return [];
+  }
+
+  let normalized = text;
+
+  for (const abbreviation of ABBREVIATIONS) {
+    normalized = normalized.replaceAll(abbreviation, abbreviation.replaceAll('.', ABBREVIATION_PLACEHOLDER));
+  }
+
+  normalized = normalized.replace(/\b(?:[A-Za-z]\.){2,}/g, (match) => match.replaceAll('.', ABBREVIATION_PLACEHOLDER));
+
+  return normalized
+    .split(/(?<=[.?!])\s+/)
+    .map((sentence) => sentence.replaceAll(ABBREVIATION_PLACEHOLDER, '.').trim())
+    .filter(Boolean);
+}

--- a/src/lib/shortcut-definitions.test.ts
+++ b/src/lib/shortcut-definitions.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+
+import { getActiveShortcutScopes } from './shortcut-definitions';
+
+describe('getActiveShortcutScopes', () => {
+  it('always includes global scope', () => {
+    expect(getActiveShortcutScopes('/settings')).toEqual(['global']);
+  });
+
+  it('enables listen scope only on listen practice detail pages', () => {
+    expect(getActiveShortcutScopes('/listen')).toEqual(['global']);
+    expect(getActiveShortcutScopes('/listen/lesson-1')).toEqual(['global', 'listen']);
+  });
+
+  it('enables speak, read, and write scopes on their detail pages', () => {
+    expect(getActiveShortcutScopes('/speak/scenario-a')).toEqual(['global', 'speak']);
+    expect(getActiveShortcutScopes('/read/article-a')).toEqual(['global', 'read']);
+    expect(getActiveShortcutScopes('/write/exercise-a')).toEqual(['global', 'write']);
+  });
+});

--- a/src/lib/shortcut-definitions.ts
+++ b/src/lib/shortcut-definitions.ts
@@ -1,0 +1,306 @@
+export type ShortcutScope = 'global' | 'listen' | 'speak' | 'read' | 'write';
+
+export interface ShortcutDefinition {
+  id: string;
+  label: string;
+  description: string;
+  scope: ShortcutScope;
+  /** Default key combo, e.g. "mod+k", "space", "arrowleft" */
+  defaultKey: string;
+  /** Whether this shortcut requires a modifier (Cmd/Ctrl) */
+  requiresMod: boolean;
+}
+
+/**
+ * Key format convention:
+ * - "mod" = Cmd on Mac, Ctrl on Windows/Linux
+ * - Keys are lowercase: "space", "arrowleft", "arrowright", "enter", "escape"
+ * - Modifiers joined with "+": "mod+k", "mod+shift+1"
+ * - Single keys: "space", "r", "t", "l"
+ */
+export const SHORTCUT_DEFINITIONS: ShortcutDefinition[] = [
+  // ── Global (require mod) ──────────────────────────────────
+  {
+    id: 'global:command-palette',
+    label: 'Command Palette',
+    description: 'Open the command palette',
+    scope: 'global',
+    defaultKey: 'mod+k',
+    requiresMod: true,
+  },
+  {
+    id: 'global:open-settings',
+    label: 'Open Settings',
+    description: 'Navigate to settings page',
+    scope: 'global',
+    defaultKey: 'mod+,',
+    requiresMod: true,
+  },
+  {
+    id: 'global:toggle-chat',
+    label: 'Toggle Chat',
+    description: 'Open or close the chat panel',
+    scope: 'global',
+    defaultKey: 'mod+j',
+    requiresMod: true,
+  },
+  {
+    id: 'global:nav-listen',
+    label: 'Go to Listen',
+    description: 'Navigate to Listen module',
+    scope: 'global',
+    defaultKey: 'mod+1',
+    requiresMod: true,
+  },
+  {
+    id: 'global:nav-speak',
+    label: 'Go to Speak',
+    description: 'Navigate to Speak module',
+    scope: 'global',
+    defaultKey: 'mod+2',
+    requiresMod: true,
+  },
+  {
+    id: 'global:nav-read',
+    label: 'Go to Read',
+    description: 'Navigate to Read module',
+    scope: 'global',
+    defaultKey: 'mod+3',
+    requiresMod: true,
+  },
+  {
+    id: 'global:nav-write',
+    label: 'Go to Write',
+    description: 'Navigate to Write module',
+    scope: 'global',
+    defaultKey: 'mod+4',
+    requiresMod: true,
+  },
+  {
+    id: 'global:speed-down',
+    label: 'Speed Down',
+    description: 'Decrease TTS speed',
+    scope: 'global',
+    defaultKey: 'mod+alt+s',
+    requiresMod: true,
+  },
+  {
+    id: 'global:speed-up',
+    label: 'Speed Up',
+    description: 'Increase TTS speed',
+    scope: 'global',
+    defaultKey: 'mod+alt+shift+s',
+    requiresMod: true,
+  },
+  {
+    id: 'global:pitch-down',
+    label: 'Pitch Down',
+    description: 'Decrease TTS pitch',
+    scope: 'global',
+    defaultKey: 'mod+alt+p',
+    requiresMod: true,
+  },
+  {
+    id: 'global:pitch-up',
+    label: 'Pitch Up',
+    description: 'Increase TTS pitch',
+    scope: 'global',
+    defaultKey: 'mod+alt+shift+p',
+    requiresMod: true,
+  },
+  {
+    id: 'global:volume-down',
+    label: 'Volume Down',
+    description: 'Decrease TTS volume',
+    scope: 'global',
+    defaultKey: 'mod+alt+v',
+    requiresMod: true,
+  },
+  {
+    id: 'global:volume-up',
+    label: 'Volume Up',
+    description: 'Increase TTS volume',
+    scope: 'global',
+    defaultKey: 'mod+alt+shift+v',
+    requiresMod: true,
+  },
+  {
+    id: 'global:stop-tts',
+    label: 'Stop TTS',
+    description: 'Stop the current text-to-speech playback',
+    scope: 'global',
+    defaultKey: 'mod+.',
+    requiresMod: true,
+  },
+
+  // ── Listen Mode ───────────────────────────────────────────
+  {
+    id: 'listen:play-pause',
+    label: 'Play / Pause',
+    description: 'Toggle TTS playback',
+    scope: 'listen',
+    defaultKey: 'space',
+    requiresMod: false,
+  },
+  {
+    id: 'listen:speed-down',
+    label: 'Speed Down',
+    description: 'Decrease playback speed',
+    scope: 'listen',
+    defaultKey: 'arrowleft',
+    requiresMod: false,
+  },
+  {
+    id: 'listen:speed-up',
+    label: 'Speed Up',
+    description: 'Increase playback speed',
+    scope: 'listen',
+    defaultKey: 'arrowright',
+    requiresMod: false,
+  },
+  {
+    id: 'listen:restart',
+    label: 'Restart',
+    description: 'Restart playback from beginning',
+    scope: 'listen',
+    defaultKey: 'r',
+    requiresMod: false,
+  },
+  {
+    id: 'listen:toggle-translation',
+    label: 'Toggle Translation',
+    description: 'Show or hide translation',
+    scope: 'listen',
+    defaultKey: 't',
+    requiresMod: false,
+  },
+
+  // ── Speak Mode ────────────────────────────────────────────
+  {
+    id: 'speak:toggle-recording',
+    label: 'Toggle Recording',
+    description: 'Start or stop voice recording',
+    scope: 'speak',
+    defaultKey: 'space',
+    requiresMod: false,
+  },
+  {
+    id: 'speak:toggle-translation',
+    label: 'Toggle Translation',
+    description: 'Show or hide translation',
+    scope: 'speak',
+    defaultKey: 't',
+    requiresMod: false,
+  },
+  {
+    id: 'speak:replay-last-assistant',
+    label: 'Replay Last Reply',
+    description: 'Replay the latest assistant message',
+    scope: 'speak',
+    defaultKey: 'l',
+    requiresMod: false,
+  },
+  {
+    id: 'speak:reset-conversation',
+    label: 'Reset Conversation',
+    description: 'Reset the conversation to the opening prompt',
+    scope: 'speak',
+    defaultKey: 'r',
+    requiresMod: false,
+  },
+
+  // ── Read Mode ─────────────────────────────────────────────
+  {
+    id: 'read:toggle-recording',
+    label: 'Start / Stop Recording',
+    description: 'Toggle speech recognition',
+    scope: 'read',
+    defaultKey: 'space',
+    requiresMod: false,
+  },
+  {
+    id: 'read:toggle-translation',
+    label: 'Toggle Translation',
+    description: 'Show or hide translation',
+    scope: 'read',
+    defaultKey: 't',
+    requiresMod: false,
+  },
+  {
+    id: 'read:listen',
+    label: 'Listen to Text',
+    description: 'Play reference text with TTS',
+    scope: 'read',
+    defaultKey: 'l',
+    requiresMod: false,
+  },
+  {
+    id: 'read:reset',
+    label: 'Reset',
+    description: 'Clear transcript and results',
+    scope: 'read',
+    defaultKey: 'r',
+    requiresMod: false,
+  },
+
+  // ── Write Mode ────────────────────────────────────────────
+  {
+    id: 'write:toggle-translation',
+    label: 'Toggle Translation',
+    description: 'Show or hide translation',
+    scope: 'write',
+    defaultKey: 'mod+alt+t',
+    requiresMod: true,
+  },
+  {
+    id: 'write:reset',
+    label: 'Reset',
+    description: 'Restart the typing practice',
+    scope: 'write',
+    defaultKey: 'mod+alt+r',
+    requiresMod: true,
+  },
+];
+
+/** Quick lookup by id */
+export const SHORTCUT_MAP = new Map(SHORTCUT_DEFINITIONS.map((d) => [d.id, d]));
+
+/** Get shortcuts for a specific scope */
+export function getShortcutsByScope(scope: ShortcutScope): ShortcutDefinition[] {
+  return SHORTCUT_DEFINITIONS.filter((d) => d.scope === scope);
+}
+
+/** Scope labels for display */
+export const SCOPE_LABELS: Record<ShortcutScope, string> = {
+  global: 'Global',
+  listen: 'Listen Mode',
+  speak: 'Speak Mode',
+  read: 'Read Mode',
+  write: 'Write Mode',
+};
+
+export function getActiveShortcutScopes(pathname: string): ShortcutScope[] {
+  const scopes: ShortcutScope[] = ['global'];
+
+  if (/^\/listen\/[^/]+$/.test(pathname)) scopes.push('listen');
+  if (/^\/speak\/[^/]+$/.test(pathname)) scopes.push('speak');
+  if (/^\/read\/[^/]+$/.test(pathname)) scopes.push('read');
+  if (/^\/write\/[^/]+$/.test(pathname)) scopes.push('write');
+
+  return scopes;
+}
+
+export function getScopeAvailabilityDescription(scope: ShortcutScope): string {
+  switch (scope) {
+    case 'global':
+      return 'Available on every app page, including search.';
+    case 'listen':
+      return 'Available only while viewing a specific Listen practice page.';
+    case 'speak':
+      return 'Available only while viewing a specific Speak practice page.';
+    case 'read':
+      return 'Available only while viewing a specific Read practice page.';
+    case 'write':
+      return 'Available only while viewing a specific Write practice page.';
+  }
+}

--- a/src/lib/shortcut-utils.test.ts
+++ b/src/lib/shortcut-utils.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { getNormalizedShortcutKey } from './shortcut-utils';
+
+describe('shortcut-utils', () => {
+  it('normalizes option-modified letter keys using event.code', () => {
+    expect(
+      getNormalizedShortcutKey({
+        code: 'KeyS',
+        key: 'ß',
+      } as Pick<KeyboardEvent, 'code' | 'key'>),
+    ).toBe('s');
+  });
+
+  it('normalizes number row keys using event.code', () => {
+    expect(
+      getNormalizedShortcutKey({
+        code: 'Digit1',
+        key: '1',
+      } as Pick<KeyboardEvent, 'code' | 'key'>),
+    ).toBe('1');
+  });
+
+  it('falls back to mapped special keys', () => {
+    expect(
+      getNormalizedShortcutKey({
+        code: 'ArrowLeft',
+        key: 'ArrowLeft',
+      } as Pick<KeyboardEvent, 'code' | 'key'>),
+    ).toBe('arrowleft');
+  });
+});

--- a/src/lib/shortcut-utils.ts
+++ b/src/lib/shortcut-utils.ts
@@ -1,0 +1,78 @@
+import { isMac } from '@/lib/utils';
+
+const KEY_CODE_MAP: Record<string, string> = {
+  ArrowLeft: 'arrowleft',
+  ArrowRight: 'arrowright',
+  ArrowUp: 'arrowup',
+  ArrowDown: 'arrowdown',
+  Backquote: '`',
+  Backslash: '\\',
+  Backspace: 'backspace',
+  BracketLeft: '[',
+  BracketRight: ']',
+  Comma: ',',
+  Enter: 'enter',
+  Equal: '=',
+  Escape: 'escape',
+  Minus: '-',
+  Period: '.',
+  Quote: "'",
+  Semicolon: ';',
+  Slash: '/',
+  Space: 'space',
+  Tab: 'tab',
+};
+
+const KEY_VALUE_MAP: Record<string, string> = {
+  ' ': 'space',
+  arrowleft: 'arrowleft',
+  arrowright: 'arrowright',
+  arrowup: 'arrowup',
+  arrowdown: 'arrowdown',
+  backspace: 'backspace',
+  enter: 'enter',
+  escape: 'escape',
+  tab: 'tab',
+};
+
+export function parseShortcutCombo(combo: string) {
+  const parts = combo.toLowerCase().split('+');
+  const key = parts.pop() ?? '';
+  return {
+    mod: parts.includes('mod'),
+    shift: parts.includes('shift'),
+    alt: parts.includes('alt'),
+    key,
+  };
+}
+
+export function getNormalizedShortcutKey(event: Pick<KeyboardEvent, 'code' | 'key'>): string {
+  if (/^Key[A-Z]$/.test(event.code)) {
+    return event.code.slice(3).toLowerCase();
+  }
+
+  if (/^Digit[0-9]$/.test(event.code)) {
+    return event.code.slice(5);
+  }
+
+  if (KEY_CODE_MAP[event.code]) {
+    return KEY_CODE_MAP[event.code];
+  }
+
+  const eventKey = event.key.toLowerCase();
+  return KEY_VALUE_MAP[eventKey] ?? eventKey;
+}
+
+export function matchesShortcutEvent(
+  event: Pick<KeyboardEvent, 'altKey' | 'code' | 'ctrlKey' | 'key' | 'metaKey' | 'shiftKey'>,
+  combo: string,
+): boolean {
+  const parsed = parseShortcutCombo(combo);
+  const modPressed = isMac() ? event.metaKey : event.ctrlKey;
+
+  if (parsed.mod !== modPressed) return false;
+  if (parsed.shift !== event.shiftKey) return false;
+  if (parsed.alt !== event.altKey) return false;
+
+  return getNormalizedShortcutKey(event) === parsed.key;
+}

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { isMac, normalizeTags } from './utils';
+
+describe('utils', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('detects mac platforms at runtime', () => {
+    vi.stubGlobal('navigator', {
+      platform: 'MacIntel',
+      userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)',
+      userAgentData: { platform: 'macOS' },
+    });
+
+    expect(isMac()).toBe(true);
+  });
+
+  it('does not mark non-apple platforms as mac', () => {
+    vi.stubGlobal('navigator', {
+      platform: 'Win32',
+      userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)',
+      userAgentData: { platform: 'Windows' },
+    });
+
+    expect(isMac()).toBe(false);
+  });
+
+  it('normalizes and deduplicates tags', () => {
+    expect(normalizeTags('Business, daily, business , Travel')).toEqual([
+      'business',
+      'daily',
+      'travel',
+    ]);
+  });
+});

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -5,6 +5,18 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
+/** Detect Apple platforms at runtime to avoid server-side evaluation locking the wrong result. */
+export function isMac() {
+  if (typeof navigator === 'undefined') return false;
+
+  const platform =
+    (navigator as Navigator & { userAgentData?: { platform: string } }).userAgentData?.platform ??
+    navigator.platform ??
+    navigator.userAgent;
+
+  return /Mac|iPod|iPhone|iPad/.test(platform) || /Macintosh/.test(navigator.userAgent);
+}
+
 export function normalizeTags(input: string): string[] {
   return [
     ...new Set(

--- a/src/stores/shortcut-store.test.ts
+++ b/src/stores/shortcut-store.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const storage = new Map<string, string>();
+
+const localStorageMock: Storage = {
+  getItem: (key: string) => storage.get(key) ?? null,
+  setItem: (key: string, value: string) => {
+    storage.set(key, value);
+  },
+  removeItem: (key: string) => {
+    storage.delete(key);
+  },
+  clear: () => storage.clear(),
+  get length() {
+    return storage.size;
+  },
+  key: (index: number) => [...storage.keys()][index] ?? null,
+};
+
+vi.stubGlobal('localStorage', localStorageMock);
+vi.stubGlobal('window', globalThis);
+
+const { useShortcutStore } = await import('./shortcut-store');
+
+describe('shortcut-store', () => {
+  beforeEach(() => {
+    storage.clear();
+    useShortcutStore.setState({ overrides: {}, isPaused: false });
+  });
+
+  it('falls back to default shortcuts when no override exists', () => {
+    expect(useShortcutStore.getState().getKey('global:open-settings')).toBe('mod+,');
+    expect(useShortcutStore.getState().getKey('global:stop-tts')).toBe('mod+.');
+    expect(useShortcutStore.getState().getKey('listen:speed-up')).toBe('arrowright');
+    expect(useShortcutStore.getState().getKey('write:reset')).toBe('mod+alt+r');
+  });
+
+  it('persists overrides to localStorage', () => {
+    useShortcutStore.getState().setOverride('global:toggle-chat', 'mod+shift+j');
+
+    expect(useShortcutStore.getState().getKey('global:toggle-chat')).toBe('mod+shift+j');
+    expect(JSON.parse(storage.get('echotype_shortcut_overrides') ?? '{}')).toEqual({
+      overrides: {
+        'global:toggle-chat': 'mod+shift+j',
+      },
+    });
+  });
+
+  it('hydrates saved overrides from localStorage', () => {
+    storage.set(
+      'echotype_shortcut_overrides',
+      JSON.stringify({
+        overrides: {
+          'listen:toggle-translation': 'shift+t',
+        },
+      }),
+    );
+
+    useShortcutStore.getState().hydrate();
+
+    expect(useShortcutStore.getState().getKey('listen:toggle-translation')).toBe('shift+t');
+  });
+
+  it('tracks paused state separately from persisted overrides', () => {
+    const store = useShortcutStore.getState();
+
+    store.setOverride('global:nav-listen', 'mod+l');
+    store.setPaused(true);
+
+    expect(useShortcutStore.getState().isPaused).toBe(true);
+    expect(JSON.parse(storage.get('echotype_shortcut_overrides') ?? '{}')).toEqual({
+      overrides: {
+        'global:nav-listen': 'mod+l',
+      },
+    });
+  });
+});

--- a/src/stores/shortcut-store.ts
+++ b/src/stores/shortcut-store.ts
@@ -1,0 +1,84 @@
+import { create } from 'zustand';
+
+import { SHORTCUT_MAP } from '@/lib/shortcut-definitions';
+
+const STORAGE_KEY = 'echotype_shortcut_overrides';
+
+export interface ShortcutOverrides {
+  /** Map of shortcut id → custom key combo (e.g. "mod+k" → "mod+p") */
+  overrides: Record<string, string>;
+}
+
+interface ShortcutStore extends ShortcutOverrides {
+  /** Temporarily suspend shortcut handling while a modal/capture UI is open */
+  isPaused: boolean;
+  /** Get the effective key for a shortcut (override or default) */
+  getKey: (id: string) => string;
+  /** Set a custom binding for a shortcut */
+  setOverride: (id: string, key: string) => void;
+  /** Remove a custom binding, reverting to default */
+  clearOverride: (id: string) => void;
+  /** Reset all overrides */
+  resetAll: () => void;
+  setPaused: (paused: boolean) => void;
+  hydrate: () => void;
+}
+
+function loadFromStorage(): Partial<ShortcutOverrides> {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) return JSON.parse(raw);
+  } catch {
+    /* ignore */
+  }
+  return {};
+}
+
+function saveToStorage(overrides: Record<string, string>) {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ overrides }));
+  } catch {
+    /* ignore */
+  }
+}
+
+export const useShortcutStore = create<ShortcutStore>((set, get) => ({
+  overrides: {},
+  isPaused: false,
+
+  getKey: (id: string) => {
+    const override = get().overrides[id];
+    if (override) return override;
+    const def = SHORTCUT_MAP.get(id);
+    return def?.defaultKey ?? '';
+  },
+
+  setOverride: (id, key) => {
+    const overrides = { ...get().overrides, [id]: key };
+    set({ overrides });
+    saveToStorage(overrides);
+  },
+
+  clearOverride: (id) => {
+    const overrides = { ...get().overrides };
+    delete overrides[id];
+    set({ overrides });
+    saveToStorage(overrides);
+  },
+
+  resetAll: () => {
+    set({ overrides: {} });
+    saveToStorage({});
+  },
+
+  setPaused: (paused) => set({ isPaused: paused }),
+
+  hydrate: () => {
+    const saved = loadFromStorage();
+    if (saved.overrides) {
+      set({ overrides: saved.overrides });
+    }
+  },
+}));

--- a/src/stores/tts-store.ts
+++ b/src/stores/tts-store.ts
@@ -1,8 +1,9 @@
 import { create } from 'zustand';
+import { DEFAULT_KOKORO_SERVER_URL } from '@/lib/kokoro-shared';
 
 const STORAGE_KEY = 'echotype_tts_settings';
 
-export type TTSSource = 'browser' | 'fish';
+export type TTSSource = 'browser' | 'fish' | 'kokoro';
 
 export interface TTSSettings {
   voiceSource: TTSSource;
@@ -14,6 +15,10 @@ export interface TTSSettings {
   fishVoiceId: string;
   fishVoiceName: string;
   fishModel: string;
+  kokoroServerUrl: string;
+  kokoroApiKey: string;
+  kokoroVoiceId: string;
+  kokoroVoiceName: string;
   targetLang: string;
   showTranslation: boolean;
   recommendationsEnabled: boolean;
@@ -33,6 +38,9 @@ interface TTSStore extends TTSSettings {
   setFishApiKey: (key: string) => void;
   setFishVoice: (voiceId: string, voiceName?: string) => void;
   setFishModel: (model: string) => void;
+  setKokoroServerUrl: (url: string) => void;
+  setKokoroApiKey: (key: string) => void;
+  setKokoroVoice: (voiceId: string, voiceName?: string) => void;
   setTargetLang: (lang: string) => void;
   setShowTranslation: (show: boolean) => void;
   toggleTranslation: () => void;
@@ -75,6 +83,10 @@ const defaults: TTSSettings = {
   fishVoiceId: '',
   fishVoiceName: '',
   fishModel: 's2-pro',
+  kokoroServerUrl: DEFAULT_KOKORO_SERVER_URL,
+  kokoroApiKey: '',
+  kokoroVoiceId: 'af_heart',
+  kokoroVoiceName: 'Heart',
   targetLang: 'zh-CN',
   showTranslation: true,
   recommendationsEnabled: true,
@@ -128,6 +140,21 @@ export const useTTSStore = create<TTSStore>((set, get) => ({
     saveToStorage({ ...get(), fishModel });
   },
 
+  setKokoroServerUrl: (kokoroServerUrl) => {
+    set({ kokoroServerUrl });
+    saveToStorage({ ...get(), kokoroServerUrl });
+  },
+
+  setKokoroApiKey: (kokoroApiKey) => {
+    set({ kokoroApiKey });
+    saveToStorage({ ...get(), kokoroApiKey });
+  },
+
+  setKokoroVoice: (kokoroVoiceId, kokoroVoiceName = '') => {
+    set({ kokoroVoiceId, kokoroVoiceName });
+    saveToStorage({ ...get(), kokoroVoiceId, kokoroVoiceName });
+  },
+
   setTargetLang: (targetLang) => {
     set({ targetLang });
     saveToStorage({ ...get(), targetLang });
@@ -177,6 +204,10 @@ export const useTTSStore = create<TTSStore>((set, get) => ({
   hydrate: () => {
     const saved = loadFromStorage();
     if (Object.keys(saved).length > 0) {
+      // Don't overwrite the default Kokoro server URL with an empty string
+      if ('kokoroServerUrl' in saved && !saved.kokoroServerUrl?.trim()) {
+        delete saved.kokoroServerUrl;
+      }
       set(saved);
     }
   },


### PR DESCRIPTION
## Summary
- add a configurable keyboard shortcut system with global and page-scoped bindings
- add command palette and shortcut settings UI with platform-aware search shortcut messaging
- add Kokoro TTS proxy routes, listen-mode highlighting updates, and supporting tests/docs

## Verification
- pre-commit ran biome check --write --no-errors-on-unmatched
- pre-commit ran tsc --noEmit
- manually verified shortcut settings modal interactions in the browser
- pnpm vitest run src/lib/shortcut-definitions.test.ts src/lib/shortcut-utils.test.ts
