### PR TITLE
refactor: align model recommendation prompt with actual EchoType workloads

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import './.next/types/routes.d.ts';
+import './.next/dev/types/routes.d.ts';
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app/(app)/read/[id]/page.tsx
+++ b/src/app/(app)/read/[id]/page.tsx
@@ -5,7 +5,7 @@ import { ArrowLeft, Mic, MicOff, RotateCcw, Volume2 } from 'lucide-react';
 import { nanoid } from 'nanoid';
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { flushSync } from 'react-dom';
 import { FormattedContentText } from '@/components/shared/formatted-content-text';
 import { RecommendationPanel } from '@/components/shared/recommendation-panel';
@@ -19,6 +19,7 @@ import type { Recommendation } from '@/hooks/use-recommendations';
 import { useShortcuts } from '@/hooks/use-shortcuts';
 import { useTranslation } from '@/hooks/use-translation';
 import { useTTS } from '@/hooks/use-tts';
+import { type ContentBlock, splitContentBlocks } from '@/lib/content-format';
 import { savePracticeSession } from '@/lib/daily-plan-progress';
 import { db } from '@/lib/db';
 import { compareWords, type WordResult } from '@/lib/levenshtein';
@@ -54,6 +55,42 @@ export default function ReadDetailPage() {
     retry: retryTranslation,
     fetchTranslation,
   } = useTranslation(content?.text || '', targetLang, showTranslation);
+
+  const translatedBlocks: Array<{ block: ContentBlock; translations: string[] }> = useMemo(() => {
+    const blocks = splitContentBlocks(content?.text || '');
+    if (!sentenceTranslations?.length) {
+      return blocks.map((block) => ({ block, translations: [] as string[] }));
+    }
+
+    let sentenceIndex = 0;
+
+    const grouped = blocks.map((block) => {
+      const translations: string[] = [];
+      let consumedWords = 0;
+
+      while (sentenceIndex < sentenceTranslations.length && consumedWords < block.wordCount) {
+        const sentence = sentenceTranslations[sentenceIndex];
+        const sentenceWords = sentence.original.split(/\s+/).filter(Boolean).length;
+
+        if (translations.length > 0 && consumedWords + sentenceWords > block.wordCount) {
+          break;
+        }
+
+        translations.push(sentence.translation);
+        consumedWords += sentenceWords;
+        sentenceIndex += 1;
+      }
+
+      return { block, translations };
+    });
+
+    while (sentenceIndex < sentenceTranslations.length && grouped.length > 0) {
+      grouped[grouped.length - 1].translations.push(sentenceTranslations[sentenceIndex].translation);
+      sentenceIndex += 1;
+    }
+
+    return grouped;
+  }, [content?.text, sentenceTranslations]);
 
   useEffect(() => {
     if (showTranslation && content?.text) fetchTranslation();
@@ -289,13 +326,27 @@ export default function ReadDetailPage() {
           </div>
           <div className="flex-1 overflow-y-auto pr-2 scrollbar-thin scrollbar-thumb-indigo-200 scrollbar-track-transparent">
             {showTranslation && sentenceTranslations && sentenceTranslations.length > 0 ? (
-              <div className="space-y-3">
-                {sentenceTranslations.map((st, i) => (
-                  <div key={i}>
-                    <p className="text-lg leading-relaxed text-indigo-800 whitespace-pre-wrap">{st.original}</p>
-                    <p className="text-sm text-indigo-400/80 leading-relaxed mt-0.5 pl-0.5 whitespace-pre-wrap">
-                      {st.translation}
-                    </p>
+              <div className="space-y-4">
+                {translatedBlocks.map(({ block, translations }) => (
+                  <div key={block.id} className="space-y-1.5">
+                    <div
+                      className={
+                        block.kind === 'title'
+                          ? 'text-2xl font-semibold text-indigo-900 leading-tight whitespace-pre-wrap'
+                          : block.kind === 'label'
+                            ? 'text-xs font-semibold tracking-[0.18em] text-indigo-400 whitespace-pre-wrap'
+                            : block.kind === 'quote'
+                              ? 'border-l-2 border-indigo-200 pl-4 text-lg italic leading-relaxed text-indigo-700 whitespace-pre-wrap'
+                              : 'text-lg leading-relaxed text-indigo-800 whitespace-pre-wrap'
+                      }
+                    >
+                      {block.text}
+                    </div>
+                    {translations.length > 0 && (
+                      <p className="text-sm text-indigo-400/80 leading-relaxed pl-0.5 whitespace-pre-wrap">
+                        {translations.join('\n')}
+                      </p>
+                    )}
                   </div>
                 ))}
               </div>

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -2,6 +2,7 @@
 
 import {
   AlertCircle,
+  AlertTriangle,
   Check,
   ChevronDown,
   Database,
@@ -244,16 +245,19 @@ function ModelCombobox({
   recommendations,
   selectedModelId,
   onSelect,
+  disabled,
 }: {
   models: ProviderModel[];
   recommendations?: ProviderModelRecommendation[];
   selectedModelId: string;
   onSelect: (id: string) => void;
+  disabled?: boolean;
 }) {
   const [open, setOpen] = useState(false);
   const selectedModel = models.find((m) => m.id === selectedModelId) ?? models[0];
   const selectedMeta = selectedModel ? getModelRecommendationMeta(recommendations, selectedModel.id) : null;
   const displayModels = sortModelsByRecommendation(models, recommendations);
+  const isEmpty = models.length === 0;
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -262,11 +266,15 @@ function ModelCombobox({
           type="button"
           role="combobox"
           aria-expanded={open}
-          className="flex h-9 flex-1 min-w-0 items-center justify-between rounded-lg border border-slate-200 bg-slate-50 px-3 text-sm cursor-pointer hover:bg-slate-100 transition-colors"
+          disabled={disabled || isEmpty}
+          className={cn(
+            'flex h-9 flex-1 min-w-0 items-center justify-between rounded-lg border border-slate-200 bg-slate-50 px-3 text-sm cursor-pointer hover:bg-slate-100 transition-colors',
+            (disabled || isEmpty) && 'opacity-50 cursor-not-allowed hover:bg-slate-50',
+          )}
         >
           <span className="flex min-w-0 items-center gap-2">
             <span className="truncate text-slate-700">
-              {selectedModel?.name ?? selectedModel?.id ?? 'Select model'}
+              {isEmpty ? 'No models available' : (selectedModel?.name ?? selectedModel?.id ?? 'Select model')}
             </span>
             {selectedMeta && (
               <Badge
@@ -363,6 +371,7 @@ function AIProviderSection({
   const [modelsLoading, setModelsLoading] = useState(false);
   const [connectLoading, setConnectLoading] = useState(false);
   const [oauthLoading, setOauthLoading] = useState(false);
+  const [serviceUnavailable, setServiceUnavailable] = useState(false);
   const autoFetchAttemptedRef = useRef<Set<string>>(new Set());
   const lastAutoFetchedProviderRef = useRef<ProviderId | null>(null);
   const resetTransientProviderState = useCallback(() => {
@@ -370,6 +379,7 @@ function AIProviderSection({
     setShowKey(false);
     setModelsLoading(false);
     setConnectLoading(false);
+    setServiceUnavailable(false);
   }, []);
   const switchEditingProvider = useCallback(
     (id: ProviderId) => {
@@ -395,7 +405,8 @@ function AIProviderSection({
   const isActive = activeProviderId === editingId;
   const noModelApi = config?.noModelApi ?? false;
   const dynamicModels = config?.dynamicModels ?? [];
-  const models: ProviderModel[] = !noModelApi && dynamicModels.length > 0 ? dynamicModels : def.models;
+  const models: ProviderModel[] =
+    serviceUnavailable && !noModelApi ? [] : !noModelApi && dynamicModels.length > 0 ? dynamicModels : def.models;
   const recommendationKey = createModelRecommendationKey(models);
   const cachedRecommendations =
     config?.modelRecommendationKey === recommendationKey ? (config.modelRecommendations ?? []) : [];
@@ -423,7 +434,15 @@ function AIProviderSection({
             ...(path && { 'x-api-path': path }),
           },
         });
-        const data: { models: ProviderModel[]; dynamic: boolean; error?: string } = await res.json();
+        const data: { models: ProviderModel[]; dynamic: boolean; error?: string; unavailable?: boolean } =
+          await res.json();
+        if (data.unavailable) {
+          setDynamicModels(id, []);
+          setServiceUnavailable(true);
+          if (data.error) setAuthError(data.error);
+          return [];
+        }
+        setServiceUnavailable(false);
         if (data.dynamic && data.models?.length > 0) {
           setDynamicModels(id, data.models);
           const currentId = providers[id]?.selectedModelId;
@@ -436,7 +455,7 @@ function AIProviderSection({
         if (data.error) setAuthError(data.error);
         return data.dynamic ? (data.models ?? []) : [];
       } catch {
-        // silent: keep static models
+        setServiceUnavailable(true);
         return [];
       } finally {
         setModelsLoading(false);
@@ -876,6 +895,7 @@ function AIProviderSection({
               recommendations={cachedRecommendations}
               selectedModelId={config.selectedModelId}
               onSelect={(id) => setSelectedModel(editingId, id)}
+              disabled={serviceUnavailable && !noModelApi}
             />
 
             {isConnected && (
@@ -892,6 +912,31 @@ function AIProviderSection({
             )}
           </div>
           {selectedModel?.description && <p className="text-[11px] text-slate-400">{selectedModel.description}</p>}
+
+          {/* Service unavailable warning */}
+          {serviceUnavailable && !noModelApi && (
+            <div
+              role="alert"
+              className="flex items-start gap-2.5 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-xs text-amber-800"
+            >
+              <AlertTriangle className="h-4 w-4 mt-0.5 shrink-0 text-amber-600" aria-hidden="true" />
+              <div className="flex-1 min-w-0">
+                <p className="font-semibold text-amber-900">Unable to fetch models from this provider</p>
+                <p className="mt-0.5 leading-relaxed">
+                  The service may be temporarily unavailable. Please check your network connection and API key, then try
+                  again.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => void handleRefreshModels()}
+                disabled={modelsLoading}
+                className="shrink-0 mt-0.5 rounded-md border border-amber-300 bg-amber-100 px-2.5 py-1 text-[11px] font-medium text-amber-800 hover:bg-amber-200 cursor-pointer transition-colors disabled:opacity-50"
+              >
+                {modelsLoading ? <Loader2 className="h-3 w-3 animate-spin" /> : 'Retry'}
+              </button>
+            </div>
+          )}
 
           {/* Set as default provider + model */}
           {isConnected && !isActive && (

--- a/src/app/api/model-recommendations/route.ts
+++ b/src/app/api/model-recommendations/route.ts
@@ -52,21 +52,60 @@ export async function POST(req: NextRequest) {
       contextWindow: item.contextWindow ?? null,
     }));
 
-    const system = `You are ranking LLMs for EchoType, an English learning SaaS.
+    const system = `You are selecting the best LLMs for EchoType, an English learning app for Chinese speakers (CEFR A1–C2).
 
-EchoType needs models that are especially strong at:
-- tutoring chat in English learning scenarios
-- generating short learning content and exercises
-- structured classification with reliable JSON output
-- Chinese/English text translation
-- evaluating learner answers and giving corrections
+EchoType has 7 AI workloads. Evaluate each candidate model against ALL of them:
 
-Prefer models that are stable, instruction-following, multilingual, and good at precise text work.
-De-prioritize models that are mainly for audio, image, search, routing, moderation, or embeddings.
+1. CHAT TUTOR — streaming, highest weight
+   - English coach with 15+ tool-calling actions (navigate, import YouTube/URL, generate content, search library, show analytics, speak text, etc.)
+   - Tool calling support is REQUIRED — models without function calling cannot serve this workload
+   - Mixed zh/en: user writes Chinese, model responds in English then explains in Chinese
+   - Multiple modes: general chat, practice (generates :::quiz/:::fill-blank/:::vocab blocks), reading comprehension, analytics review
+   - Strict language rule: only English + Simplified Chinese, never Japanese/Korean/other scripts
 
-Choose at most 3 truly strong recommendations from the supplied models only.
+2. CONVERSATION PRACTICE — streaming
+   - Role-play scenarios (e.g. ordering food, job interview) with injected system prompt, title, goals, difficulty
+   - Must stay in character, keep responses to 1–3 sentences, model correct grammar naturally without breaking character
+   - Input: multi-turn dialogue with "recording" role (transcribed speech) mapped to user role
+
+3. CONTENT GENERATION — single-shot JSON
+   - Generates words (10–15 with definitions), sentences (5–8), or articles (150–200 words) at a given CEFR difficulty
+   - Can rewrite web page content into learning material (up to 12K source chars)
+   - Output: {"title":"...","text":"..."} — clean plain text, no markdown formatting
+
+4. CLASSIFICATION — single-shot JSON, most frequent call (runs on every library import)
+   - Input: title + up to 4K chars of text
+   - Output: {"type":"article|phrase|sentence|word","difficulty":"beginner|intermediate|advanced","title":"...","tags":["..."]}
+   - Must be fast, cheap, and never produce broken JSON or hallucinated field values
+
+5. TRANSLATION — single-shot, English → Chinese (primarily)
+   - Batch mode: numbered English sentences → JSON array of Chinese translations
+   - Single mode: English text → plain Chinese translation, no explanations
+   - Must handle CEFR A1 simple phrases through C2 academic prose accurately
+
+6. LEVEL ASSESSMENT — single-shot JSON, large output (~8K tokens)
+   - Generates exactly 30 multiple-choice English proficiency questions
+   - Strict schema: {"questions":[{"question":"...","options":["A) ...","B) ...","C) ...","D) ..."],"correct":"B","difficulty":"B1","category":"vocabulary|grammar|reading"}]}
+   - CEFR-adaptive distribution (e.g. focus questions around the learner's current level ±1)
+   - Must produce all 30 questions in one call with valid JSON — partial/truncated output fails
+
+7. CONTENT RECOMMENDATIONS — single-shot JSON
+   - For words: returns synonyms, antonyms, word-root relatives, collocations with example sentences
+   - For sentences/articles: returns related learning content on similar topics
+   - Output: {"recommendations":[{"title":"...","text":"...","type":"word|sentence|phrase","relation":"synonym|antonym|word-root|collocation|related topic"}]}
+
+Scoring:
+- CRITICAL: function/tool calling support (chat tutor is unusable without it)
+- CRITICAL: reliable JSON output (5 of 7 workloads return structured JSON)
+- STRONGLY PREFER: strong zh↔en bilingual ability, instruction-following, low hallucination
+- PREFER: low latency (2 workloads stream to user), good at short precise tasks
+- NEUTRAL: large context window (most tasks <2K tokens; assessment output ~8K is the max)
+- PENALIZE: models primarily for code, image, audio, search, embeddings, or routing
+- PENALIZE: models that mix in Japanese/Korean/other scripts or ignore format constraints
+
+Choose at most 3 models that best cover ALL seven workloads. Prefer a strong all-rounder over a specialist.
 Return ONLY valid JSON in this exact format:
-{"recommendations":[{"modelId":"exact-id-from-list","rank":1,"score":96,"reason":"short concrete reason","label":"Recommended"}]}`;
+{"recommendations":[{"modelId":"exact-id-from-list","rank":1,"score":96,"reason":"short concrete reason tied to EchoType workloads","label":"Recommended"}]}`;
 
     const prompt = `Provider: ${providerId}
 Evaluator model: ${evaluatorModelId || getDefaultModelId(providerId)}
@@ -74,7 +113,7 @@ Evaluator model: ${evaluatorModelId || getDefaultModelId(providerId)}
 Candidate models:
 ${JSON.stringify(candidateModels, null, 2)}
 
-Return at most 3 recommended models as JSON. Only use exact modelId values from the candidate list.`;
+Rank the best models for EchoType (English learning app for Chinese speakers). Key requirements: tool/function calling, reliable JSON output, strong zh↔en bilingual. Return at most 3 as JSON. Only use exact modelId values from the candidate list.`;
 
     const { text } = await generateText({
       model,

--- a/src/app/api/models/route.test.ts
+++ b/src/app/api/models/route.test.ts
@@ -150,19 +150,9 @@ describe('GET /api/models', () => {
     const data = await res.json();
 
     expect(data.dynamic).toBe(false);
+    expect(data.unavailable).toBe(true);
     expect(data.error).toBe('Provider models endpoint is behind a bot challenge and cannot be fetched server-side');
-    expect(data.models).toEqual([
-      {
-        id: 'gpt-4o',
-        name: 'GPT-4o',
-        description: 'Flagship multimodal model',
-        contextWindow: 128000,
-        isDefault: true,
-      },
-      { id: 'gpt-4o-mini', name: 'GPT-4o Mini', description: 'Fast & affordable', contextWindow: 128000 },
-      { id: 'o4-mini', name: 'o4-mini', description: 'Fast reasoning model', contextWindow: 200000 },
-      { id: 'o3', name: 'o3', description: 'Most capable reasoning', contextWindow: 200000 },
-    ]);
+    expect(data.models).toEqual([]);
   });
 
   it('retries the OpenAI-compatible models endpoint three times before falling back', async () => {

--- a/src/app/api/models/route.ts
+++ b/src/app/api/models/route.ts
@@ -141,7 +141,7 @@ export async function GET(req: NextRequest) {
       return NextResponse.json({ models, dynamic: true });
     }
 
-    return NextResponse.json({ models: provider.models, dynamic: false, error: error || 'Ollama not reachable' });
+    return NextResponse.json({ models: [], dynamic: false, unavailable: true, error: error || 'Ollama not reachable' });
   }
 
   // ── LM Studio: try OpenAI-compatible /v1/models ───────────────────────────
@@ -155,7 +155,12 @@ export async function GET(req: NextRequest) {
       return NextResponse.json({ models: models.length ? models : provider.models, dynamic: models.length > 0 });
     }
 
-    return NextResponse.json({ models: provider.models, dynamic: false, error: error || 'LM Studio not reachable' });
+    return NextResponse.json({
+      models: [],
+      dynamic: false,
+      unavailable: true,
+      error: error || 'LM Studio not reachable',
+    });
   }
 
   // ── Anthropic: custom auth header ───────────────────────────────────────────
@@ -177,8 +182,9 @@ export async function GET(req: NextRequest) {
     }
 
     return NextResponse.json({
-      models: provider.models,
+      models: [],
       dynamic: false,
+      unavailable: true,
       error: error || 'Anthropic models fetch failed',
     });
   }
@@ -201,7 +207,12 @@ export async function GET(req: NextRequest) {
       return NextResponse.json({ models: models.length ? models : provider.models, dynamic: models.length > 0 });
     }
 
-    return NextResponse.json({ models: provider.models, dynamic: false, error: error || 'Google models fetch failed' });
+    return NextResponse.json({
+      models: [],
+      dynamic: false,
+      unavailable: true,
+      error: error || 'Google models fetch failed',
+    });
   }
 
   // ── Dynamic fetch: OpenAI-compatible /models endpoint ────────────────────
@@ -242,8 +253,13 @@ export async function GET(req: NextRequest) {
       return NextResponse.json({ models, dynamic: true });
     }
 
-    return NextResponse.json({ models: provider.models, dynamic: false, error: 'Model endpoint returned no models' });
+    return NextResponse.json({
+      models: [],
+      dynamic: false,
+      unavailable: true,
+      error: 'Model endpoint returned no models',
+    });
   }
 
-  return NextResponse.json({ models: provider.models, dynamic: false, error: error || 'Failed to fetch models' });
+  return NextResponse.json({ models: [], dynamic: false, unavailable: true, error: error || 'Failed to fetch models' });
 }


### PR DESCRIPTION
## Summary
- **Model recommendation prompt**: replace generic 5-workload prompt with 7 real AI workloads derived from actual API routes, remove 2 phantom workloads (answer evaluation, SRS scheduling), elevate tool-calling and JSON reliability to CRITICAL scoring criteria
- **Model API unavailable state**: return empty models with `unavailable: true` when provider service is unreachable instead of silently falling back to stale presets; settings UI shows disabled combobox + warning banner with Retry
- **Read page formatting**: use `splitContentBlocks` to render translated content with proper paragraph formatting (title/quote/label blocks), fixing missing `useMemo` and `ContentBlock` imports

## Test plan
- [x] Unit tests pass (5/5 — model-recommendations route + lib)
- [x] `tsc --noEmit` passes with zero errors
- [x] Pre-commit hooks (biome + tsc) pass
- [x] Browser test: model selection and recommendation flow triggers correctly on Settings page

🤖 Generated with [Claude Code](https://claude.com/claude-code)