### PR TITLE
ci: use ubuntu-22.04 runner for Linux builds

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -41,7 +41,7 @@ jobs:
           - os: macos-latest
             name: macOS
             bundles: app,dmg
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             name: Linux
             bundles: deb,appimage
           - os: windows-latest


### PR DESCRIPTION
## Summary
- Switch Linux build runner from `ubuntu-latest` (24.04) to `ubuntu-22.04` in release workflow
- Ensures deb and AppImage packages are compatible with Ubuntu 22.04+ (glibc 2.35)
- All three platforms (Linux, macOS, Windows) verified passing via workflow_dispatch run

## Test plan
- [x] Triggered `Release Desktop` workflow on this branch — all 3 builds passed
- [x] Run link: https://github.com/Talljack/echo-type/actions/runs/23354811601

🤖 Generated with [Claude Code](https://claude.com/claude-code)