### PR TITLE
Improve read practice feedback and layout

### DIFF
--- a/e2e/read.spec.ts
+++ b/e2e/read.spec.ts
@@ -1,0 +1,48 @@
+import { expect, test } from '@playwright/test';
+
+async function waitForSeedAndReload(page: import('@playwright/test').Page, url: string) {
+  await page.goto(url);
+  await page.waitForSelector('main[data-seeded="true"]', { timeout: 15000 });
+  await page.reload();
+  await page.waitForSelector('main[data-seeded="true"]', { timeout: 15000 });
+}
+
+test.describe('Read Module', () => {
+  async function openFirstReadDetail(page: import('@playwright/test').Page) {
+    await waitForSeedAndReload(page, '/read');
+    await page.getByRole('button', { name: /Sentence \(\d+\)/ }).click();
+
+    const detailLink = page.locator('a[href^="/read/"]:not([href*="/book/"])').first();
+    await expect(detailLink).toBeVisible({ timeout: 10000 });
+    await detailLink.click();
+    await expect(page).toHaveURL(/\/read\/(?!book\/).+/);
+  }
+
+  test('read list page loads with content', async ({ page }) => {
+    await waitForSeedAndReload(page, '/read');
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('Read');
+    await expect(page.getByText('Read English content aloud and get pronunciation feedback')).toBeVisible();
+
+    const items = page.locator('[class*="grid gap"] a');
+    await expect(items.first()).toBeVisible({ timeout: 10000 });
+  });
+
+  test('read detail page shows stable practice controls without transcript card', async ({ page }) => {
+    await openFirstReadDetail(page);
+
+    await expect(page.getByText('Reference Text')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Listen' })).toBeVisible();
+    await expect(page.getByText('Reset')).toBeVisible();
+    await expect(page.getByText('Read Aloud Mode')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Your Speech' })).toHaveCount(0);
+    await expect(page.getByRole('heading', { name: 'Live Reading Feedback' })).toHaveCount(0);
+    await expect(page.getByRole('heading', { name: 'Your Results' })).toHaveCount(0);
+  });
+
+  test('read detail back button returns to list', async ({ page }) => {
+    await openFirstReadDetail(page);
+
+    await page.locator('a[href="/read"]').first().click();
+    await expect(page).toHaveURL(/\/read$/);
+  });
+});

--- a/src/app/(app)/read/[id]/page.tsx
+++ b/src/app/(app)/read/[id]/page.tsx
@@ -7,6 +7,7 @@ import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { flushSync } from 'react-dom';
+import { LiveReadingFeedback } from '@/components/read/live-reading-feedback';
 import { FormattedContentText } from '@/components/shared/formatted-content-text';
 import { PracticeCompleteBanner } from '@/components/shared/practice-complete-banner';
 import { RecommendationPanel } from '@/components/shared/recommendation-panel';
@@ -24,7 +25,12 @@ import { useTTS } from '@/hooks/use-tts';
 import { type ContentBlock, splitContentBlocks } from '@/lib/content-format';
 import { savePracticeSession } from '@/lib/daily-plan-progress';
 import { db } from '@/lib/db';
-import { compareWords, type WordResult } from '@/lib/levenshtein';
+import {
+  buildProgressiveWordResults,
+  compareWords,
+  type ProgressiveWordResult,
+  type WordResult,
+} from '@/lib/levenshtein';
 import { matchesShortcutEvent } from '@/lib/shortcut-utils';
 import { IS_TAURI } from '@/lib/tauri';
 import { useContentStore } from '@/stores/content-store';
@@ -32,6 +38,11 @@ import { usePracticeTranslationStore } from '@/stores/practice-translation-store
 import { useShortcutStore } from '@/stores/shortcut-store';
 import { useTTSStore } from '@/stores/tts-store';
 import type { ContentItem } from '@/types/content';
+
+type ReadPracticePhase = 'idle' | 'listening' | 'processing' | 'completed';
+type LiveFeedbackResult = ProgressiveWordResult & {
+  provisional?: boolean;
+};
 
 export default function ReadDetailPage() {
   const params = useParams();
@@ -103,6 +114,17 @@ export default function ReadDetailPage() {
     return grouped;
   }, [content?.text, sentenceTranslations]);
 
+  const referenceWords = useMemo(
+    () =>
+      content?.text
+        ? content.text
+            .split(/\s+/)
+            .map((word) => word.replace(/[^a-zA-Z']/g, ''))
+            .filter(Boolean)
+        : [],
+    [content?.text],
+  );
+
   useEffect(() => {
     if (showTranslation && content?.text) fetchTranslation();
   }, [showTranslation, content?.text, fetchTranslation]);
@@ -149,6 +171,42 @@ export default function ReadDetailPage() {
 
   const [speechError, setSpeechError] = useState<string | null>(null);
   const [isFallbackTranscribing, setIsFallbackTranscribing] = useState(false);
+  const phase: ReadPracticePhase = results
+    ? 'completed'
+    : isFallbackTranscribing
+      ? 'processing'
+      : isListening
+        ? 'listening'
+        : 'idle';
+
+  const liveResults = useMemo<LiveFeedbackResult[] | null>(() => {
+    if (phase !== 'listening' || referenceWords.length === 0) return null;
+
+    const finalWords = transcript
+      .split(/\s+/)
+      .map((word) => word.replace(/[^a-zA-Z']/g, ''))
+      .filter(Boolean);
+    const interimWords = interimTranscript
+      .split(/\s+/)
+      .map((word) => word.replace(/[^a-zA-Z']/g, ''))
+      .filter(Boolean);
+
+    if (finalWords.length === 0 && interimWords.length === 0) {
+      return referenceWords.map((word) => ({
+        word,
+        accuracy: 'pending',
+        similarity: 0,
+      }));
+    }
+
+    const combinedWords = [...finalWords, ...interimWords];
+
+    return buildProgressiveWordResults(referenceWords, combinedWords).map((result, index) => ({
+      ...result,
+      provisional:
+        result.accuracy !== 'pending' && index >= finalWords.length && index < finalWords.length + interimWords.length,
+    }));
+  }, [interimTranscript, phase, referenceWords, transcript]);
 
   // Fallback STT for Tauri / browsers without SpeechRecognition
   const fallbackSTT = useFallbackSTT({
@@ -352,7 +410,7 @@ export default function ReadDetailPage() {
   }
 
   return (
-    <div className="max-w-4xl mx-auto flex flex-col h-[calc(100vh-8rem)] md:h-[calc(100vh-4rem)]">
+    <div className="max-w-4xl mx-auto flex flex-col gap-4 pb-6">
       <div className="flex items-center gap-3 md:gap-4 py-3 md:py-4 shrink-0">
         <Link href="/read">
           <Button variant="ghost" size="icon" className="text-indigo-600 cursor-pointer">
@@ -367,8 +425,8 @@ export default function ReadDetailPage() {
         </div>
       </div>
 
-      <Card className="bg-white border-slate-100 shadow-sm flex flex-col flex-1 min-h-0">
-        <CardContent className="p-4 md:p-6 flex flex-col h-full">
+      <Card className="bg-white border-slate-100 shadow-sm shrink-0">
+        <CardContent className="p-4 md:p-6">
           <div className="flex items-center justify-between mb-4 shrink-0 gap-2">
             <h3 className="font-semibold text-indigo-900 shrink-0">Reference Text</h3>
             <div className="flex items-center gap-1 md:gap-2">
@@ -384,7 +442,7 @@ export default function ReadDetailPage() {
               </Button>
             </div>
           </div>
-          <div className="flex-1 overflow-y-auto pr-2 scrollbar-thin scrollbar-thumb-indigo-200 scrollbar-track-transparent">
+          <div className="min-h-[18rem] max-h-[24rem] overflow-y-auto pr-2 scrollbar-thin scrollbar-thumb-indigo-200 scrollbar-track-transparent md:min-h-[22rem] md:max-h-[30rem]">
             {showTranslation && sentenceTranslations && sentenceTranslations.length > 0 ? (
               <div className="space-y-4">
                 {translatedBlocks.map(({ block, translations }) => (
@@ -435,7 +493,7 @@ export default function ReadDetailPage() {
         </CardContent>
       </Card>
 
-      <div className="flex flex-col items-center gap-2 py-4 shrink-0">
+      <div className="flex flex-col items-center gap-2 py-2 shrink-0">
         <div className="flex items-center justify-center gap-4">
           <motion.div
             animate={isListening ? { scale: [1, 1.08, 1] } : {}}
@@ -471,32 +529,13 @@ export default function ReadDetailPage() {
           </Button>
         </div>
         {speechError && <p className="text-xs text-red-500 text-center max-w-md">{speechError}</p>}
-        {isFallbackTranscribing && <p className="text-xs text-amber-600 font-medium">Processing your speech...</p>}
+        {phase === 'processing' && <p className="text-xs text-amber-600 font-medium">Processing your speech...</p>}
       </div>
 
-      <AnimatePresence>
-        {(transcript || interimTranscript) && !results && (
-          <motion.div
-            initial={{ opacity: 0, y: 12 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0, y: -8 }}
-            transition={{ duration: 0.25 }}
-          >
-            <Card className="bg-white border-slate-100 shadow-sm">
-              <CardContent className="p-6">
-                <h3 className="font-semibold text-indigo-900 mb-3">Your Speech</h3>
-                <p className="text-lg leading-relaxed">
-                  <span className="text-indigo-800">{transcript}</span>
-                  {interimTranscript && <span className="text-indigo-400 italic"> {interimTranscript}</span>}
-                </p>
-              </CardContent>
-            </Card>
-          </motion.div>
-        )}
-      </AnimatePresence>
+      {phase === 'listening' && liveResults && <LiveReadingFeedback results={liveResults} />}
 
       <AnimatePresence>
-        {results && (
+        {phase === 'completed' && results && (
           <motion.div
             initial={{ opacity: 0, y: 16 }}
             animate={{ opacity: 1, y: 0 }}

--- a/src/components/read/live-reading-feedback.tsx
+++ b/src/components/read/live-reading-feedback.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import type { ProgressiveWordResult } from '@/lib/levenshtein';
+
+type LiveFeedbackWord = ProgressiveWordResult & {
+  provisional?: boolean;
+};
+
+interface LiveReadingFeedbackProps {
+  results: LiveFeedbackWord[];
+}
+
+const badgeStyles: Record<
+  ProgressiveWordResult['accuracy'],
+  {
+    container: string;
+    text: string;
+    label: string;
+  }
+> = {
+  correct: {
+    container: 'border-green-200 bg-green-50/90',
+    text: 'text-green-700',
+    label: 'Correct',
+  },
+  close: {
+    container: 'border-amber-200 bg-amber-50/90',
+    text: 'text-amber-700',
+    label: 'Close',
+  },
+  wrong: {
+    container: 'border-red-200 bg-red-50/90',
+    text: 'text-red-700',
+    label: 'Try again',
+  },
+  missing: {
+    container: 'border-slate-200 bg-slate-50/90',
+    text: 'text-slate-400',
+    label: 'Missed',
+  },
+  extra: {
+    container: 'border-fuchsia-200 bg-fuchsia-50/90',
+    text: 'text-fuchsia-700',
+    label: 'Extra',
+  },
+  pending: {
+    container: 'border-slate-200 bg-white/80',
+    text: 'text-slate-400',
+    label: 'Pending',
+  },
+};
+
+export function LiveReadingFeedback({ results }: LiveReadingFeedbackProps) {
+  const spokenCount = results.filter((result) => result.accuracy !== 'pending').length;
+  const issueCount = results.filter((result) => result.accuracy === 'wrong' || result.accuracy === 'close').length;
+
+  return (
+    <div className="rounded-2xl border border-indigo-100/80 bg-white/75 p-4 shadow-sm backdrop-blur-sm">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <h3 className="text-sm font-semibold text-indigo-900">Live Reading Feedback</h3>
+          <p className="text-xs text-indigo-500">
+            {spokenCount === 0
+              ? 'Start reading. Feedback will appear as words are recognized.'
+              : `${spokenCount} words processed${issueCount > 0 ? ` · ${issueCount} to revisit` : ''}`}
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2 text-[11px] text-indigo-400">
+          <span className="inline-flex items-center gap-1">
+            <span className="h-2 w-2 rounded-full bg-green-400" />
+            Correct
+          </span>
+          <span className="inline-flex items-center gap-1">
+            <span className="h-2 w-2 rounded-full bg-amber-400" />
+            Close
+          </span>
+          <span className="inline-flex items-center gap-1">
+            <span className="h-2 w-2 rounded-full bg-red-400" />
+            Retry
+          </span>
+        </div>
+      </div>
+
+      <div className="mt-3 max-h-40 overflow-y-auto pr-1">
+        <div className="flex flex-wrap gap-1.5">
+          {results.map((result, index) => {
+            const style = badgeStyles[result.accuracy];
+
+            return (
+              <span
+                key={`${result.word}-${index}`}
+                className={`inline-flex items-center rounded-lg border px-2.5 py-1 text-sm transition-colors ${
+                  style.container
+                } ${style.text} ${result.provisional ? 'border-dashed opacity-75' : ''}`}
+                title={result.hint || style.label}
+              >
+                {result.word}
+              </span>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/levenshtein-progressive.test.ts
+++ b/src/lib/levenshtein-progressive.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { buildProgressiveWordResults } from './levenshtein';
+
+describe('buildProgressiveWordResults', () => {
+  it('only scores the consumed prefix and leaves unread words pending', () => {
+    const results = buildProgressiveWordResults(['My', 'best', 'friend', 'is'], ['My', 'best']);
+
+    expect(results.map((result) => result.accuracy)).toEqual(['correct', 'correct', 'pending', 'pending']);
+  });
+
+  it('keeps close and wrong states aligned with compareWords semantics', () => {
+    const results = buildProgressiveWordResults(['Sarah', 'rides'], ['Sara', 'x']);
+
+    expect(results[0].accuracy).toBe('close');
+    expect(results[1].accuracy).toBe('wrong');
+  });
+});

--- a/src/lib/levenshtein.ts
+++ b/src/lib/levenshtein.ts
@@ -34,6 +34,16 @@ export interface WordResult {
   hint?: string;
 }
 
+export type ProgressiveWordAccuracy = WordAccuracy | 'pending';
+
+export interface ProgressiveWordResult {
+  word: string;
+  accuracy: ProgressiveWordAccuracy;
+  recognized?: string;
+  similarity: number;
+  hint?: string;
+}
+
 /**
  * Align two word arrays using Needleman-Wunsch (global sequence alignment).
  * Returns aligned pairs where gaps are represented as null.
@@ -169,6 +179,25 @@ export function compareWords(original: string[], recognized: string[]): WordResu
       hint: getHint(accuracy, orig, rec),
     };
   });
+}
+
+/**
+ * Compare only the portion of the passage that has been read so far.
+ * Unread words remain pending so live feedback stays forward-looking.
+ */
+export function buildProgressiveWordResults(original: string[], recognized: string[]): ProgressiveWordResult[] {
+  const consumedCount = Math.min(original.length, recognized.length);
+  const consumedOriginal = original.slice(0, consumedCount);
+  const consumedRecognized = recognized.slice(0, consumedCount);
+
+  const consumedResults = compareWords(consumedOriginal, consumedRecognized);
+  const pendingResults = original.slice(consumedCount).map((word) => ({
+    word,
+    accuracy: 'pending' as const,
+    similarity: 0,
+  }));
+
+  return [...consumedResults, ...pendingResults];
 }
 
 /**


### PR DESCRIPTION
## Summary
- remove the transient in-progress transcript card from Read detail
- keep the reference text viewport at a stable height with internal scrolling
- add progressive live word feedback during read-aloud practice and cover it with tests

## Testing
- pnpm exec vitest run src/lib/levenshtein-progressive.test.ts
- pnpm exec playwright test e2e/read.spec.ts
- pnpm lint
- pnpm typecheck