### PR TITLE
fix: add Check for Updates button and fix version display

### DIFF
--- a/scripts/set-release-version.mjs
+++ b/scripts/set-release-version.mjs
@@ -22,6 +22,7 @@ const projectRoot = process.cwd();
 const packageJsonPath = path.join(projectRoot, 'package.json');
 const tauriConfigPath = path.join(projectRoot, 'src-tauri', 'tauri.conf.json');
 const cargoTomlPath = path.join(projectRoot, 'src-tauri', 'Cargo.toml');
+const versionTsPath = path.join(projectRoot, 'src', 'lib', 'version.ts');
 
 const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
 packageJson.version = normalizedVersion;
@@ -33,15 +34,19 @@ const cargoToml = fs
   .readFileSync(cargoTomlPath, 'utf8')
   .replace(/^version = ".*"$/m, `version = "${normalizedVersion}"`);
 
+const versionTs = `export const APP_VERSION = '${normalizedVersion}';\n`;
+
 if (dryRun) {
   console.log(`package.json -> ${normalizedVersion}`);
   console.log(`src-tauri/tauri.conf.json -> ${normalizedVersion}`);
   console.log(`src-tauri/Cargo.toml -> ${normalizedVersion}`);
+  console.log(`src/lib/version.ts -> ${normalizedVersion}`);
   process.exit(0);
 }
 
 fs.writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
 fs.writeFileSync(tauriConfigPath, `${JSON.stringify(tauriConfig, null, 2)}\n`);
 fs.writeFileSync(cargoTomlPath, cargoToml);
+fs.writeFileSync(versionTsPath, versionTs);
 
 console.log(`Release version synced to ${normalizedVersion}`);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -37,12 +37,20 @@ export default function LandingPage() {
           </div>
           <span className="text-xl font-bold text-indigo-900 font-[var(--font-poppins)]">EchoType</span>
         </div>
-        <Link
-          href="/dashboard"
-          className="px-6 py-2.5 bg-indigo-600 text-white rounded-lg font-medium hover:bg-indigo-700 transition-colors duration-200 cursor-pointer"
-        >
-          Start Learning
-        </Link>
+        <div className="flex items-center gap-3">
+          <Link
+            href="/login"
+            className="px-5 py-2.5 text-indigo-600 font-medium hover:bg-indigo-50 rounded-lg transition-colors duration-200 cursor-pointer"
+          >
+            Sign In
+          </Link>
+          <Link
+            href="/dashboard"
+            className="px-6 py-2.5 bg-indigo-600 text-white rounded-lg font-medium hover:bg-indigo-700 transition-colors duration-200 cursor-pointer"
+          >
+            Start Learning
+          </Link>
+        </div>
       </nav>
 
       <section className="max-w-4xl mx-auto text-center px-8 pt-20 pb-16">

--- a/src/components/settings/about-section.tsx
+++ b/src/components/settings/about-section.tsx
@@ -1,9 +1,11 @@
 'use client';
 
-import { AlertCircle, ExternalLink, Info, Zap } from 'lucide-react';
+import { AlertCircle, ExternalLink, Info, Loader2, RefreshCw, Zap } from 'lucide-react';
 import { Section } from '@/components/settings/section';
 import { Button } from '@/components/ui/button';
+import { IS_TAURI } from '@/lib/tauri';
 import { APP_VERSION } from '@/lib/version';
+import { useUpdaterStore } from '@/stores/updater-store';
 
 const INFO_ROWS = [
   { label: 'Application', value: 'EchoType' },
@@ -12,6 +14,54 @@ const INFO_ROWS = [
   { label: 'Data Storage', value: 'Local (IndexedDB) + Cloud Sync' },
   { label: 'Desktop', value: 'Tauri v2' },
 ];
+
+function UpdateButton() {
+  const status = useUpdaterStore((s) => s.status);
+  const error = useUpdaterStore((s) => s.error);
+  const newVersion = useUpdaterStore((s) => s.newVersion);
+  const { checkForUpdate, openDialog } = useUpdaterStore();
+
+  if (!IS_TAURI) return null;
+
+  if (status === 'checking') {
+    return (
+      <Button variant="outline" disabled className="w-full gap-2 text-sm">
+        <Loader2 className="w-3.5 h-3.5 animate-spin" />
+        Checking for updates...
+      </Button>
+    );
+  }
+
+  if (status === 'available' || status === 'downloading' || status === 'downloaded') {
+    return (
+      <Button className="w-full gap-2 text-sm bg-indigo-600 hover:bg-indigo-700 cursor-pointer" onClick={openDialog}>
+        <RefreshCw className="w-3.5 h-3.5" />
+        Update to v{newVersion}
+      </Button>
+    );
+  }
+
+  if (status === 'error') {
+    return (
+      <div className="space-y-2">
+        <Button variant="outline" className="w-full gap-2 text-sm cursor-pointer" onClick={() => void checkForUpdate()}>
+          <RefreshCw className="w-3.5 h-3.5" />
+          Retry Check
+        </Button>
+        <p className="text-xs text-red-500 text-center truncate" title={error}>
+          Update check failed
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <Button variant="outline" className="w-full gap-2 text-sm cursor-pointer" onClick={() => void checkForUpdate()}>
+      <RefreshCw className="w-3.5 h-3.5" />
+      Check for Updates
+    </Button>
+  );
+}
 
 export function AboutSection() {
   return (
@@ -39,6 +89,9 @@ export function AboutSection() {
             </div>
           ))}
         </div>
+
+        {/* Update button (desktop only) */}
+        <UpdateButton />
 
         {/* Links */}
         <div className="flex items-center gap-3">

--- a/src/components/updater/update-dialog.tsx
+++ b/src/components/updater/update-dialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ArrowDownCircle, Loader2, RotateCcw } from 'lucide-react';
+import { AlertCircle, ArrowDownCircle, Loader2, RotateCcw } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -13,11 +13,38 @@ import {
 import { useUpdaterStore } from '@/stores/updater-store';
 
 export function UpdateDialog() {
-  const { status, currentVersion, newVersion, changelog, downloadProgress, dialogOpen } = useUpdaterStore();
-  const { downloadUpdate, installUpdate, dismissUpdate, closeDialog } = useUpdaterStore();
+  const { status, currentVersion, newVersion, changelog, downloadProgress, error, dialogOpen } = useUpdaterStore();
+  const { downloadUpdate, installUpdate, dismissUpdate, closeDialog, checkForUpdate } = useUpdaterStore();
 
-  if (status !== 'available' && status !== 'downloading' && status !== 'downloaded') {
+  if (status !== 'available' && status !== 'downloading' && status !== 'downloaded' && status !== 'error') {
     return null;
+  }
+
+  // Error state
+  if (status === 'error') {
+    return (
+      <Dialog open={dialogOpen} onOpenChange={(open) => !open && closeDialog()}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <AlertCircle className="w-5 h-5 text-red-500" />
+              Update Failed
+            </DialogTitle>
+            <DialogDescription>Something went wrong while checking for updates.</DialogDescription>
+          </DialogHeader>
+          <div className="rounded-md bg-red-50 p-3 text-sm text-red-700 break-all">{error || 'Unknown error'}</div>
+          <DialogFooter>
+            <Button variant="outline" onClick={closeDialog}>
+              Close
+            </Button>
+            <Button onClick={() => void checkForUpdate()}>
+              <RotateCcw className="w-4 h-4 mr-1.5" />
+              Retry
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    );
   }
 
   // Downloaded state — restart prompt

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = '1.1.0';
+export const APP_VERSION = '1.2.1';


### PR DESCRIPTION
## Summary

- Fix `APP_VERSION` stuck at `1.1.0` — now correctly shows `1.2.1`
- Add `version.ts` to `set-release-version.mjs` so CI keeps it in sync automatically
- Add **Check for Updates** button to Settings About section (desktop only)
- Show error state in `UpdateDialog` with retry option (was silently hidden before)
- Show "Update to vX.Y.Z" button when an update is available

## Test plan

- [x] TypeScript type check passes
- [ ] Verify About section shows v1.2.1
- [ ] Verify "Check for Updates" button appears in desktop app Settings
- [ ] Verify update error state shows in dialog with retry option

🤖 Generated with [Claude Code](https://claude.com/claude-code)