### PR TITLE
feat: polish sidebar, settings, tray icon and provider UX

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "echotype",
-  "version": "0.1.0",
+  "version": "1.1.0",
   "private": true,
   "scripts": {
     "preinstall": "npx only-allow pnpm",

--- a/scripts/generate-latest-json.mjs
+++ b/scripts/generate-latest-json.mjs
@@ -9,9 +9,9 @@
  */
 
 import { execSync } from 'node:child_process';
-import { writeFileSync, readFileSync, mkdtempSync, rmSync } from 'node:fs';
-import { join } from 'node:path';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 const REPO = 'Talljack/echo-type';
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -868,7 +868,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "echotype"
-version = "0.1.0"
+version = "1.1.0"
 dependencies = [
  "portpicker",
  "reqwest 0.12.28",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echotype"
-version = "0.1.0"
+version = "1.1.0"
 description = "EchoType - Learn English by Listening, Speaking, Reading & Writing"
 authors = ["EchoType"]
 edition = "2021"

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -13,9 +13,13 @@ const QUIT_ID: &str = "quit";
 pub fn setup_tray(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
     let show_hide = MenuItemBuilder::with_id(SHOW_HIDE_ID, "Hide Window").build(app)?;
     let dashboard = MenuItemBuilder::with_id(DASHBOARD_ID, "Dashboard").build(app)?;
-    let settings = MenuItemBuilder::with_id(SETTINGS_ID, "Settings").build(app)?;
+    let settings = MenuItemBuilder::with_id(SETTINGS_ID, "Settings")
+        .accelerator("CmdOrCtrl+,")
+        .build(app)?;
     let separator = PredefinedMenuItem::separator(app)?;
-    let quit = MenuItemBuilder::with_id(QUIT_ID, "Quit").build(app)?;
+    let quit = MenuItemBuilder::with_id(QUIT_ID, "Quit")
+        .accelerator("CmdOrCtrl+Q")
+        .build(app)?;
 
     let menu = MenuBuilder::new(app)
         .item(&show_hide)
@@ -29,11 +33,14 @@ pub fn setup_tray(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
         .or_else(|_| app.default_window_icon().cloned().ok_or("no default icon"))
         .map_err(|e| format!("Failed to load tray icon: {e}"))?;
 
+    let show_hide_for_tray = show_hide.clone();
+    let show_hide_for_menu = show_hide.clone();
+
     TrayIconBuilder::new()
         .icon(icon)
         .tooltip("EchoType")
         .menu(&menu)
-        .on_tray_icon_event(|tray_icon, event| {
+        .on_tray_icon_event(move |tray_icon, event| {
             if let tauri::tray::TrayIconEvent::Click {
                 button: tauri::tray::MouseButton::Left,
                 button_state: tauri::tray::MouseButtonState::Up,
@@ -44,21 +51,25 @@ pub fn setup_tray(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
                 if let Some(window) = app.get_webview_window("main") {
                     if window.is_visible().unwrap_or(false) {
                         let _ = window.hide();
+                        let _ = show_hide_for_tray.set_text("Show Window");
                     } else {
                         let _ = window.show();
                         let _ = window.set_focus();
+                        let _ = show_hide_for_tray.set_text("Hide Window");
                     }
                 }
             }
         })
-        .on_menu_event(|app, event| match event.id().as_ref() {
+        .on_menu_event(move |app, event| match event.id().as_ref() {
             SHOW_HIDE_ID => {
                 if let Some(window) = app.get_webview_window("main") {
                     if window.is_visible().unwrap_or(false) {
                         let _ = window.hide();
+                        let _ = show_hide_for_menu.set_text("Show Window");
                     } else {
                         let _ = window.show();
                         let _ = window.set_focus();
+                        let _ = show_hide_for_menu.set_text("Hide Window");
                     }
                 }
             }
@@ -66,14 +77,14 @@ pub fn setup_tray(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
                 if let Some(window) = app.get_webview_window("main") {
                     let _ = window.show();
                     let _ = window.set_focus();
-                    let _ = window.eval("window.location.hash = '#/dashboard';");
+                    let _ = window.eval("window.location.pathname = '/dashboard';");
                 }
             }
             SETTINGS_ID => {
                 if let Some(window) = app.get_webview_window("main") {
                     let _ = window.show();
                     let _ = window.set_focus();
-                    let _ = window.eval("window.location.hash = '#/settings';");
+                    let _ = window.eval("window.location.pathname = '/settings';");
                 }
             }
             QUIT_ID => {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicosResworksql/tauri-apps/tauri-v2/packages/tauri-utils/schema.json",
   "productName": "EchoType",
-  "version": "0.1.0",
+  "version": "1.1.0",
   "identifier": "com.echotype.desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",
@@ -23,7 +23,7 @@
       }
     ],
     "trayIcon": {
-      "iconPath": "icons/icon.png",
+      "iconPath": "icons/32x32.png",
       "iconAsTemplate": true,
       "tooltip": "EchoType"
     },

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -11,8 +11,6 @@ import {
   ExternalLink,
   Eye,
   EyeOff,
-  Globe,
-  Info,
   Keyboard,
   KeyRound,
   Languages,
@@ -20,14 +18,10 @@ import {
   LogIn,
   LogOut,
   Mic,
-  Monitor,
-  Moon,
-  Palette,
   RefreshCw,
   Repeat,
   Sparkles,
   Star,
-  Sun,
   Tag,
   User,
   Volume2,
@@ -39,7 +33,11 @@ import { useSearchParams } from 'next/navigation';
 import { type FormEvent, Suspense, useCallback, useEffect, useRef, useState } from 'react';
 import { AssessmentSection } from '@/components/assessment/assessment-section';
 import { OllamaWarningBanner } from '@/components/ollama/ollama-warning-banner';
+import { AboutSection } from '@/components/settings/about-section';
+import { AppearanceSection } from '@/components/settings/appearance-section';
 import { DataBackup } from '@/components/settings/data-backup';
+import { LanguageSection } from '@/components/settings/language-section';
+import { Section } from '@/components/settings/section';
 import { ShortcutSettings } from '@/components/settings/shortcut-settings';
 import { TagManagement } from '@/components/settings/tag-management';
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion';
@@ -67,8 +65,6 @@ import {
 } from '@/lib/providers';
 import { createClient } from '@/lib/supabase/client';
 import { cn } from '@/lib/utils';
-import { type Theme, useAppearanceStore } from '@/stores/appearance-store';
-import { type InterfaceLanguage, useLanguageStore } from '@/stores/language-store';
 import { usePronunciationStore } from '@/stores/pronunciation-store';
 import { useProviderStore } from '@/stores/provider-store';
 import { useSyncStore } from '@/stores/sync-store';
@@ -399,10 +395,16 @@ function AIProviderSection({
   }, []);
   const switchEditingProvider = useCallback(
     (id: ProviderId) => {
+      if (id !== editingId) {
+        const currentConfig = providers[editingId];
+        if (currentConfig?.auth.type !== 'none') {
+          clearAuth(editingId);
+        }
+      }
       resetTransientProviderState();
       setEditingId(id);
     },
-    [resetTransientProviderState],
+    [editingId, providers, clearAuth, resetTransientProviderState],
   );
 
   // Sync editingId when activeProviderId changes (e.g. after hydration)
@@ -678,8 +680,12 @@ function AIProviderSection({
   ]);
 
   const handleRefreshModels = useCallback(async () => {
-    await refreshProviderModelsAndRecommendations(editingId, { forceReevaluate: true });
-  }, [editingId, refreshProviderModelsAndRecommendations]);
+    await refreshProviderModelsAndRecommendations(editingId, {
+      forceReevaluate: true,
+      baseUrlOverride: effectiveBaseUrl,
+      apiPathOverride: effectiveApiPath,
+    });
+  }, [editingId, effectiveBaseUrl, effectiveApiPath, refreshProviderModelsAndRecommendations]);
 
   const handleDisconnect = useCallback(() => {
     clearAuth(editingId);
@@ -1295,28 +1301,6 @@ function Toggle({ value, onChange }: { value: boolean; onChange: (v: boolean) =>
   );
 }
 
-// ─── Section wrapper ───────────────────────────────────────────────────────────
-
-function Section({
-  title,
-  icon: Icon,
-  children,
-}: {
-  title: string;
-  icon: React.ComponentType<{ className?: string }>;
-  children: React.ReactNode;
-}) {
-  return (
-    <div className="bg-white rounded-xl border border-slate-100 shadow-sm overflow-hidden">
-      <div className="flex items-center gap-2 px-5 py-3.5 border-b border-slate-100">
-        <Icon className="w-4 h-4 text-slate-400" />
-        <h2 className="text-sm font-semibold text-slate-800">{title}</h2>
-      </div>
-      <div className="p-5">{children}</div>
-    </div>
-  );
-}
-
 // ─── Main settings content ────────────────────────────────────────────────────
 
 function SettingsContent() {
@@ -1469,6 +1453,12 @@ function SettingsContent() {
 
       {/* English Level Assessment */}
       <AssessmentSection />
+
+      {/* Appearance */}
+      <AppearanceSection />
+
+      {/* Language */}
+      <LanguageSection />
 
       {/* AI Provider */}
       <AIProviderSection
@@ -1976,174 +1966,9 @@ function SettingsContent() {
         <TagManagement />
       </Section>
 
-      {/* Appearance */}
-      <AppearanceSection />
-
-      {/* Language */}
-      <LanguageSection />
-
       {/* About */}
       <AboutSection />
     </div>
-  );
-}
-
-// ─── Appearance Section ──────────────────────────────────────────────────────
-
-const THEME_OPTIONS: { id: Theme; label: string; icon: typeof Sun }[] = [
-  { id: 'light', label: 'Light', icon: Sun },
-  { id: 'dark', label: 'Dark', icon: Moon },
-  { id: 'system', label: 'System', icon: Monitor },
-];
-
-function AppearanceSection() {
-  const { theme, setTheme, hydrate } = useAppearanceStore();
-
-  useEffect(() => {
-    hydrate();
-  }, [hydrate]);
-
-  return (
-    <Section title="Appearance" icon={Palette}>
-      <div className="space-y-4">
-        <div>
-          <p className="text-sm font-medium text-slate-700 mb-2">Theme</p>
-          <div className="grid grid-cols-3 gap-2">
-            {THEME_OPTIONS.map(({ id, label, icon: Icon }) => (
-              <button
-                key={id}
-                type="button"
-                onClick={() => setTheme(id)}
-                className={cn(
-                  'flex items-center justify-center gap-2 rounded-lg border px-4 py-3 text-sm font-medium transition-colors cursor-pointer',
-                  theme === id
-                    ? 'border-indigo-300 bg-indigo-50 text-indigo-700'
-                    : 'border-slate-200 bg-white text-slate-600 hover:bg-slate-50',
-                )}
-              >
-                <Icon className="w-4 h-4" />
-                {label}
-              </button>
-            ))}
-          </div>
-          <p className="text-xs text-slate-400 mt-2">
-            {theme === 'system' ? 'Follows your operating system preference' : `Using ${theme} mode`}
-          </p>
-        </div>
-      </div>
-    </Section>
-  );
-}
-
-// ─── Language Section ────────────────────────────────────────────────────────
-
-const LANGUAGE_OPTIONS: { id: InterfaceLanguage; label: string; native: string }[] = [
-  { id: 'en', label: 'English', native: 'English' },
-  { id: 'zh', label: 'Chinese', native: '中文' },
-];
-
-function LanguageSection() {
-  const { interfaceLanguage, setInterfaceLanguage, hydrate } = useLanguageStore();
-
-  useEffect(() => {
-    hydrate();
-  }, [hydrate]);
-
-  return (
-    <Section title="Language" icon={Globe}>
-      <div className="space-y-4">
-        <div>
-          <p className="text-sm font-medium text-slate-700 mb-2">Interface Language</p>
-          <div className="grid grid-cols-2 gap-2">
-            {LANGUAGE_OPTIONS.map(({ id, label, native }) => (
-              <button
-                key={id}
-                type="button"
-                onClick={() => setInterfaceLanguage(id)}
-                className={cn(
-                  'flex items-center justify-center gap-2 rounded-lg border px-4 py-3 text-sm font-medium transition-colors cursor-pointer',
-                  interfaceLanguage === id
-                    ? 'border-indigo-300 bg-indigo-50 text-indigo-700'
-                    : 'border-slate-200 bg-white text-slate-600 hover:bg-slate-50',
-                )}
-              >
-                <span>{native}</span>
-                {interfaceLanguage === id && <Check className="w-3.5 h-3.5" />}
-              </button>
-            ))}
-          </div>
-        </div>
-        <div className="flex items-center justify-between rounded-lg border border-slate-100 px-4 py-3">
-          <div>
-            <p className="text-sm font-medium text-slate-700">Learning Target</p>
-            <p className="text-xs text-slate-400">The language you are learning</p>
-          </div>
-          <span className="text-sm font-medium text-indigo-600">English</span>
-        </div>
-      </div>
-    </Section>
-  );
-}
-
-// ─── About Section ───────────────────────────────────────────────────────────
-
-function AboutSection() {
-  const infoRows = [
-    { label: 'Application', value: 'EchoType' },
-    { label: 'Version', value: 'v1.1.0' },
-    { label: 'Tech Stack', value: 'Next.js + React + TypeScript' },
-    { label: 'Data Storage', value: 'Local (IndexedDB) + Cloud Sync' },
-    { label: 'Desktop', value: 'Tauri v2' },
-  ];
-
-  return (
-    <Section title="About" icon={Info}>
-      <div className="space-y-5">
-        {/* App identity */}
-        <div className="flex flex-col items-center text-center py-4">
-          <div className="w-16 h-16 rounded-2xl bg-gradient-to-br from-indigo-500 to-violet-600 flex items-center justify-center shadow-lg shadow-indigo-200 mb-3">
-            <Zap className="w-8 h-8 text-white" />
-          </div>
-          <h3 className="text-lg font-bold text-slate-900">EchoType</h3>
-          <p className="text-xs text-slate-400 mt-0.5">v1.1.0</p>
-          <p className="text-sm text-slate-500 mt-2 max-w-sm">
-            An English learning app for mastering listening, speaking, reading &amp; writing skills through practice and
-            typing.
-          </p>
-        </div>
-
-        {/* Info rows */}
-        <div className="rounded-lg border border-slate-100 divide-y divide-slate-100">
-          {infoRows.map(({ label, value }) => (
-            <div key={label} className="flex items-center justify-between px-4 py-3">
-              <span className="text-sm text-slate-500">{label}</span>
-              <span className="text-sm font-medium text-slate-700">{value}</span>
-            </div>
-          ))}
-        </div>
-
-        {/* Links */}
-        <div className="flex items-center gap-3">
-          <a href="https://github.com/Talljack/echo-type" target="_blank" rel="noopener noreferrer" className="flex-1">
-            <Button variant="outline" className="w-full gap-2 text-sm cursor-pointer">
-              <ExternalLink className="w-3.5 h-3.5" />
-              GitHub
-            </Button>
-          </a>
-          <a
-            href="https://github.com/Talljack/echo-type/issues"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex-1"
-          >
-            <Button variant="outline" className="w-full gap-2 text-sm cursor-pointer">
-              <AlertCircle className="w-3.5 h-3.5" />
-              Report a Bug
-            </Button>
-          </a>
-        </div>
-      </div>
-    </Section>
   );
 }
 

--- a/src/components/auth/user-menu.tsx
+++ b/src/components/auth/user-menu.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { LogIn, LogOut, RefreshCw, User } from 'lucide-react';
+import { LogIn, LogOut, RefreshCw, Settings } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import {
   DropdownMenu,
@@ -10,6 +10,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { useAuthStore } from '@/stores/auth-store';
 
 function getInitials(name?: string | null): string {
@@ -38,14 +39,22 @@ function getAvatarUrl(user: { user_metadata?: Record<string, unknown> } | null):
   return null;
 }
 
-export function UserMenu() {
+export function UserMenu({ collapsed = false }: { collapsed?: boolean }) {
   const { user, isAuthenticated, isLoading, isConfigured, signOut } = useAuthStore();
   const router = useRouter();
 
+  // Loading state
   if (isLoading) {
+    if (collapsed) {
+      return (
+        <div className="flex items-center justify-center py-1">
+          <div className="w-8 h-8 rounded-full bg-slate-200 animate-pulse shrink-0" />
+        </div>
+      );
+    }
     return (
       <div className="flex items-center gap-2.5 px-2 py-2 rounded-lg">
-        <div className="w-7 h-7 rounded-full bg-slate-200 animate-pulse shrink-0" />
+        <div className="w-8 h-8 rounded-full bg-slate-200 animate-pulse shrink-0" />
         <div className="flex-1 min-w-0 space-y-1">
           <div className="h-3 w-16 bg-slate-200 rounded animate-pulse" />
           <div className="h-2.5 w-12 bg-slate-100 rounded animate-pulse" />
@@ -54,74 +63,96 @@ export function UserMenu() {
     );
   }
 
+  // Not configured (local-only mode) — hide entirely
   if (!isConfigured) {
-    return (
-      <div className="flex items-center gap-2.5 px-2 py-2 rounded-lg">
-        <div className="w-7 h-7 rounded-full bg-gradient-to-br from-indigo-400 to-violet-500 flex items-center justify-center shrink-0">
-          <span className="text-white text-[10px] font-bold">ET</span>
-        </div>
-        <div className="flex-1 min-w-0 text-left">
-          <p className="text-xs font-medium text-slate-700 truncate leading-none">EchoType</p>
-          <p className="text-[10px] text-slate-400 truncate leading-none mt-0.5">v1.0 · Local</p>
-        </div>
-      </div>
-    );
+    return null;
   }
 
+  // Not authenticated — show sign-in prompt
   if (!isAuthenticated || !user) {
+    if (collapsed) {
+      return (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={() => router.push('/login')}
+              className="flex items-center justify-center w-full py-1 cursor-pointer"
+            >
+              <div className="w-8 h-8 rounded-full bg-slate-100 flex items-center justify-center hover:bg-slate-200 transition-colors">
+                <LogIn className="w-3.5 h-3.5 text-slate-500" />
+              </div>
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="right" sideOffset={8}>
+            Sign in to sync
+          </TooltipContent>
+        </Tooltip>
+      );
+    }
+
     return (
       <button
         type="button"
         onClick={() => router.push('/login')}
         className="flex items-center gap-2.5 px-2 py-2 rounded-lg hover:bg-slate-50 cursor-pointer transition-colors duration-150 w-full"
       >
-        <div className="w-7 h-7 rounded-full bg-gradient-to-br from-indigo-400 to-violet-500 flex items-center justify-center shrink-0">
-          <LogIn className="w-3.5 h-3.5 text-white" />
+        <div className="w-8 h-8 rounded-full bg-slate-100 flex items-center justify-center shrink-0">
+          <LogIn className="w-3.5 h-3.5 text-slate-500" />
         </div>
         <div className="flex-1 min-w-0 text-left">
-          <p className="text-xs font-medium text-slate-700 truncate leading-none">Sign In</p>
+          <p className="text-xs font-medium text-slate-600 truncate leading-none">Sign in</p>
           <p className="text-[10px] text-slate-400 truncate leading-none mt-0.5">Sync your data</p>
         </div>
       </button>
     );
   }
 
+  // Authenticated
   const displayName = getDisplayName(user);
   const initials = getInitials(displayName);
   const avatarUrl = getAvatarUrl(user);
 
+  const avatar = avatarUrl ? (
+    <img
+      src={avatarUrl}
+      alt={displayName}
+      className="w-8 h-8 rounded-full shrink-0 object-cover"
+      referrerPolicy="no-referrer"
+    />
+  ) : (
+    <div className="w-8 h-8 rounded-full bg-gradient-to-br from-indigo-400 to-violet-500 flex items-center justify-center shrink-0">
+      <span className="text-white text-[10px] font-bold">{initials}</span>
+    </div>
+  );
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <button
-          type="button"
-          className="flex items-center gap-2.5 px-2 py-2 rounded-lg hover:bg-slate-50 cursor-pointer transition-colors duration-150 w-full outline-none"
-        >
-          {avatarUrl ? (
-            <img
-              src={avatarUrl}
-              alt={displayName}
-              className="w-7 h-7 rounded-full shrink-0 object-cover"
-              referrerPolicy="no-referrer"
-            />
-          ) : (
-            <div className="w-7 h-7 rounded-full bg-gradient-to-br from-indigo-400 to-violet-500 flex items-center justify-center shrink-0">
-              <span className="text-white text-[10px] font-bold">{initials}</span>
+        {collapsed ? (
+          <button type="button" className="flex items-center justify-center w-full py-1 cursor-pointer outline-none">
+            {avatar}
+          </button>
+        ) : (
+          <button
+            type="button"
+            className="flex items-center gap-2.5 px-2 py-2 rounded-lg hover:bg-slate-50 cursor-pointer transition-colors duration-150 w-full outline-none"
+          >
+            {avatar}
+            <div className="flex-1 min-w-0 text-left">
+              <p className="text-xs font-medium text-slate-700 truncate leading-none">{displayName}</p>
+              <p className="text-[10px] text-slate-400 truncate leading-none mt-0.5">{user.email ?? 'Signed in'}</p>
             </div>
-          )}
-          <div className="flex-1 min-w-0 text-left">
-            <p className="text-xs font-medium text-slate-700 truncate leading-none">{displayName}</p>
-            <p className="text-[10px] text-slate-400 truncate leading-none mt-0.5">{user.email ?? 'Signed in'}</p>
-          </div>
-        </button>
+          </button>
+        )}
       </DropdownMenuTrigger>
 
-      <DropdownMenuContent side="top" align="start" className="w-56">
+      <DropdownMenuContent side="top" align={collapsed ? 'center' : 'start'} className="w-56">
         <DropdownMenuLabel className="text-xs font-normal text-slate-500">{user.email}</DropdownMenuLabel>
         <DropdownMenuSeparator />
         <DropdownMenuItem onClick={() => router.push('/settings')}>
-          <User className="mr-2 h-4 w-4" />
-          Account
+          <Settings className="mr-2 h-4 w-4" />
+          Settings
         </DropdownMenuItem>
         <DropdownMenuItem disabled>
           <RefreshCw className="mr-2 h-4 w-4" />

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -6,6 +6,8 @@ import {
   BookMarked,
   BookOpen,
   ChevronDown,
+  ChevronsLeft,
+  ChevronsRight,
   Headphones,
   LayoutDashboard,
   Library,
@@ -18,6 +20,7 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useState } from 'react';
 import { UserMenu } from '@/components/auth/user-menu';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { UpdateDialog } from '@/components/updater/update-dialog';
 import { IS_TAURI } from '@/lib/tauri';
 import { cn } from '@/lib/utils';
@@ -62,7 +65,17 @@ const navGroups: NavGroup[] = [
   },
 ];
 
-function NavLink({ item, pathname, depth = 0 }: { item: NavItem; pathname: string; depth?: number }) {
+function NavLink({
+  item,
+  pathname,
+  depth = 0,
+  collapsed = false,
+}: {
+  item: NavItem;
+  pathname: string;
+  depth?: number;
+  collapsed?: boolean;
+}) {
   const isActive =
     item.href === '/library'
       ? pathname === '/library' || (pathname.startsWith('/library') && !pathname.startsWith('/library/wordbooks'))
@@ -75,19 +88,59 @@ function NavLink({ item, pathname, depth = 0 }: { item: NavItem; pathname: strin
 
   if (depth === 0) {
     if (!hasChildren) {
-      return (
+      const link = (
         <Link
           href={item.href}
           className={cn(
-            'flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm transition-colors duration-150 cursor-pointer select-none',
+            'flex items-center gap-2.5 rounded-lg text-sm transition-colors duration-150 cursor-pointer select-none',
+            collapsed ? 'justify-center px-2 py-2' : 'px-3 py-2',
             active
               ? 'bg-indigo-600 text-white font-medium'
               : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900 font-normal',
           )}
         >
           <item.icon className={cn('w-4 h-4 shrink-0', active ? 'text-white' : 'text-slate-400')} />
-          <span className="truncate">{item.label}</span>
+          {!collapsed && <span className="truncate">{item.label}</span>}
         </Link>
+      );
+
+      if (collapsed) {
+        return (
+          <Tooltip>
+            <TooltipTrigger asChild>{link}</TooltipTrigger>
+            <TooltipContent side="right" sideOffset={8}>
+              {item.label}
+            </TooltipContent>
+          </Tooltip>
+        );
+      }
+
+      return link;
+    }
+
+    if (collapsed) {
+      // Collapsed: show only parent icon, no children
+      const link = (
+        <Link
+          href={item.href}
+          className={cn(
+            'flex items-center justify-center px-2 py-2 rounded-lg text-sm transition-colors duration-150 cursor-pointer select-none',
+            active
+              ? 'bg-indigo-600 text-white font-medium'
+              : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900 font-normal',
+          )}
+        >
+          <item.icon className={cn('w-4 h-4 shrink-0', active ? 'text-white' : 'text-slate-400')} />
+        </Link>
+      );
+
+      return (
+        <Tooltip>
+          <TooltipTrigger asChild>{link}</TooltipTrigger>
+          <TooltipContent side="right" sideOffset={8}>
+            {item.label}
+          </TooltipContent>
+        </Tooltip>
       );
     }
 
@@ -96,7 +149,7 @@ function NavLink({ item, pathname, depth = 0 }: { item: NavItem; pathname: strin
         <button
           type="button"
           className={cn(
-            'flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm transition-colors duration-150 cursor-pointer select-none',
+            'flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm transition-colors duration-150 cursor-pointer select-none w-full',
             active
               ? 'bg-indigo-600 text-white font-medium'
               : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900 font-normal',
@@ -143,7 +196,7 @@ function NavLink({ item, pathname, depth = 0 }: { item: NavItem; pathname: strin
   );
 }
 
-function UpdateIndicator() {
+function UpdateIndicator({ collapsed }: { collapsed: boolean }) {
   const status = useUpdaterStore((s) => s.status);
   const openDialog = useUpdaterStore((s) => s.openDialog);
 
@@ -160,14 +213,31 @@ function UpdateIndicator() {
             transition={{ duration: 0.2 }}
             className="px-3 pb-3"
           >
-            <button
-              type="button"
-              onClick={openDialog}
-              className="flex w-full items-center gap-2 rounded-lg bg-indigo-50 px-3 py-2 text-sm font-medium text-indigo-600 transition-colors hover:bg-indigo-100"
-            >
-              <ArrowDownCircle className="w-4 h-4" />
-              <span>{status === 'downloaded' ? 'Restart to Update' : 'Update Available'}</span>
-            </button>
+            {collapsed ? (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    onClick={openDialog}
+                    className="flex w-full items-center justify-center rounded-lg bg-indigo-50 p-2 text-indigo-600 transition-colors hover:bg-indigo-100"
+                  >
+                    <ArrowDownCircle className="w-4 h-4" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="right" sideOffset={8}>
+                  {status === 'downloaded' ? 'Restart to Update' : 'Update Available'}
+                </TooltipContent>
+              </Tooltip>
+            ) : (
+              <button
+                type="button"
+                onClick={openDialog}
+                className="flex w-full items-center gap-2 rounded-lg bg-indigo-50 px-3 py-2 text-sm font-medium text-indigo-600 transition-colors hover:bg-indigo-100"
+              >
+                <ArrowDownCircle className="w-4 h-4" />
+                <span>{status === 'downloaded' ? 'Restart to Update' : 'Update Available'}</span>
+              </button>
+            )}
           </motion.div>
         )}
       </AnimatePresence>
@@ -178,35 +248,46 @@ function UpdateIndicator() {
 
 export function Sidebar() {
   const pathname = usePathname();
+  const [collapsed, setCollapsed] = useState(false);
 
   return (
-    <aside className="w-60 h-screen bg-white border-r border-slate-100 flex flex-col shrink-0">
-      {/* Logo + User */}
-      <div className="px-4 py-4 border-b border-slate-100 space-y-3">
+    <aside
+      className={cn(
+        'h-screen bg-white border-r border-slate-100 flex flex-col shrink-0 transition-[width] duration-200',
+        collapsed ? 'w-[60px]' : 'w-60',
+      )}
+    >
+      {/* Logo */}
+      <div className={cn('border-b border-slate-100', collapsed ? 'px-2 py-4' : 'px-4 py-4')}>
         <Link href="/" className="flex items-center gap-2.5 cursor-pointer group">
-          <div className="w-8 h-8 rounded-xl bg-gradient-to-br from-indigo-500 to-violet-600 flex items-center justify-center shadow-sm shadow-indigo-200">
+          <div className="w-8 h-8 rounded-xl bg-gradient-to-br from-indigo-500 to-violet-600 flex items-center justify-center shadow-sm shadow-indigo-200 shrink-0">
             <Zap className="w-4 h-4 text-white" />
           </div>
-          <div>
-            <span className="text-[15px] font-bold text-slate-900 font-[var(--font-poppins)] leading-none block">
-              EchoType
-            </span>
-            <span className="text-[10px] text-slate-400 leading-none block mt-0.5 tracking-wide">English Learning</span>
-          </div>
+          {!collapsed && (
+            <div>
+              <span className="text-[15px] font-bold text-slate-900 font-[var(--font-poppins)] leading-none block">
+                EchoType
+              </span>
+              <span className="text-[10px] text-slate-400 leading-none block mt-0.5 tracking-wide">
+                English Learning
+              </span>
+            </div>
+          )}
         </Link>
-        <UserMenu />
       </div>
 
       {/* Nav */}
-      <nav className="flex-1 px-2 py-3 space-y-4 overflow-y-auto">
+      <nav className={cn('flex-1 py-3 space-y-4 overflow-y-auto', collapsed ? 'px-1.5' : 'px-2')}>
         {navGroups.map((group) => (
           <div key={group.label}>
-            <p className="px-3 mb-1 text-[10px] font-semibold uppercase tracking-widest text-slate-400">
-              {group.label}
-            </p>
+            {!collapsed && (
+              <p className="px-3 mb-1 text-[10px] font-semibold uppercase tracking-widest text-slate-400">
+                {group.label}
+              </p>
+            )}
             <div className="space-y-0.5">
               {group.items.map((item) => (
-                <NavLink key={item.href} item={item} pathname={pathname} />
+                <NavLink key={item.href} item={item} pathname={pathname} collapsed={collapsed} />
               ))}
             </div>
           </div>
@@ -214,7 +295,23 @@ export function Sidebar() {
       </nav>
 
       {/* Update indicator - only in Tauri desktop */}
-      {IS_TAURI && <UpdateIndicator />}
+      {IS_TAURI && <UpdateIndicator collapsed={collapsed} />}
+
+      {/* User menu + Collapse toggle */}
+      <div className={cn('border-t border-slate-100', collapsed ? 'px-2 py-2 space-y-1' : 'px-2 py-2 space-y-1')}>
+        <UserMenu collapsed={collapsed} />
+        <button
+          type="button"
+          onClick={() => setCollapsed(!collapsed)}
+          className={cn(
+            'flex items-center w-full rounded-lg py-1.5 text-xs text-slate-400 hover:text-slate-600 hover:bg-slate-50 transition-colors cursor-pointer',
+            collapsed ? 'justify-center px-2' : 'gap-2.5 px-2',
+          )}
+        >
+          {collapsed ? <ChevronsRight className="w-4 h-4" /> : <ChevronsLeft className="w-4 h-4" />}
+          {!collapsed && <span>Collapse</span>}
+        </button>
+      </div>
     </aside>
   );
 }

--- a/src/components/settings/about-section.tsx
+++ b/src/components/settings/about-section.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { AlertCircle, ExternalLink, Info, Zap } from 'lucide-react';
+import { Section } from '@/components/settings/section';
+import { Button } from '@/components/ui/button';
+import { APP_VERSION } from '@/lib/version';
+
+const INFO_ROWS = [
+  { label: 'Application', value: 'EchoType' },
+  { label: 'Version', value: `v${APP_VERSION}` },
+  { label: 'Tech Stack', value: 'Next.js + React + TypeScript' },
+  { label: 'Data Storage', value: 'Local (IndexedDB) + Cloud Sync' },
+  { label: 'Desktop', value: 'Tauri v2' },
+];
+
+export function AboutSection() {
+  return (
+    <Section title="About" icon={Info}>
+      <div className="space-y-5">
+        {/* App identity */}
+        <div className="flex flex-col items-center text-center py-4">
+          <div className="w-16 h-16 rounded-2xl bg-gradient-to-br from-indigo-500 to-violet-600 flex items-center justify-center shadow-lg shadow-indigo-200 mb-3">
+            <Zap className="w-8 h-8 text-white" />
+          </div>
+          <h3 className="text-lg font-bold text-slate-900">EchoType</h3>
+          <p className="text-xs text-slate-400 mt-0.5">v{APP_VERSION}</p>
+          <p className="text-sm text-slate-500 mt-2 max-w-sm">
+            An English learning app for mastering listening, speaking, reading &amp; writing skills through practice and
+            typing.
+          </p>
+        </div>
+
+        {/* Info rows */}
+        <div className="rounded-lg border border-slate-100 divide-y divide-slate-100">
+          {INFO_ROWS.map(({ label, value }) => (
+            <div key={label} className="flex items-center justify-between px-4 py-3">
+              <span className="text-sm text-slate-500">{label}</span>
+              <span className="text-sm font-medium text-slate-700">{value}</span>
+            </div>
+          ))}
+        </div>
+
+        {/* Links */}
+        <div className="flex items-center gap-3">
+          <a href="https://github.com/Talljack/echo-type" target="_blank" rel="noopener noreferrer" className="flex-1">
+            <Button variant="outline" className="w-full gap-2 text-sm cursor-pointer">
+              <ExternalLink className="w-3.5 h-3.5" />
+              GitHub
+            </Button>
+          </a>
+          <a
+            href="https://github.com/Talljack/echo-type/issues"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex-1"
+          >
+            <Button variant="outline" className="w-full gap-2 text-sm cursor-pointer">
+              <AlertCircle className="w-3.5 h-3.5" />
+              Report a Bug
+            </Button>
+          </a>
+        </div>
+      </div>
+    </Section>
+  );
+}

--- a/src/components/settings/appearance-section.tsx
+++ b/src/components/settings/appearance-section.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { Monitor, Moon, Palette, Sun } from 'lucide-react';
+import { useEffect } from 'react';
+import { Section } from '@/components/settings/section';
+import { cn } from '@/lib/utils';
+import { type Theme, useAppearanceStore } from '@/stores/appearance-store';
+
+const THEME_OPTIONS: { id: Theme; label: string; icon: typeof Sun }[] = [
+  { id: 'light', label: 'Light', icon: Sun },
+  { id: 'dark', label: 'Dark', icon: Moon },
+  { id: 'system', label: 'System', icon: Monitor },
+];
+
+export function AppearanceSection() {
+  const { theme, setTheme, hydrate } = useAppearanceStore();
+
+  useEffect(() => {
+    hydrate();
+  }, [hydrate]);
+
+  return (
+    <Section title="Appearance" icon={Palette}>
+      <div className="space-y-4">
+        <div>
+          <p className="text-sm font-medium text-slate-700 mb-2">Theme</p>
+          <div className="grid grid-cols-3 gap-2">
+            {THEME_OPTIONS.map(({ id, label, icon: Icon }) => (
+              <button
+                key={id}
+                type="button"
+                onClick={() => setTheme(id)}
+                className={cn(
+                  'flex items-center justify-center gap-2 rounded-lg border px-4 py-3 text-sm font-medium transition-colors cursor-pointer',
+                  theme === id
+                    ? 'border-indigo-300 bg-indigo-50 text-indigo-700'
+                    : 'border-slate-200 bg-white text-slate-600 hover:bg-slate-50',
+                )}
+              >
+                <Icon className="w-4 h-4" />
+                {label}
+              </button>
+            ))}
+          </div>
+          <p className="text-xs text-slate-400 mt-2">
+            {theme === 'system' ? 'Follows your operating system preference' : `Using ${theme} mode`}
+          </p>
+        </div>
+      </div>
+    </Section>
+  );
+}

--- a/src/components/settings/language-section.tsx
+++ b/src/components/settings/language-section.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { Check, Globe } from 'lucide-react';
+import { useEffect } from 'react';
+import { Section } from '@/components/settings/section';
+import { cn } from '@/lib/utils';
+import { type InterfaceLanguage, useLanguageStore } from '@/stores/language-store';
+
+const LANGUAGE_OPTIONS: { id: InterfaceLanguage; label: string; native: string }[] = [
+  { id: 'en', label: 'English', native: 'English' },
+  { id: 'zh', label: 'Chinese', native: '中文' },
+];
+
+export function LanguageSection() {
+  const { interfaceLanguage, setInterfaceLanguage, hydrate } = useLanguageStore();
+
+  useEffect(() => {
+    hydrate();
+  }, [hydrate]);
+
+  return (
+    <Section title="Language" icon={Globe}>
+      <div className="space-y-4">
+        <div>
+          <p className="text-sm font-medium text-slate-700 mb-2">Interface Language</p>
+          <div className="grid grid-cols-2 gap-2">
+            {LANGUAGE_OPTIONS.map(({ id, native }) => (
+              <button
+                key={id}
+                type="button"
+                onClick={() => setInterfaceLanguage(id)}
+                className={cn(
+                  'flex items-center justify-center gap-2 rounded-lg border px-4 py-3 text-sm font-medium transition-colors cursor-pointer',
+                  interfaceLanguage === id
+                    ? 'border-indigo-300 bg-indigo-50 text-indigo-700'
+                    : 'border-slate-200 bg-white text-slate-600 hover:bg-slate-50',
+                )}
+              >
+                <span>{native}</span>
+                {interfaceLanguage === id && <Check className="w-3.5 h-3.5" />}
+              </button>
+            ))}
+          </div>
+        </div>
+        <div className="flex items-center justify-between rounded-lg border border-slate-100 px-4 py-3">
+          <div>
+            <p className="text-sm font-medium text-slate-700">Learning Target</p>
+            <p className="text-xs text-slate-400">The language you are learning</p>
+          </div>
+          <span className="text-sm font-medium text-indigo-600">English</span>
+        </div>
+      </div>
+    </Section>
+  );
+}

--- a/src/components/settings/section.tsx
+++ b/src/components/settings/section.tsx
@@ -1,0 +1,21 @@
+import type React from 'react';
+
+export function Section({
+  title,
+  icon: Icon,
+  children,
+}: {
+  title: string;
+  icon: React.ComponentType<{ className?: string }>;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="bg-white rounded-xl border border-slate-100 shadow-sm overflow-hidden">
+      <div className="flex items-center gap-2 px-5 py-3.5 border-b border-slate-100">
+        <Icon className="w-4 h-4 text-slate-400" />
+        <h2 className="text-sm font-semibold text-slate-800">{title}</h2>
+      </div>
+      <div className="p-5">{children}</div>
+    </div>
+  );
+}

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -1,0 +1,1 @@
+export const APP_VERSION = '1.1.0';


### PR DESCRIPTION
## Summary
- Move Sign In from sidebar header to bottom (VS Code/Figma pattern)
- Add collapsible sidebar with icon-only mode and tooltips
- Reorder settings: Appearance & Language moved up for discoverability
- Extract settings sections into separate component files
- Unify version to 1.1.0 across all config files (single-source `APP_VERSION`)
- Fix tray: pathname routing, dynamic Show/Hide text, keyboard accelerators (⌘, / ⌘Q), unified icon path
- Auto-disconnect provider on switch, explicit baseUrl on model refresh

## Test plan
- [ ] Verify sidebar Sign In button at bottom, click navigates to /login
- [ ] Test sidebar collapse/expand toggle, tooltips on collapsed icons
- [ ] Verify settings page order: Account → Assessment → Appearance → Language → AI Provider → ...
- [ ] Check About section shows v1.1.0 from APP_VERSION constant
- [ ] Desktop: test tray menu items (Show/Hide toggles text, Dashboard/Settings navigate correctly)
- [ ] Switch AI provider → old one auto-disconnects
- [ ] Change baseUrl → refresh model list → uses new URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)