### PR TITLE
feat: practice UX improvements - translation, TTS, completion celebrations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "echotype",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "scripts": {
     "preinstall": "npx only-allow pnpm",
@@ -43,6 +43,7 @@
     "@upstash/ratelimit": "^2.0.8",
     "@upstash/redis": "^1.36.3",
     "ai": "^6.0.101",
+    "canvas-confetti": "^1.9.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
@@ -75,6 +76,7 @@
     "@playwright/test": "^1.58.2",
     "@tailwindcss/postcss": "^4",
     "@tauri-apps/cli": "^2.10.1",
+    "@types/canvas-confetti": "^1.9.0",
     "@types/node": "^20",
     "@types/pdf-parse": "^1.1.5",
     "@types/react": "^19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       ai:
         specifier: ^6.0.101
         version: 6.0.101(zod@4.3.6)
+      canvas-confetti:
+        specifier: ^1.9.4
+        version: 1.9.4
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -165,6 +168,9 @@ importers:
       '@tauri-apps/cli':
         specifier: ^2.10.1
         version: 2.10.1
+      '@types/canvas-confetti':
+        specifier: ^1.9.0
+        version: 1.9.0
       '@types/node':
         specifier: ^20
         version: 20.19.34
@@ -2219,6 +2225,9 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/canvas-confetti@1.9.0':
+    resolution: {integrity: sha512-aBGj/dULrimR1XDZLtG9JwxX1b4HPRF6CX9Yfwh3NvstZEm1ZL7RBnel4keCPSqs1ANRu1u2Aoz9R+VmtjYuTg==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -2733,6 +2742,9 @@ packages:
 
   caniuse-lite@1.0.30001774:
     resolution: {integrity: sha512-DDdwPGz99nmIEv216hKSgLD+D4ikHQHjBC/seF98N9CPqRX4M5mSxT9eTV6oyisnJcuzxtZy4n17yKKQYmYQOA==}
+
+  canvas-confetti@1.9.4:
+    resolution: {integrity: sha512-yxQbJkAVrFXWNbTUjPqjF7G+g6pDotOUHGbkZq2NELZUMDpiJ85rIEazVb8GTaAptNW2miJAXbs1BtioA251Pw==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -7268,6 +7280,8 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/canvas-confetti@1.9.0': {}
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -7795,6 +7809,8 @@ snapshots:
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001774: {}
+
+  canvas-confetti@1.9.4: {}
 
   ccount@2.0.1: {}
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -868,7 +868,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "echotype"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "portpicker",
  "reqwest 0.12.28",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echotype"
-version = "1.2.0"
+version = "1.2.1"
 description = "EchoType - Learn English by Listening, Speaking, Reading & Writing"
 authors = ["EchoType"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicosResworksql/tauri-apps/tauri-v2/packages/tauri-utils/schema.json",
   "productName": "EchoType",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "identifier": "com.echotype.desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/app/(app)/listen/[id]/page.tsx
+++ b/src/app/(app)/listen/[id]/page.tsx
@@ -5,6 +5,7 @@ import { nanoid } from 'nanoid';
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { PracticeCompleteBanner } from '@/components/shared/practice-complete-banner';
 import { RecommendationPanel } from '@/components/shared/recommendation-panel';
 import { TranslationBar } from '@/components/translation/translation-bar';
 import { TranslationDisplay } from '@/components/translation/translation-display';
@@ -87,6 +88,7 @@ export default function ListenDetailPage() {
   const targetLang = useTTSStore((s) => s.targetLang);
   const recommendationsEnabled = useTTSStore((s) => s.recommendationsEnabled);
   const shadowReadingEnabled = useTTSStore((s) => s.shadowReadingEnabled);
+  const [sessionCompleted, setSessionCompleted] = useState(false);
   const { addContent, setActiveContentId } = useContentStore();
   const {
     sentenceTranslations,
@@ -198,6 +200,7 @@ export default function ListenDetailPage() {
       accuracy: 0,
       completed: true,
     });
+    setSessionCompleted(true);
   }, [content]);
 
   const speakWithWordHighlight = useCallback(
@@ -534,6 +537,8 @@ export default function ListenDetailPage() {
           )}
         </CardContent>
       </Card>
+
+      {sessionCompleted && <PracticeCompleteBanner module="listen" />}
 
       {recommendationsEnabled && <RecommendationPanel content={content} onNavigate={handleRecommendationNavigate} />}
     </div>

--- a/src/app/(app)/read/[id]/page.tsx
+++ b/src/app/(app)/read/[id]/page.tsx
@@ -8,6 +8,7 @@ import { useParams, useRouter } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { flushSync } from 'react-dom';
 import { FormattedContentText } from '@/components/shared/formatted-content-text';
+import { PracticeCompleteBanner } from '@/components/shared/practice-complete-banner';
 import { RecommendationPanel } from '@/components/shared/recommendation-panel';
 import { PronunciationFeedback } from '@/components/speak/pronunciation-feedback';
 import { SpeechStats } from '@/components/speak/speech-stats';
@@ -43,6 +44,7 @@ export default function ReadDetailPage() {
   const transcriptRef = useRef('');
   const interimTranscriptRef = useRef('');
   const hasPersistedResultRef = useRef(false);
+  const [sessionCompleted, setSessionCompleted] = useState(false);
   const showTranslation = useTTSStore((s) => s.showTranslation);
   const targetLang = useTTSStore((s) => s.targetLang);
   const recommendationsEnabled = useTTSStore((s) => s.recommendationsEnabled);
@@ -204,6 +206,7 @@ export default function ReadDetailPage() {
       accuracy,
       completed: true,
     });
+    setSessionCompleted(true);
   }, [content]);
 
   const finalizePracticeRef = useRef(finalizePractice);
@@ -454,6 +457,8 @@ export default function ReadDetailPage() {
           </motion.div>
         )}
       </AnimatePresence>
+
+      {sessionCompleted && <PracticeCompleteBanner module="read" />}
 
       {recommendationsEnabled && <RecommendationPanel content={content} onNavigate={handleRecommendationNavigate} />}
     </div>

--- a/src/app/(app)/write/[id]/page.tsx
+++ b/src/app/(app)/write/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ArrowLeft, Pause, Play, RotateCcw, Target, Timer, Trophy } from 'lucide-react';
+import { ArrowLeft, Pause, Play, RotateCcw, Target, Timer, Trophy, Volume2 } from 'lucide-react';
 import { nanoid } from 'nanoid';
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
@@ -13,6 +13,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import type { Recommendation } from '@/hooks/use-recommendations';
 import { useTranslation } from '@/hooks/use-translation';
+import { useTTS } from '@/hooks/use-tts';
 import { getInitialState, typingReducer } from '@/hooks/use-typing-reducer';
 import { splitContentBlocks } from '@/lib/content-format';
 import { savePracticeSession } from '@/lib/daily-plan-progress';
@@ -56,6 +57,7 @@ export default function WriteDetailPage() {
   const recommendationsEnabled = useTTSStore((s) => s.recommendationsEnabled);
   const shadowReadingEnabled = useTTSStore((s) => s.shadowReadingEnabled);
   const { addContent, setActiveContentId } = useContentStore();
+  const { speak } = useTTS();
   const {
     sentenceTranslations,
     isLoading: translationLoading,
@@ -302,6 +304,16 @@ export default function WriteDetailPage() {
             )}
 
             <TranslationBar />
+
+            <Button
+              variant="ghost"
+              size="sm"
+              className="text-indigo-600 cursor-pointer"
+              onClick={() => content && speak(content.text)}
+              title="Listen to text"
+            >
+              <Volume2 className="w-4 h-4 mr-1" /> Listen
+            </Button>
 
             <Button
               variant="outline"

--- a/src/app/(app)/write/[id]/page.tsx
+++ b/src/app/(app)/write/[id]/page.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react';
 import { FormattedContentText } from '@/components/shared/formatted-content-text';
+import { fireConfetti } from '@/components/shared/practice-complete-banner';
 import { RecommendationPanel } from '@/components/shared/recommendation-panel';
 import { TranslationBar } from '@/components/translation/translation-bar';
 import { TranslationDisplay } from '@/components/translation/translation-display';
@@ -143,6 +144,7 @@ export default function WriteDetailPage() {
 
   useEffect(() => {
     if (state.mode === 'finished' && content) {
+      fireConfetti();
       const session = {
         id: nanoid(),
         contentId: content.id,
@@ -438,12 +440,15 @@ export default function WriteDetailPage() {
           </Card>
         </div>
       ) : (
-        <Card className="bg-white border-slate-100 shadow-sm">
+        <Card className="bg-gradient-to-br from-green-50 via-white to-indigo-50 border-green-200 shadow-lg">
           <CardContent className="p-8 text-center space-y-6">
             <div className="w-16 h-16 rounded-full bg-green-100 flex items-center justify-center mx-auto">
               <Trophy className="w-8 h-8 text-green-600" />
             </div>
-            <h2 className="text-2xl font-bold text-indigo-900 font-[var(--font-poppins)]">Session Complete!</h2>
+            <div>
+              <h2 className="text-2xl font-bold text-indigo-900 font-[var(--font-poppins)]">Session Complete!</h2>
+              <p className="text-green-600 mt-2">Your typing is leveling up — come back tomorrow to keep improving!</p>
+            </div>
 
             <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
               <div className="bg-indigo-50 rounded-xl p-4">
@@ -481,9 +486,9 @@ export default function WriteDetailPage() {
               <Button onClick={handleReset} className="bg-indigo-600 hover:bg-indigo-700 cursor-pointer">
                 <RotateCcw className="w-4 h-4 mr-2" /> Try Again
               </Button>
-              <Link href="/write">
-                <Button variant="outline" className="border-indigo-200 text-indigo-600 cursor-pointer">
-                  Back to List
+              <Link href="/dashboard">
+                <Button variant="outline" className="border-green-300 text-green-700 hover:bg-green-50 cursor-pointer">
+                  Back to Dashboard
                 </Button>
               </Link>
             </div>

--- a/src/components/shared/practice-complete-banner.tsx
+++ b/src/components/shared/practice-complete-banner.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import confetti from 'canvas-confetti';
+import { PartyPopper } from 'lucide-react';
+import Link from 'next/link';
+import { useEffect, useRef } from 'react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+
+interface PracticeCompleteBannerProps {
+  module: 'listen' | 'speak' | 'read' | 'write';
+  /** Optional extra stats line */
+  stats?: string;
+}
+
+const moduleMessages: Record<string, { title: string; subtitle: string }> = {
+  listen: {
+    title: 'Listening Complete!',
+    subtitle: 'Your ears are getting sharper — come back tomorrow for more!',
+  },
+  speak: {
+    title: 'Speaking Complete!',
+    subtitle: 'Great pronunciation practice — keep the streak going tomorrow!',
+  },
+  read: {
+    title: 'Read Aloud Complete!',
+    subtitle: 'Awesome reading session — see you again tomorrow!',
+  },
+  write: {
+    title: 'Writing Complete!',
+    subtitle: 'Your typing is leveling up — come back tomorrow to keep improving!',
+  },
+};
+
+export function fireConfetti() {
+  const duration = 2000;
+  const end = Date.now() + duration;
+
+  const frame = () => {
+    confetti({
+      particleCount: 3,
+      angle: 60,
+      spread: 55,
+      origin: { x: 0, y: 0.7 },
+      colors: ['#4F46E5', '#22C55E', '#FBBF24', '#F472B6'],
+    });
+    confetti({
+      particleCount: 3,
+      angle: 120,
+      spread: 55,
+      origin: { x: 1, y: 0.7 },
+      colors: ['#4F46E5', '#22C55E', '#FBBF24', '#F472B6'],
+    });
+
+    if (Date.now() < end) {
+      requestAnimationFrame(frame);
+    }
+  };
+
+  // Initial burst
+  confetti({
+    particleCount: 80,
+    spread: 100,
+    origin: { y: 0.6 },
+    colors: ['#4F46E5', '#22C55E', '#FBBF24', '#F472B6', '#818CF8'],
+  });
+
+  frame();
+}
+
+export function PracticeCompleteBanner({ module, stats }: PracticeCompleteBannerProps) {
+  const firedRef = useRef(false);
+
+  useEffect(() => {
+    if (firedRef.current) return;
+    firedRef.current = true;
+    fireConfetti();
+  }, []);
+
+  const msg = moduleMessages[module] ?? moduleMessages.write;
+
+  return (
+    <Card className="bg-gradient-to-r from-green-50 to-emerald-50 border-green-200 shadow-md animate-in fade-in slide-in-from-bottom-4 duration-500">
+      <CardContent className="p-5">
+        <div className="flex items-center gap-4">
+          <div className="w-12 h-12 rounded-full bg-green-100 flex items-center justify-center shrink-0">
+            <PartyPopper className="w-6 h-6 text-green-600" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <p className="font-bold text-green-800 text-lg">{msg.title}</p>
+            <p className="text-sm text-green-600 mt-0.5">{msg.subtitle}</p>
+            {stats && <p className="text-xs text-green-500 mt-1">{stats}</p>}
+          </div>
+        </div>
+        <div className="flex gap-3 mt-4 ml-16">
+          <Link href="/dashboard">
+            <Button size="sm" className="bg-green-600 hover:bg-green-700 cursor-pointer">
+              Back to Dashboard
+            </Button>
+          </Link>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/shared/word-book-practice.tsx
+++ b/src/components/shared/word-book-practice.tsx
@@ -13,12 +13,14 @@ import {
   PenTool,
   Play,
   RotateCcw,
+  Trophy,
   Volume2,
 } from 'lucide-react';
 import { nanoid } from 'nanoid';
 import Link from 'next/link';
 import { useParams, useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { fireConfetti } from '@/components/shared/practice-complete-banner';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
@@ -518,6 +520,73 @@ function ReadSpeakPractice({
   );
 }
 
+// ─── Completion Screen ──────────────────────────────────────────────────────
+
+const encourageMessages: Record<string, string> = {
+  listen: 'Your ears are getting sharper — come back tomorrow for more!',
+  speak: 'Great pronunciation practice — keep the streak going tomorrow!',
+  read: 'Awesome reading session — see you again tomorrow!',
+  write: 'Your typing is leveling up — come back tomorrow to keep improving!',
+};
+
+function WordBookCompleteScreen({
+  module,
+  completedCount,
+  total,
+  onRestart,
+}: {
+  module: string;
+  completedCount: number;
+  total: number;
+  onRestart: () => void;
+}) {
+  const firedRef = useRef(false);
+
+  useEffect(() => {
+    if (firedRef.current) return;
+    firedRef.current = true;
+    fireConfetti();
+  }, []);
+
+  return (
+    <div className="max-w-2xl mx-auto space-y-6">
+      <Card className="bg-gradient-to-br from-green-50 via-white to-indigo-50 border-green-200 shadow-lg">
+        <CardContent className="p-8 text-center space-y-6">
+          <div className="w-20 h-20 rounded-full bg-green-100 flex items-center justify-center mx-auto">
+            <Trophy className="w-10 h-10 text-green-600" />
+          </div>
+          <div>
+            <h2 className="text-2xl font-bold text-indigo-900">Session Complete!</h2>
+            <p className="text-green-600 mt-2">{encourageMessages[module]}</p>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div className="bg-indigo-50 rounded-xl p-4">
+              <p className="text-sm text-indigo-500">Total Items</p>
+              <p className="text-2xl font-bold text-indigo-900">{total}</p>
+            </div>
+            <div className="bg-green-50 rounded-xl p-4">
+              <p className="text-sm text-green-600">Completed</p>
+              <p className="text-2xl font-bold text-green-700">{completedCount}</p>
+            </div>
+          </div>
+
+          <div className="flex gap-4 justify-center">
+            <Button onClick={onRestart} className="bg-indigo-600 hover:bg-indigo-700 cursor-pointer">
+              <RotateCcw className="w-4 h-4 mr-2" /> Practice Again
+            </Button>
+            <Link href="/dashboard">
+              <Button variant="outline" className="border-green-300 text-green-700 hover:bg-green-50 cursor-pointer">
+                Back to Dashboard
+              </Button>
+            </Link>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
 // ─── Main Component ──────────────────────────────────────────────────────────
 
 export function WordBookPractice({ module }: WordBookPracticeProps) {
@@ -533,7 +602,8 @@ export function WordBookPractice({ module }: WordBookPracticeProps) {
   const [currentIndex, setCurrentIndex] = useState(0);
   const [loading, setLoading] = useState(true);
   const [slideClass, setSlideClass] = useState('');
-
+  const [finished, setFinished] = useState(false);
+  const [completedCount, setCompletedCount] = useState(0);
   // Translation & TTS
   const targetLang = useTTSStore((s) => s.targetLang);
   const { speak } = useTTS();
@@ -589,7 +659,11 @@ export function WordBookPractice({ module }: WordBookPracticeProps) {
 
   // Navigation with slide animation
   const goToNext = useCallback(() => {
-    if (currentIndex >= total - 1) return;
+    if (currentIndex >= total - 1) {
+      // Last item — show completion screen
+      setFinished(true);
+      return;
+    }
     setSlideClass('animate-slide-out-left');
     setTimeout(() => {
       setCurrentIndex((i) => i + 1);
@@ -597,6 +671,10 @@ export function WordBookPractice({ module }: WordBookPracticeProps) {
       setTimeout(() => setSlideClass(''), 200);
     }, 150);
   }, [currentIndex, total]);
+
+  const handleItemCompleted = useCallback(() => {
+    setCompletedCount((c) => c + 1);
+  }, []);
 
   const goToPrev = useCallback(() => {
     if (currentIndex <= 0) return;
@@ -652,6 +730,21 @@ export function WordBookPractice({ module }: WordBookPracticeProps) {
           </Button>
         </Link>
       </div>
+    );
+  }
+
+  if (finished) {
+    return (
+      <WordBookCompleteScreen
+        module={module}
+        completedCount={completedCount}
+        total={total}
+        onRestart={() => {
+          setFinished(false);
+          setCurrentIndex(0);
+          setCompletedCount(0);
+        }}
+      />
     );
   }
 
@@ -735,12 +828,28 @@ export function WordBookPractice({ module }: WordBookPracticeProps) {
                 </div>
 
                 {/* Mode-specific practice area */}
-                {module === 'listen' && <ListenPractice item={currentItem} persistProgress={persistProgress} />}
+                {module === 'listen' && (
+                  <ListenPractice
+                    item={currentItem}
+                    persistProgress={persistProgress}
+                    onCompleted={handleItemCompleted}
+                  />
+                )}
                 {module === 'write' && (
-                  <WritePractice item={currentItem} onCorrect={goToNext} persistProgress={persistProgress} />
+                  <WritePractice
+                    item={currentItem}
+                    onCorrect={goToNext}
+                    persistProgress={persistProgress}
+                    onCompleted={handleItemCompleted}
+                  />
                 )}
                 {(module === 'read' || module === 'speak') && (
-                  <ReadSpeakPractice item={currentItem} module={module} persistProgress={persistProgress} />
+                  <ReadSpeakPractice
+                    item={currentItem}
+                    module={module}
+                    persistProgress={persistProgress}
+                    onCompleted={handleItemCompleted}
+                  />
                 )}
               </CardContent>
             </Card>
@@ -790,11 +899,16 @@ export function WordBookPractice({ module }: WordBookPracticeProps) {
         <Button
           variant="outline"
           size="sm"
-          onClick={goToNext}
-          disabled={currentIndex === total - 1}
-          className="border-indigo-200 text-indigo-600 cursor-pointer disabled:opacity-30"
+          onClick={currentIndex === total - 1 ? () => setFinished(true) : goToNext}
+          disabled={false}
+          className={cn(
+            'cursor-pointer',
+            currentIndex === total - 1
+              ? 'border-green-300 text-green-600 bg-green-50 hover:bg-green-100'
+              : 'border-indigo-200 text-indigo-600 disabled:opacity-30',
+          )}
         >
-          Next <ChevronRight className="w-4 h-4 ml-1" />
+          {currentIndex === total - 1 ? 'Finish' : 'Next'} <ChevronRight className="w-4 h-4 ml-1" />
         </Button>
       </div>
     </div>

--- a/src/components/shared/word-book-practice.tsx
+++ b/src/components/shared/word-book-practice.tsx
@@ -17,7 +17,7 @@ import {
 } from 'lucide-react';
 import { nanoid } from 'nanoid';
 import Link from 'next/link';
-import { useParams } from 'next/navigation';
+import { useParams, useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -71,6 +71,50 @@ const moduleConfig = {
 };
 
 const SWIPE_THRESHOLD = 50;
+
+// ─── Translation Helper ─────────────────────────────────────────────────────
+
+function useItemTranslation(text: string, targetLang: string) {
+  const [translation, setTranslation] = useState('');
+  const cacheRef = useRef<Map<string, string>>(new Map());
+
+  useEffect(() => {
+    if (!text) return;
+    const key = `${text}::${targetLang}`;
+    const cached = cacheRef.current.get(key);
+    if (cached) {
+      setTranslation(cached);
+      return;
+    }
+
+    setTranslation('');
+    let cancelled = false;
+    fetch('/api/translate/free', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text, targetLang }),
+    })
+      .then((r) => r.json())
+      .then((data: { translation?: string }) => {
+        if (!cancelled && data.translation) {
+          cacheRef.current.set(key, data.translation);
+          setTranslation(data.translation);
+        }
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [text, targetLang]);
+
+  return translation;
+}
+
+function SentenceTranslation({ text, targetLang }: { text: string; targetLang: string }) {
+  const translation = useItemTranslation(text, targetLang);
+  if (!translation) return null;
+  return <p className="text-sm text-indigo-400/80 text-center leading-relaxed">{translation}</p>;
+}
 
 // ─── Listen Practice ─────────────────────────────────────────────────────────
 
@@ -237,14 +281,22 @@ function WritePractice({
       {/* Character feedback display */}
       <div className="bg-slate-50 rounded-lg p-3 min-h-[2.5rem] font-mono text-lg text-center tracking-wide">
         {expectedChars.map((char, i) => {
+          const isSpace = char === ' ';
           let color = 'text-slate-300';
           if (i < typedChars.length) {
-            color = typedChars[i] === char ? 'text-green-600' : 'text-red-500 bg-red-50';
+            if (typedChars[i] === char) {
+              color = 'text-green-600';
+            } else if (isSpace) {
+              // Missing/wrong space: highly visible
+              color = 'text-red-500 bg-red-200 border-b-2 border-red-500 rounded-sm';
+            } else {
+              color = 'text-red-500 bg-red-50';
+            }
           }
           const isCursor = i === typedChars.length;
           return (
             <span key={i} className={cn(color, isCursor && 'border-b-2 border-indigo-500')}>
-              {char}
+              {isSpace && i < typedChars.length && typedChars[i] !== char ? '·' : char}
             </span>
           );
         })}
@@ -470,7 +522,9 @@ function ReadSpeakPractice({
 
 export function WordBookPractice({ module }: WordBookPracticeProps) {
   const params = useParams();
+  const searchParams = useSearchParams();
   const bookId = params.bookId as string;
+  const limit = searchParams.get('limit') ? Number(searchParams.get('limit')) : 0;
 
   const [book, setBook] = useState<WordBook | null>(null);
   const [bookInfo, setBookInfo] = useState<BookInfo | null>(null);
@@ -479,6 +533,10 @@ export function WordBookPractice({ module }: WordBookPracticeProps) {
   const [currentIndex, setCurrentIndex] = useState(0);
   const [loading, setLoading] = useState(true);
   const [slideClass, setSlideClass] = useState('');
+
+  // Translation & TTS
+  const targetLang = useTTSStore((s) => s.targetLang);
+  const { speak } = useTTS();
 
   // Touch handling
   const touchStartX = useRef(0);
@@ -507,7 +565,7 @@ export function WordBookPractice({ module }: WordBookPracticeProps) {
       // First try loading from DB (already imported items)
       const dbItems = await db.contents.where('category').equals(bookId).toArray();
       if (dbItems.length > 0) {
-        setItems(dbItems);
+        setItems(limit > 0 ? dbItems.slice(0, limit) : dbItems);
         setPersistProgress(true);
       } else if (wb) {
         // Not imported yet — load directly from wordbook data for practice
@@ -518,7 +576,7 @@ export function WordBookPractice({ module }: WordBookPracticeProps) {
           createdAt: Date.now(),
           updatedAt: Date.now(),
         }));
-        setItems(practiceItems);
+        setItems(limit > 0 ? practiceItems.slice(0, limit) : practiceItems);
         setPersistProgress(false);
       }
       setLoading(false);
@@ -633,7 +691,17 @@ export function WordBookPractice({ module }: WordBookPracticeProps) {
               <CardContent className="p-6 space-y-4">
                 {/* Word / Title */}
                 <div className="text-center space-y-2">
-                  <h2 className="text-3xl font-bold text-indigo-900">{currentItem.title}</h2>
+                  <div className="flex items-center justify-center gap-2">
+                    <h2 className="text-3xl font-bold text-indigo-900">{currentItem.title}</h2>
+                    <button
+                      type="button"
+                      onClick={() => speak(currentItem.title)}
+                      className="text-indigo-400 hover:text-indigo-600 cursor-pointer transition-colors p-1"
+                      title="Play word"
+                    >
+                      <Volume2 className="w-5 h-5" />
+                    </button>
+                  </div>
                   <div className="flex items-center justify-center gap-2 flex-wrap">
                     {currentItem.difficulty && (
                       <Badge className={difficultyColors[currentItem.difficulty]} variant="secondary">
@@ -649,8 +717,21 @@ export function WordBookPractice({ module }: WordBookPracticeProps) {
                 </div>
 
                 {/* Example text / content */}
-                <div className="bg-indigo-50/50 rounded-xl p-4">
-                  <p className="text-indigo-700 leading-relaxed text-center whitespace-pre-wrap">{currentItem.text}</p>
+                <div className="bg-indigo-50/50 rounded-xl p-4 space-y-2">
+                  <div className="flex items-center justify-center gap-2">
+                    <p className="text-indigo-700 leading-relaxed text-center whitespace-pre-wrap">
+                      {currentItem.text}
+                    </p>
+                    <button
+                      type="button"
+                      onClick={() => speak(currentItem.text)}
+                      className="text-indigo-300 hover:text-indigo-500 cursor-pointer transition-colors shrink-0 p-1"
+                      title="Play sentence"
+                    >
+                      <Volume2 className="w-4 h-4" />
+                    </button>
+                  </div>
+                  <SentenceTranslation text={currentItem.text} targetLang={targetLang} />
                 </div>
 
                 {/* Mode-specific practice area */}
@@ -721,11 +802,24 @@ export function WordBookPractice({ module }: WordBookPracticeProps) {
 }
 
 export function SingleItemPractice({ item, module, persistProgress = true, onCompleted }: SingleItemPracticeProps) {
+  const targetLang = useTTSStore((s) => s.targetLang);
+  const { speak } = useTTS();
+
   return (
     <Card className="bg-white border-indigo-100 shadow-md">
       <CardContent className="p-6 space-y-4">
         <div className="text-center space-y-2">
-          <h2 className="text-3xl font-bold text-indigo-900">{item.title}</h2>
+          <div className="flex items-center justify-center gap-2">
+            <h2 className="text-3xl font-bold text-indigo-900">{item.title}</h2>
+            <button
+              type="button"
+              onClick={() => speak(item.title)}
+              className="text-indigo-400 hover:text-indigo-600 cursor-pointer transition-colors p-1"
+              title="Play word"
+            >
+              <Volume2 className="w-5 h-5" />
+            </button>
+          </div>
           <div className="flex items-center justify-center gap-2 flex-wrap">
             {item.difficulty && (
               <Badge className={difficultyColors[item.difficulty]} variant="secondary">
@@ -740,8 +834,19 @@ export function SingleItemPractice({ item, module, persistProgress = true, onCom
           </div>
         </div>
 
-        <div className="bg-indigo-50/50 rounded-xl p-4">
-          <p className="text-indigo-700 leading-relaxed text-center whitespace-pre-wrap">{item.text}</p>
+        <div className="bg-indigo-50/50 rounded-xl p-4 space-y-2">
+          <div className="flex items-center justify-center gap-2">
+            <p className="text-indigo-700 leading-relaxed text-center whitespace-pre-wrap">{item.text}</p>
+            <button
+              type="button"
+              onClick={() => speak(item.text)}
+              className="text-indigo-300 hover:text-indigo-500 cursor-pointer transition-colors shrink-0 p-1"
+              title="Play sentence"
+            >
+              <Volume2 className="w-4 h-4" />
+            </button>
+          </div>
+          <SentenceTranslation text={item.text} targetLang={targetLang} />
         </div>
 
         {module === 'listen' && (

--- a/src/lib/daily-plan-links.ts
+++ b/src/lib/daily-plan-links.ts
@@ -7,7 +7,9 @@ export function getTaskHref(task: PlanTask): string {
 
   if (task.bookId) {
     const base = `/${task.module}/book/${task.bookId}`;
-    return task.limit ? `${base}?limit=${task.limit}` : base;
+    // Use explicit limit, or extract from title for older plans (e.g. "Learn 20 new words")
+    const limit = task.limit ?? (task.type === 'new-words' ? Number(task.title.match(/\d+/)?.[0]) || 0 : 0);
+    return limit > 0 ? `${base}?limit=${limit}` : base;
   }
   if (task.contentId) return `/${task.module}/${task.contentId}`;
   return `/${task.module}`;

--- a/src/lib/daily-plan-links.ts
+++ b/src/lib/daily-plan-links.ts
@@ -5,7 +5,10 @@ export function getTaskHref(task: PlanTask): string {
     return '/review/today';
   }
 
-  if (task.bookId) return `/${task.module}/book/${task.bookId}`;
+  if (task.bookId) {
+    const base = `/${task.module}/book/${task.bookId}`;
+    return task.limit ? `${base}?limit=${task.limit}` : base;
+  }
   if (task.contentId) return `/${task.module}/${task.contentId}`;
   return `/${task.module}`;
 }

--- a/src/lib/daily-plan-progress.ts
+++ b/src/lib/daily-plan-progress.ts
@@ -20,21 +20,6 @@ function isPracticedOnDay(timestamp: number | undefined, dayKey: string): boolea
   return typeof timestamp === 'number' && toLocalDateKey(timestamp) === dayKey;
 }
 
-function matchesBookTask(
-  task: PlanTask,
-  record: LearningRecord | undefined,
-  session: TypingSession | undefined,
-  contents: Map<string, ContentItem>,
-) {
-  if (!task.bookId) return false;
-
-  const relatedContentId = record?.contentId ?? session?.contentId;
-  if (!relatedContentId) return false;
-
-  const content = contents.get(relatedContentId);
-  return content?.category === task.bookId;
-}
-
 function matchesTask(
   task: PlanTask,
   contents: Map<string, ContentItem>,
@@ -42,25 +27,37 @@ function matchesTask(
   sessions: TypingSession[],
   dayKey: string,
 ) {
-  const matchesTarget = (record: LearningRecord | undefined, session: TypingSession | undefined) => {
-    if (task.bookId) {
-      return matchesBookTask(task, record, session, contents);
-    }
-
-    const relatedContentId = record?.contentId ?? session?.contentId;
-    return task.contentId ? relatedContentId === task.contentId : false;
-  };
-
   const sameDayRecords = records.filter((record) => isPracticedOnDay(record.lastPracticed, dayKey));
   const sameDaySessions = sessions.filter((session) => isPracticedOnDay(session.endTime ?? session.startTime, dayKey));
 
+  if (task.bookId) {
+    // For book-based tasks, count unique items practiced today
+    const practicedIds = new Set<string>();
+
+    for (const record of sameDayRecords) {
+      if (record.module !== task.module) continue;
+      const content = contents.get(record.contentId);
+      if (content?.category === task.bookId) {
+        practicedIds.add(record.contentId);
+      }
+    }
+    for (const session of sameDaySessions) {
+      if (session.module !== task.module) continue;
+      const content = contents.get(session.contentId);
+      if (content?.category === task.bookId) {
+        practicedIds.add(session.contentId);
+      }
+    }
+
+    // If task has a limit, require that many unique items; otherwise any match
+    const requiredCount = task.limit ?? 1;
+    return practicedIds.size >= requiredCount;
+  }
+
+  // For content-based tasks, any matching record/session is enough
   return (
-    sameDayRecords.some((record) => {
-      return matchesTarget(record, undefined) && record.module === task.module;
-    }) ||
-    sameDaySessions.some((session) => {
-      return matchesTarget(undefined, session) && session.module === task.module;
-    })
+    sameDayRecords.some((record) => record.contentId === task.contentId && record.module === task.module) ||
+    sameDaySessions.some((session) => session.contentId === task.contentId && session.module === task.module)
   );
 }
 

--- a/src/lib/daily-plan.ts
+++ b/src/lib/daily-plan.ts
@@ -231,6 +231,7 @@ async function buildNewWordsTask(
         description: `From ${book.nameEn}`,
         module: 'write',
         bookId: book.id,
+        limit: wordCount,
         completed: false,
         skipped: false,
       },

--- a/src/lib/daily-plan.ts
+++ b/src/lib/daily-plan.ts
@@ -63,7 +63,7 @@ export async function generateDailyPlan(goal: DailyGoal, options: DailyPlanOptio
   const readTask = await buildArticleTask(contents, sessions, targetDifficulty, modulePriority.read, dateKey);
   if (readTask) candidates.push(readTask);
 
-  const speakTask = await buildSpeakTask(targetDifficulty, modulePriority.speak, sessions, contentsById, dateKey);
+  const speakTask = await buildSpeakTask(goal, targetDifficulty, modulePriority.speak, sessions, contentsById, dateKey);
   if (speakTask) candidates.push(speakTask);
 
   const listenTask = await buildListenTask(
@@ -318,6 +318,7 @@ async function buildListenTask(
 }
 
 async function buildSpeakTask(
+  goal: DailyGoal,
   targetDifficulty: Difficulty | undefined,
   modulePriority: number,
   sessions: TypingSession[],
@@ -328,30 +329,35 @@ async function buildSpeakTask(
 
   for (const book of ALL_WORDBOOKS) {
     if (book.kind !== 'scenario') continue;
-    const count = await db.contents.where('category').equals(book.id).count();
-    if (count === 0) continue;
+    const bookContents = await db.contents.where('category').equals(book.id).toArray();
+    if (bookContents.length === 0) continue;
 
-    const practicedCount = sessions.reduce((sum, session) => {
-      if (session.module !== 'speak') return sum;
+    const practicedIds = new Set<string>();
+    for (const session of sessions) {
+      if (session.module !== 'speak') continue;
       const content = contentsById.get(session.contentId);
-      return content?.category === book.id ? sum + 1 : sum;
-    }, 0);
+      if (content?.category === book.id) practicedIds.add(session.contentId);
+    }
+
+    const unpracticedCount = bookContents.length - practicedIds.size;
+    const speakLimit = unpracticedCount > 0 ? Math.min(unpracticedCount, goal.sessionsPerDay) : goal.sessionsPerDay;
 
     candidates.push({
       task: {
         id: nanoid(),
         type: 'speak',
-        title: 'Speak practice',
+        title: `Practice ${speakLimit} scenarios`,
         description: book.nameEn,
         module: 'speak',
         bookId: book.id,
+        limit: speakLimit,
         completed: false,
         skipped: false,
       },
       score:
         modulePriority +
         difficultyFitScore(targetDifficulty, book.difficulty) +
-        Math.max(0, 3 - Math.min(practicedCount, 3)),
+        Math.max(0, 3 - Math.min(practicedIds.size, 3)),
       weeklyPriorityEligible: isWeeklyBalanceEligible(targetDifficulty, book.difficulty),
     });
   }

--- a/src/stores/daily-plan-store.ts
+++ b/src/stores/daily-plan-store.ts
@@ -16,6 +16,7 @@ export interface PlanTask {
   module: 'listen' | 'speak' | 'read' | 'write';
   contentId?: string;
   bookId?: string;
+  limit?: number;
   completed: boolean;
   skipped: boolean;
 }


### PR DESCRIPTION
## Summary

- Add translation (free Google Translate) and TTS audio playback to all word book practice modes (Listen/Speak/Read/Write)
- Add TTS "Listen" button to Write article practice page
- Add completion celebration with confetti animation (`canvas-confetti`) for all practice pages
- Add daily plan task limit support — word book practice shows only the daily target count, not the entire book
- Fix daily plan completion detection to count unique practiced items (not mark complete after 1 word)
- Add limit to Speak daily plan tasks (`sessionsPerDay`)
- Improve space error highlighting in write practice with visible `·` marker
- Add encouraging messages per module on session completion
- Bump version to v1.2.1

## Changes

| File | Change |
|------|--------|
| `practice-complete-banner.tsx` | New shared component: confetti + encouragement banner |
| `word-book-practice.tsx` | Translation, TTS, completion screen, limit support, space highlighting |
| `listen/[id]/page.tsx` | Completion banner after listening |
| `read/[id]/page.tsx` | Completion banner after read aloud |
| `write/[id]/page.tsx` | Confetti on completion, TTS button, encouraging message |
| `daily-plan.ts` | Speak task limit, improved word count title |
| `daily-plan-links.ts` | Pass `?limit=N` with fallback for old plans |
| `daily-plan-progress.ts` | Count-based completion detection for book tasks |

## Test plan

- [x] TypeScript type check passes
- [x] All 35 daily plan tests pass
- [ ] Verify confetti fires on completing a word book practice session
- [ ] Verify daily plan shows correct limited word count (e.g., 20/20 not 20/100)
- [ ] Verify translation appears below example sentences in word book practice
- [ ] Verify TTS buttons work for word title and example sentence
- [ ] Verify space errors show visible `·` marker with red background

🤖 Generated with [Claude Code](https://claude.com/claude-code)