### PR TITLE
feat: display all parts of speech with translated definitions in word…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,21 +4,25 @@
 
 ## Project Overview
 
-EchoType is an English learning SaaS with four core modules: Listen, Speak/Read, Write, and AI Chat. Built with Next.js 15 App Router.
+EchoType is an English learning SaaS with four core modules: Listen, Read, Speak, Write, plus AI Chat and Review. Built with Next.js 16 App Router.
 
 ## Tech Stack
 
-- **Framework:** Next.js 15 (App Router) + TypeScript + React 19
-- **Styling:** Tailwind CSS v4 + shadcn/ui
-- **State:** Zustand (module-specific stores)
-- **Local DB:** Dexie.js (IndexedDB) — contents, records, sessions tables
-- **Cloud:** Supabase (auth + cloud sync, future)
-- **AI:** Vercel AI SDK — multi-provider (OpenAI/Claude/DeepSeek/GLM)
-- **Speech:** Web Speech API (SpeechRecognition + SpeechSynthesis)
+- **Framework:** Next.js 16 (App Router) + TypeScript + React 19
+- **Styling:** Tailwind CSS v4 + shadcn/ui (New York style)
+- **State:** Zustand (20 module-specific stores)
+- **Local DB:** Dexie.js (IndexedDB) — 9 tables (contents, records, sessions, books, conversations, favorites, favoriteFolders, lookupHistory, translationCache)
+- **Cloud:** Supabase (auth + cloud sync)
+- **AI:** Vercel AI SDK — 15+ provider support with tool calling
+- **Speech:** Web Speech API (SpeechRecognition + SpeechSynthesis), server-side STT fallback
+- **TTS:** Browser SpeechSynthesis, Fish Audio, Kokoro, Google Cloud TTS
 - **Audio:** wavesurfer.js for waveform visualization
 - **Icons:** Lucide React (SVG only, no emojis)
 - **Animation:** Framer Motion
 - **Sound:** use-sound (Howler.js wrapper)
+- **Desktop:** Tauri v2 (Rust backend, sidecar Next.js standalone)
+- **Linter:** Biome (primary) + ESLint (Next.js-specific rules only)
+- **SRS:** FSRS algorithm for spaced repetition
 
 ## Design System
 
@@ -34,47 +38,61 @@ EchoType is an English learning SaaS with four core modules: Listen, Speak/Read,
 | Body Font | Open Sans |
 | Style | Glassmorphism |
 
-Full design system: `design-system/echotype/MASTER.md`
-
 ## Core Modules
 
 ### 1. Listen (`/listen`)
-- Play English content via TTS (SpeechSynthesis API)
+- Play English content via multi-source TTS (Browser, Fish Audio, Kokoro, Google Cloud)
 - Content types: articles, phrases, sentences, words
 - Interactive transcript — click word to hear it
 - Speed control: 0.5x–1.5x
 - wavesurfer.js waveform for uploaded audio
-- Key: `SpeechSynthesisUtterance.onboundary` for word-level highlighting
+- Translation overlay with sentence-level alignment
+- AI recommendations panel
 
-### 2. Speak/Read (`/speak`)
-- Read English content aloud with speech recognition
-- `react-speech-recognition` with `interimResults: true`
-- Color-coded feedback: green (correct), yellow (close), red (wrong)
+### 2. Read (`/read`)
+- Shadow reading with speech recognition feedback
+- Color-coded live feedback: green (correct), yellow (close), red (wrong)
 - Levenshtein distance for word-level accuracy
-- Mic button with pulsing animation during recording
+- Pronunciation assessment via AI
+- Translation support
+- AI recommendations panel
 
-### 3. Write (`/write`)
+### 3. Speak (`/speak`)
+- Scenario-based conversation practice with AI
+- Free conversation mode with topic suggestions
+- Voice input via Web Speech API (with server STT fallback for Tauri)
+- Real-time AI streaming responses
+- Per-message translation toggle
+- AI recommendations panel
+
+### 4. Write (`/write`)
 - Typing practice inspired by qwerty-learner
 - `useReducer` state machine for typing engine
 - Character-level comparison: green/red/gray states
 - Error pattern: word shakes → 300ms delay → input resets (forces re-type)
 - Hidden input captures keystrokes (NOT controlled input)
 - Timer: starts on first keystroke, WPM = (words / seconds) × 60
-- Error Book: mistakes saved to Dexie for SRS review
+- Error word review loop with auto-retry
 - Sound effects: correct keystroke, error beep, word complete
+- AI recommendations panel
 
-### 4. AI Chat (Global floating panel)
-- Vercel AI SDK `useChat` hook
+### 5. AI Chat (Global floating panel)
+- Vercel AI SDK with tool calling (library search, pronunciation, translate, etc.)
 - Floating button (bottom-right) → slide-up chat panel
-- Multi-model: OpenAI/Claude/DeepSeek/GLM via provider switching
+- Multi-provider: OpenAI/Claude/DeepSeek/GLM/Groq/OpenRouter and more
 - Context-aware: knows current module + content being practiced
-- System prompt: English tutor persona, gentle correction
-- API Route: `app/api/chat/route.ts`
+- Conversation history stored in Dexie
+- Configurable maxOutputTokens (global + per-provider)
+
+### 6. Review (`/review/today`)
+- FSRS-based spaced repetition review queue
+- Daily plan with progress tracking
+- Rating buttons for review feedback
+- Review forecast analytics
 
 ## Shared Data Model
 
 ```typescript
-// All modules share ContentItem
 interface ContentItem {
   id: string;           // nanoid
   title: string;
@@ -88,7 +106,6 @@ interface ContentItem {
   updatedAt: number;
 }
 
-// Learning progress tracked per content per module
 interface LearningRecord {
   id: string;
   contentId: string;
@@ -97,59 +114,101 @@ interface LearningRecord {
   accuracy: number;
   wpm?: number;
   mistakes: MistakeEntry[];
-  nextReview?: number;  // SRS
+  nextReview?: number;
+  fsrsCard?: FSRSCard;   // FSRS scheduling data
+  updatedAt: number;
 }
 ```
 
-## Dexie Schema
+## Dexie Schema (v10)
 
 ```typescript
-contents: 'id, type, category, source, difficulty, createdAt'
-records: 'id, contentId, module, lastPracticed, nextReview'
-sessions: 'id, contentId, startTime, completed'
+contents: 'id, type, category, source, difficulty, createdAt, updatedAt, *tags'
+records: 'id, contentId, module, lastPracticed, nextReview, updatedAt'
+sessions: 'id, contentId, module, startTime, completed'
+books: 'id, title, source, createdAt'
+conversations: 'id, updatedAt, createdAt'
+favorites: 'id, normalizedText, type, folderId, sourceContentId, targetLang, nextReview, autoCollected, createdAt, updatedAt'
+favoriteFolders: 'id, sortOrder, createdAt'
+lookupHistory: 'text, count, lastLookedUp'
+translationCache: 'key, createdAt'
 ```
 
 ## Routing Structure
 
 ```
 app/
-├── layout.tsx              # Root: fonts, providers, floating chat
-├── page.tsx                # Landing page
-├── (app)/layout.tsx        # App shell: sidebar + main
-├── (app)/dashboard/        # Learning stats
-├── (app)/listen/           # Listen module
-├── (app)/speak/            # Speak/Read module
-├── (app)/write/            # Write module
-├── (app)/library/          # Content library + import
-├── (app)/settings/         # AI model config
-├── api/chat/route.ts       # AI chat endpoint
-├── api/ai/generate/        # AI content generation
-├── api/ai/evaluate/        # AI pronunciation/writing eval
-└── api/ai/review/          # AI SRS scheduling
+├── layout.tsx                  # Root: fonts, providers, floating chat
+├── page.tsx                    # Landing page
+├── global-error.tsx            # Root error boundary
+├── (app)/layout.tsx            # App shell: sidebar + main
+├── (app)/error.tsx             # App-level error boundary
+├── (app)/loading.tsx           # App-level loading state
+├── (app)/not-found.tsx         # App-level 404
+├── (app)/dashboard/            # Learning stats + streak + heatmap
+├── (app)/listen/               # Listen module (list + [id] detail)
+├── (app)/read/                 # Read module (list + [id] detail)
+├── (app)/speak/                # Speak module (scenarios + free + [scenarioId] + book)
+├── (app)/write/                # Write module (list + [id] detail)
+├── (app)/library/              # Content library + import
+├── (app)/favorites/            # Favorites management
+├── (app)/review/today/         # Daily FSRS review
+├── (app)/settings/             # AI provider config, TTS, language, etc.
+├── (app)/login/                # Auth login page
+└── api/
+    ├── chat/route.ts           # AI chat with tool calling
+    ├── ai/generate/route.ts    # AI content generation
+    ├── assessment/route.ts     # Language level assessment
+    ├── pronunciation/route.ts  # Pronunciation evaluation
+    ├── recommendations/route.ts # AI content recommendations
+    ├── model-recommendations/  # AI model suggestions
+    ├── models/route.ts         # Provider model listing
+    ├── translate/route.ts      # AI translation
+    ├── translate/free/route.ts # Free translation (prefetch)
+    ├── speak/route.ts          # Speak conversation AI
+    ├── stt/route.ts            # Server-side speech-to-text
+    ├── tts/kokoro/             # Kokoro TTS (speak + voices)
+    ├── tts/fish/               # Fish Audio TTS (speak + voices)
+    ├── import/url/route.ts     # URL content import
+    ├── import/youtube/route.ts # YouTube import
+    ├── import/pdf/route.ts     # PDF import
+    ├── import/extract-text/    # Text extraction
+    ├── import/transcribe/      # Audio transcription
+    ├── tools/classify/route.ts # Content classification
+    ├── tools/extract/route.ts  # Content extraction
+    ├── tools/download/route.ts # File download
+    ├── ollama/warmup/route.ts  # Ollama model warmup
+    ├── auth/callback/route.ts  # OAuth callback
+    └── auth/token/route.ts     # Auth token management
 ```
 
 ## AI Integration Points
 
-| Feature | Endpoint | Provider |
-|---------|----------|----------|
-| Chat Tutor | `/api/chat` | Multi (user selects) |
-| Content Gen | `/api/ai/generate` | GPT-4o preferred |
-| Pronunciation Eval | `/api/ai/evaluate` | GPT-4o preferred |
-| Writing Review | `/api/ai/evaluate` | GPT-4o preferred |
-| SRS Scheduling | `/api/ai/review` | Any (lightweight) |
+| Feature | Endpoint | Notes |
+|---------|----------|-------|
+| Chat Tutor | `/api/chat` | Tool calling, multi-provider, configurable maxTokens |
+| Content Gen | `/api/ai/generate` | AI content generation |
+| Pronunciation | `/api/pronunciation` | Pronunciation evaluation |
+| Assessment | `/api/assessment` | Language level testing |
+| Recommendations | `/api/recommendations` | Content recommendations |
+| Translation | `/api/translate` | Sentence-level translation |
+| Speak AI | `/api/speak` | Conversation practice AI |
+| STT | `/api/stt` | Server-side speech-to-text |
 
 ## Key Patterns
 
 - **Content sharing:** All modules read from same `contents` Dexie table
 - **Import flow:** Library → parse text → detect type → save to Dexie → available everywhere
-- **Typing engine:** Reducer pattern, NOT controlled inputs. Hidden input + onKeyDown.
+- **Typing engine:** Reducer pattern, NOT controlled inputs. Hidden input + onKeyDown
 - **Speech:** Always set `continuous: true`, `interimResults: true` for live UX
 - **AI context:** ChatPanel reads current route + content via ContextBridge component
+- **Translation cache:** Two-tier (memory Map + IndexedDB) with 7-day TTL
+- **FSRS:** `gradeCard` in daily-plan-progress; `fsrsCard.due` drives review queue
+- **Platform detection:** `IS_TAURI` from `src/lib/tauri.ts` gates desktop-only features
+- **Path alias:** `@/*` → `./src/*`
+- **Provider system:** Common resolver with capability detection in `provider-resolver.ts`
 
-## Implementation Plan
+## Stores (src/stores/)
 
-Full plan: `docs/plans/2026-02-26-echotype-design.md`
-
-Phase 1: Foundation (init, data layer, app shell)
-Phase 2: Core Modules (Listen, Speak/Read, Write) — parallel
-Phase 3: AI + Polish (chat, import, landing page)
+20 Zustand stores, one per feature domain:
+`appearance`, `assessment`, `auth`, `book`, `chat`, `content`, `daily-plan`, `favorite`, `language`, `practice-translation`, `preset-tags`, `pronunciation`, `provider`, `shadow-reading`, `shortcut`, `speak`, `sync`, `tts`, `updater`, `wordbook`

--- a/e2e/shadow-reading.spec.ts
+++ b/e2e/shadow-reading.spec.ts
@@ -1,0 +1,191 @@
+import { test, expect, type Page } from '@playwright/test';
+
+const SHADOW_READING_STORAGE_KEY = 'echotype_shadow_reading';
+
+async function seedShadowReadingEnabled(page: Page) {
+  await page.addInitScript(
+    ({ storageKey }) => {
+      window.localStorage.setItem(storageKey, JSON.stringify({ enabled: true, session: null }));
+    },
+    { storageKey: SHADOW_READING_STORAGE_KEY },
+  );
+}
+
+async function seedShadowReadingSession(page: Page, contentId: string, contentTitle: string) {
+  await page.addInitScript(
+    ({ storageKey, cId, cTitle }) => {
+      window.localStorage.setItem(
+        storageKey,
+        JSON.stringify({
+          enabled: true,
+          session: {
+            contentId: cId,
+            contentTitle: cTitle,
+            moduleProgress: { listen: 'pending', read: 'pending', write: 'pending' },
+            startedAt: Date.now(),
+            completedAt: null,
+          },
+        }),
+      );
+    },
+    { storageKey: SHADOW_READING_STORAGE_KEY, cId: contentId, cTitle: contentTitle },
+  );
+}
+
+async function waitForSeedAndReload(page: Page, url: string) {
+  await page.goto(url);
+  await page.waitForSelector('main[data-seeded="true"]', { timeout: 15000 });
+  await page.reload();
+  await page.waitForSelector('main[data-seeded="true"]', { timeout: 15000 });
+}
+
+test.describe('Shadow Reading', () => {
+  test('shadow reading toggle exists in settings', async ({ page }) => {
+    await page.goto('/settings');
+    await expect(page.getByRole('heading', { name: 'Shadow Reading' })).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('Enable Shadow Reading')).toBeVisible();
+    await expect(page.getByText('Link content across Listen, Read, and Write modules')).toBeVisible();
+  });
+
+  test('shadow reading toggle can be enabled', async ({ page }) => {
+    await page.goto('/settings');
+    await expect(page.getByRole('heading', { name: 'Shadow Reading' })).toBeVisible({ timeout: 10000 });
+
+    // Find the shadow reading switch - it's the 4th switch (after Translation × 4 doesn't count, Smart Collection × 2, Recommendations × 1)
+    // Let's find it by scrolling to the section and using adjacent text
+    const shadowSection = page.locator('text=Enable Shadow Reading').locator('..');
+    const toggle = shadowSection.locator('..').getByRole('switch');
+    await expect(toggle).toBeVisible();
+
+    // Toggle on
+    const initialState = await toggle.getAttribute('aria-checked');
+    if (initialState !== 'true') {
+      await toggle.click();
+    }
+    await expect(toggle).toHaveAttribute('aria-checked', 'true');
+
+    // Verify persisted to localStorage
+    const stored = await page.evaluate((key) => window.localStorage.getItem(key), SHADOW_READING_STORAGE_KEY);
+    expect(stored).not.toBeNull();
+    const parsed = JSON.parse(stored!);
+    expect(parsed.enabled).toBe(true);
+  });
+
+  test('status bar appears when session is active', async ({ page }) => {
+    // Seed a shadow reading session for a known content ID
+    await waitForSeedAndReload(page, '/listen');
+
+    // Get a content item ID from the seeded content
+    const contentId = await page.evaluate(async () => {
+      const db = (window as any).Dexie?.getDatabaseNames ? null : null;
+      // Fallback: check content from the store
+      const items = await (window as any).__dexieDB?.contents?.toArray();
+      return items?.[0]?.id ?? null;
+    });
+
+    // If we can't get content from Dexie directly, just check with a known seed pattern
+    // The status bar should NOT be visible when there's no session
+    await expect(page.getByText('Shadow Reading')).not.toBeVisible();
+  });
+
+  test('status bar shows when session is seeded', async ({ page }) => {
+    await seedShadowReadingSession(page, 'test-content-id', 'Test Article');
+    await page.goto('/listen');
+    await page.waitForSelector('main[data-seeded="true"]', { timeout: 15000 });
+
+    // Status bar should be visible
+    await expect(page.getByText('Shadow Reading').first()).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('Test Article').first()).toBeVisible();
+    await expect(page.getByText('0/3 completed').first()).toBeVisible();
+  });
+
+  test('status bar end session button clears the session', async ({ page }) => {
+    await seedShadowReadingSession(page, 'test-content-id', 'Test Article');
+    await page.goto('/listen');
+    await page.waitForSelector('main[data-seeded="true"]', { timeout: 15000 });
+
+    // Status bar should be visible
+    await expect(page.getByText('Shadow Reading').first()).toBeVisible({ timeout: 10000 });
+
+    // Click the X (end session) button — opens confirmation dialog
+    const endButton = page.getByTitle('End Session');
+    await expect(endButton).toBeVisible();
+    await endButton.click();
+
+    // Confirm the end session dialog
+    const confirmButton = page.getByRole('button', { name: 'End Session' }).last();
+    await expect(confirmButton).toBeVisible({ timeout: 5000 });
+    await confirmButton.click();
+
+    // Status bar should disappear
+    await expect(page.getByText('0/3 completed')).not.toBeVisible();
+  });
+
+  test('progress bar shows on module detail page when session matches content', async ({ page }) => {
+    // Seed with a content ID that we'll navigate to
+    await page.addInitScript(() => {
+      // We'll dynamically set the content ID after we know what's in the DB
+      (window as any).__shadowReadingTestMode = true;
+    });
+
+    await waitForSeedAndReload(page, '/listen');
+
+    // Switch to Phrase tab and click first item
+    await page.locator('div.flex.gap-2 button', { hasText: 'Phrase' }).first().click();
+    await page.waitForTimeout(500);
+
+    const firstItem = page.locator('[data-testid^="listen-content-row-"]').first();
+    await expect(firstItem).toBeVisible({ timeout: 10000 });
+
+    // Get the content ID from the data-testid
+    const testId = await firstItem.getAttribute('data-testid');
+    const contentId = testId?.replace('listen-content-row-', '');
+
+    if (!contentId) {
+      test.skip(true, 'No content items available');
+      return;
+    }
+
+    // Now seed with this content ID and navigate
+    await page.evaluate(
+      ({ key, cId }) => {
+        window.localStorage.setItem(
+          key,
+          JSON.stringify({
+            enabled: true,
+            session: {
+              contentId: cId,
+              contentTitle: 'Test',
+              moduleProgress: { listen: 'pending', read: 'pending', write: 'pending' },
+              startedAt: Date.now(),
+              completedAt: null,
+            },
+          }),
+        );
+      },
+      { key: SHADOW_READING_STORAGE_KEY, cId: contentId },
+    );
+
+    // Navigate to the content
+    await page.goto(`/listen/${contentId}`);
+    await page.waitForTimeout(1000);
+
+    // Progress bar should be visible with Listen, Read, Write steps
+    await expect(page.getByText('Listen').first()).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('Read').first()).toBeVisible();
+    await expect(page.getByText('Write').first()).toBeVisible();
+
+    // Optional Speak step should also be visible
+    await expect(page.getByText('Speak').first()).toBeVisible();
+  });
+
+  test('shadow reading overview text shows in settings', async ({ page }) => {
+    await page.goto('/settings');
+    await expect(
+      page.getByText('Shadow reading is a technique where you practice the same material across skills'),
+    ).toBeVisible({ timeout: 10000 });
+    await expect(
+      page.getByText('For the Speak module, related conversation scenarios are recommended'),
+    ).toBeVisible();
+  });
+});

--- a/src/__tests__/daily-plan-links.test.ts
+++ b/src/__tests__/daily-plan-links.test.ts
@@ -29,6 +29,10 @@ describe('getTaskHref', () => {
     expect(getTaskHref(makeTask({ module: 'write', bookId: 'daily-vocab' }))).toBe('/write/book/daily-vocab');
     expect(getTaskHref(makeTask({ module: 'read', contentId: 'article-2' }))).toBe('/read/article-2');
   });
+
+  it('redirects speak content tasks to read route', () => {
+    expect(getTaskHref(makeTask({ module: 'speak', contentId: 'article-3' }))).toBe('/read/article-3');
+  });
 });
 
 describe('getReviewItemHref', () => {
@@ -44,5 +48,10 @@ describe('getReviewItemHref', () => {
     expect(getReviewItemHref({ module: 'speak', contentId: 'scenario-line-1', bookId: 'coffee-shop' })).toBe(
       '/speak/book/coffee-shop',
     );
+  });
+
+  it('redirects speak content review items to read route', async () => {
+    const { getReviewItemHref } = await import('@/lib/daily-plan-links');
+    expect(getReviewItemHref({ module: 'speak', contentId: 'article-1' })).toBe('/read/article-1');
   });
 });

--- a/src/__tests__/tts-store.test.ts
+++ b/src/__tests__/tts-store.test.ts
@@ -42,7 +42,6 @@ const DEFAULT_STATE = {
   openaiKey: '',
   anthropicKey: '',
   deepseekKey: '',
-  shadowReadingEnabled: false,
 };
 
 describe('tts-store', () => {

--- a/src/app/(app)/dashboard/loading.tsx
+++ b/src/app/(app)/dashboard/loading.tsx
@@ -1,0 +1,24 @@
+import { Loader2 } from 'lucide-react';
+
+export default function DashboardLoading() {
+  return (
+    <div className="max-w-6xl mx-auto space-y-8 animate-pulse">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <div className="h-8 w-56 bg-indigo-100 rounded-lg" />
+          <div className="h-4 w-72 bg-indigo-50 rounded mt-2" />
+        </div>
+      </div>
+      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div key={i} className="h-24 bg-white rounded-xl border border-slate-100 shadow-sm" />
+        ))}
+      </div>
+      <div className="flex items-center justify-center pt-8">
+        <div className="w-10 h-10 rounded-full bg-indigo-50 flex items-center justify-center">
+          <Loader2 className="w-5 h-5 animate-spin text-indigo-500" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -5,6 +5,7 @@ import {
   BookOpen,
   Clock,
   FileText,
+  Flame,
   Hash,
   Headphones,
   Library,
@@ -23,6 +24,7 @@ import { TodayPlan } from '@/components/dashboard/today-plan';
 import { TodayReviewCard } from '@/components/dashboard/today-review-card';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { getStreakData } from '@/lib/analytics';
 import { db } from '@/lib/db';
 import { useI18n } from '@/lib/i18n/use-i18n';
 import { useAssessmentStore } from '@/stores/assessment-store';
@@ -39,6 +41,7 @@ interface Stats {
   articlesPracticed: number;
   avgAccuracy: number;
   avgWpm: number;
+  streak: number;
   sessionsByModule: Record<string, number>;
 }
 
@@ -71,6 +74,7 @@ export default function DashboardPage() {
     articlesPracticed: 0,
     avgAccuracy: 0,
     avgWpm: 0,
+    streak: 0,
     sessionsByModule: {},
   });
   const [recent, setRecent] = useState<RecentItem[]>([]);
@@ -106,6 +110,8 @@ export default function DashboardPage() {
       const writes = completed.filter((s) => (s.module || 'write') === 'write');
       const avgWpm = writes.length > 0 ? writes.reduce((sum, s) => sum + s.wpm, 0) / writes.length : 0;
 
+      const streakData = await getStreakData();
+
       setStats({
         totalContent: contents.length,
         totalSessions: completed.length,
@@ -113,6 +119,7 @@ export default function DashboardPage() {
         articlesPracticed: practicedArticles.size,
         avgAccuracy: Math.round(avgAccuracy),
         avgWpm: Math.round(avgWpm),
+        streak: streakData.current,
         sessionsByModule,
       });
 
@@ -203,9 +210,22 @@ export default function DashboardPage() {
   return (
     <div className="max-w-6xl mx-auto space-y-8">
       {/* Header */}
-      <div>
-        <h1 className="text-3xl font-bold text-indigo-900">{dashboard.header.title}</h1>
-        <p className="text-indigo-600 mt-1">{dashboard.header.subtitle}</p>
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-3xl font-bold text-indigo-900">{dashboard.header.title}</h1>
+          <p className="text-indigo-600 mt-1">{dashboard.header.subtitle}</p>
+        </div>
+        {stats.streak > 0 && (
+          <div className="flex items-center gap-2 rounded-xl bg-gradient-to-br from-orange-50 to-amber-50 border border-orange-200 px-4 py-2.5 shadow-sm shrink-0">
+            <Flame className="w-5 h-5 text-orange-500" />
+            <div className="text-right">
+              <p className="text-2xl font-bold text-orange-600 leading-none">{stats.streak}</p>
+              <p className="text-[10px] text-orange-400 font-medium uppercase tracking-wide">
+                {dashboard.stats.streak ?? 'Streak'}
+              </p>
+            </div>
+          </div>
+        )}
       </div>
 
       {showAutoLanguageNotice && (

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -23,6 +23,7 @@ import {
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import { MiniHeatmap } from '@/components/dashboard/mini-heatmap';
+import { MiniModuleBreakdown } from '@/components/dashboard/mini-module-breakdown';
 import { MiniReviewForecast } from '@/components/dashboard/mini-review-forecast';
 import { TodayPlan } from '@/components/dashboard/today-plan';
 import { TodayReviewCard } from '@/components/dashboard/today-review-card';
@@ -421,20 +422,20 @@ export default function DashboardPage() {
       )}
 
       {/* Mini Analytics */}
-      {!isNewUser && (heatmapData.length > 0 || reviewForecastData.length > 0) && (
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+      {!isNewUser && (heatmapData.length > 0 || reviewForecastData.length > 0 || stats.totalSessions > 0) && (
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
           {heatmapData.length > 0 && (
             <Card className="bg-white border-slate-100 shadow-sm">
               <CardHeader className="flex flex-row items-center justify-between pb-2">
                 <CardTitle className="text-sm font-medium text-indigo-600 flex items-center gap-1.5">
                   <Calendar className="w-4 h-4" />
-                  Activity
+                  {dashboard.miniAnalytics.activity}
                 </CardTitle>
                 <Link
                   href="/dashboard/analytics"
                   className="text-xs text-indigo-400 hover:text-indigo-600 flex items-center gap-0.5"
                 >
-                  Details <ArrowRight className="w-3 h-3" />
+                  {dashboard.miniAnalytics.details} <ArrowRight className="w-3 h-3" />
                 </Link>
               </CardHeader>
               <CardContent>
@@ -447,17 +448,30 @@ export default function DashboardPage() {
               <CardHeader className="flex flex-row items-center justify-between pb-2">
                 <CardTitle className="text-sm font-medium text-indigo-600 flex items-center gap-1.5">
                   <Target className="w-4 h-4" />
-                  Review Forecast
+                  {dashboard.miniAnalytics.reviewForecast}
                 </CardTitle>
                 <Link
                   href="/review/today"
                   className="text-xs text-indigo-400 hover:text-indigo-600 flex items-center gap-0.5"
                 >
-                  Review <ArrowRight className="w-3 h-3" />
+                  {dashboard.miniAnalytics.review} <ArrowRight className="w-3 h-3" />
                 </Link>
               </CardHeader>
               <CardContent>
                 <MiniReviewForecast data={reviewForecastData} />
+              </CardContent>
+            </Card>
+          )}
+          {stats.totalSessions > 0 && (
+            <Card className="bg-white border-slate-100 shadow-sm">
+              <CardHeader className="flex flex-row items-center justify-between pb-2">
+                <CardTitle className="text-sm font-medium text-indigo-600 flex items-center gap-1.5">
+                  <TrendingUp className="w-4 h-4" />
+                  {dashboard.miniAnalytics.practiceBreakdown}
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <MiniModuleBreakdown data={stats.sessionsByModule} />
               </CardContent>
             </Card>
           )}

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -1,8 +1,10 @@
 'use client';
 
 import {
+  ArrowRight,
   BookMarked,
   BookOpen,
+  Calendar,
   Clock,
   FileText,
   Flame,
@@ -20,11 +22,13 @@ import {
 } from 'lucide-react';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
+import { MiniHeatmap } from '@/components/dashboard/mini-heatmap';
+import { MiniReviewForecast } from '@/components/dashboard/mini-review-forecast';
 import { TodayPlan } from '@/components/dashboard/today-plan';
 import { TodayReviewCard } from '@/components/dashboard/today-review-card';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { getStreakData } from '@/lib/analytics';
+import { getActivityHeatmapData, getReviewForecast, getStreakData } from '@/lib/analytics';
 import { db } from '@/lib/db';
 import { useI18n } from '@/lib/i18n/use-i18n';
 import { useAssessmentStore } from '@/stores/assessment-store';
@@ -78,6 +82,8 @@ export default function DashboardPage() {
     sessionsByModule: {},
   });
   const [recent, setRecent] = useState<RecentItem[]>([]);
+  const [heatmapData, setHeatmapData] = useState<{ date: string; count: number }[]>([]);
+  const [reviewForecastData, setReviewForecastData] = useState<{ date: string; count: number }[]>([]);
   const isNewUser = stats.totalContent === 0;
 
   const hasProvider = useProviderStore((s) => s.hasAnyProviderConfigured());
@@ -110,7 +116,14 @@ export default function DashboardPage() {
       const writes = completed.filter((s) => (s.module || 'write') === 'write');
       const avgWpm = writes.length > 0 ? writes.reduce((sum, s) => sum + s.wpm, 0) / writes.length : 0;
 
-      const streakData = await getStreakData();
+      const [streakData, heatmap, forecast] = await Promise.all([
+        getStreakData(),
+        getActivityHeatmapData(56),
+        getReviewForecast(7),
+      ]);
+
+      setHeatmapData(heatmap);
+      setReviewForecastData(forecast);
 
       setStats({
         totalContent: contents.length,
@@ -405,6 +418,50 @@ export default function DashboardPage() {
             </div>
           </CardContent>
         </Card>
+      )}
+
+      {/* Mini Analytics */}
+      {!isNewUser && (heatmapData.length > 0 || reviewForecastData.length > 0) && (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {heatmapData.length > 0 && (
+            <Card className="bg-white border-slate-100 shadow-sm">
+              <CardHeader className="flex flex-row items-center justify-between pb-2">
+                <CardTitle className="text-sm font-medium text-indigo-600 flex items-center gap-1.5">
+                  <Calendar className="w-4 h-4" />
+                  Activity
+                </CardTitle>
+                <Link
+                  href="/dashboard/analytics"
+                  className="text-xs text-indigo-400 hover:text-indigo-600 flex items-center gap-0.5"
+                >
+                  Details <ArrowRight className="w-3 h-3" />
+                </Link>
+              </CardHeader>
+              <CardContent>
+                <MiniHeatmap data={heatmapData} days={56} />
+              </CardContent>
+            </Card>
+          )}
+          {reviewForecastData.length > 0 && (
+            <Card className="bg-white border-slate-100 shadow-sm">
+              <CardHeader className="flex flex-row items-center justify-between pb-2">
+                <CardTitle className="text-sm font-medium text-indigo-600 flex items-center gap-1.5">
+                  <Target className="w-4 h-4" />
+                  Review Forecast
+                </CardTitle>
+                <Link
+                  href="/review/today"
+                  className="text-xs text-indigo-400 hover:text-indigo-600 flex items-center gap-0.5"
+                >
+                  Review <ArrowRight className="w-3 h-3" />
+                </Link>
+              </CardHeader>
+              <CardContent>
+                <MiniReviewForecast data={reviewForecastData} />
+              </CardContent>
+            </Card>
+          )}
+        </div>
       )}
 
       {/* Today Review */}

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -434,7 +434,7 @@ export default function DashboardPage() {
                 const mod = moduleConfig[s.module || 'write'];
                 const Icon = mod?.icon ?? PenTool;
                 return (
-                  <Link key={s.id} href={`/${s.module || 'write'}/${s.contentId}`}>
+                  <Link key={s.id} href={`/${s.module === 'speak' ? 'read' : s.module || 'write'}/${s.contentId}`}>
                     <div className="flex items-center gap-3 p-3 hover:bg-indigo-50/50 hover:translate-x-0.5 transition-all duration-200 cursor-pointer group">
                       <div
                         className={`w-8 h-8 rounded-lg ${mod?.color ?? 'bg-indigo-500'} flex items-center justify-center shrink-0`}

--- a/src/app/(app)/error.tsx
+++ b/src/app/(app)/error.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { AlertTriangle, RotateCcw } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+export default function AppError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  return (
+    <div className="flex items-center justify-center min-h-[50vh]">
+      <div className="flex flex-col items-center gap-4 max-w-md text-center px-4">
+        <div className="w-14 h-14 rounded-2xl bg-red-100 flex items-center justify-center">
+          <AlertTriangle className="w-7 h-7 text-red-500" />
+        </div>
+        <div className="space-y-1">
+          <h2 className="text-lg font-semibold text-indigo-900">Something went wrong</h2>
+          <p className="text-sm text-indigo-500">{error.message || 'An unexpected error occurred.'}</p>
+        </div>
+        <Button onClick={reset} variant="outline" className="cursor-pointer border-indigo-200 text-indigo-600">
+          <RotateCcw className="w-4 h-4 mr-2" />
+          Try Again
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -7,6 +7,8 @@ import { CommandPalette } from '@/components/layout/command-palette';
 import { MobileMenuButton } from '@/components/layout/mobile-menu-button';
 import { Sidebar } from '@/components/layout/sidebar';
 import { SelectionTranslationProvider } from '@/components/selection-translation/selection-translation-provider';
+import { ShadowReadingCompletion } from '@/components/shared/shadow-reading-completion';
+import { ShadowReadingStatusBar } from '@/components/shared/shadow-reading-status-bar';
 import { useShortcuts } from '@/hooks/use-shortcuts';
 import { I18nProvider } from '@/lib/i18n/provider';
 import { seedDatabase } from '@/lib/seed';
@@ -18,6 +20,7 @@ import { useDailyPlanStore } from '@/stores/daily-plan-store';
 import { useFavoriteStore } from '@/stores/favorite-store';
 import { usePracticeTranslationStore } from '@/stores/practice-translation-store';
 import { useProviderStore } from '@/stores/provider-store';
+import { useShadowReadingStore } from '@/stores/shadow-reading-store';
 import { useShortcutStore } from '@/stores/shortcut-store';
 import { useTTSStore } from '@/stores/tts-store';
 import { useUpdaterStore } from '@/stores/updater-store';
@@ -47,6 +50,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
     useAssessmentStore.getState().hydrate();
     useDailyPlanStore.getState().hydrate();
     usePracticeTranslationStore.getState().hydrate();
+    useShadowReadingStore.getState().hydrate();
     useShortcutStore.getState().hydrate();
     void useAuthStore.getState().initialize();
     void useFavoriteStore.getState().loadFavorites();
@@ -79,9 +83,22 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
     'global:nav-favorites': () => router.push('/favorites'),
     'global:toggle-selection-translate': () =>
       useFavoriteStore.getState().setSelectionTranslateEnabled(!useFavoriteStore.getState().selectionTranslateEnabled),
+    'global:shadow-next-module': () => {
+      const store = useShadowReadingStore.getState();
+      if (!store.session) return;
+      const next = store.getNextIncompleteModule();
+      if (next) {
+        const paths: Record<string, string> = { listen: '/listen', read: '/read', write: '/write' };
+        router.push(`${paths[next]}/${store.session.contentId}`);
+      }
+    },
+    'global:shadow-end-session': () => {
+      useShadowReadingStore.getState().requestEndSession();
+    },
   });
 
   // Close sidebar on route change (mobile)
+  // biome-ignore lint/correctness/useExhaustiveDependencies: re-run on pathname change is intentional
   useEffect(() => {
     setSidebarOpen(false);
   }, [pathname]);
@@ -100,11 +117,13 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
         <Sidebar open={sidebarOpen} onOpenChange={setSidebarOpen} />
         <SelectionTranslationProvider>
           <main className="flex-1 overflow-y-auto" data-seeded={seeded}>
+            <ShadowReadingStatusBar />
             <MobileMenuButton onClick={() => setSidebarOpen(true)} />
             <div className="min-h-full px-6 pt-16 pb-6 md:p-8">{children}</div>
           </main>
         </SelectionTranslationProvider>
         <ChatFab />
+        <ShadowReadingCompletion />
         <CommandPalette open={commandPaletteOpen} onOpenChange={setCommandPaletteOpen} />
       </div>
     </I18nProvider>

--- a/src/app/(app)/library/books/[bookId]/page.tsx
+++ b/src/app/(app)/library/books/[bookId]/page.tsx
@@ -4,6 +4,7 @@ import { ArrowLeft, BookOpen, Headphones, MessageCircle, PenTool, Trash2 } from 
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
+import { PageSpinner } from '@/components/shared/page-spinner';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
@@ -58,7 +59,7 @@ export default function BookDetailPage() {
   };
 
   if (loading) {
-    return <div className="flex items-center justify-center h-64 text-indigo-400">Loading...</div>;
+    return <PageSpinner size="sm" className="min-h-[40vh]" />;
   }
 
   if (!book) {

--- a/src/app/(app)/library/loading.tsx
+++ b/src/app/(app)/library/loading.tsx
@@ -1,0 +1,25 @@
+import { Loader2 } from 'lucide-react';
+
+export default function LibraryLoading() {
+  return (
+    <div className="max-w-6xl mx-auto space-y-6 animate-pulse">
+      <div className="flex items-center justify-between">
+        <div className="h-8 w-40 bg-indigo-100 rounded-lg" />
+        <div className="flex gap-2">
+          <div className="h-9 w-24 bg-indigo-50 rounded-lg" />
+          <div className="h-9 w-24 bg-indigo-50 rounded-lg" />
+        </div>
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div key={i} className="h-32 bg-white rounded-xl border border-slate-100 shadow-sm" />
+        ))}
+      </div>
+      <div className="flex items-center justify-center pt-4">
+        <div className="w-10 h-10 rounded-full bg-indigo-50 flex items-center justify-center">
+          <Loader2 className="w-5 h-5 animate-spin text-indigo-500" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/library/page.tsx
+++ b/src/app/(app)/library/page.tsx
@@ -212,20 +212,6 @@ function ContentRow({
           <Link
             href={`/read/${item.id}`}
             onClick={() => onSetActive(item.id)}
-            data-testid={`library-action-speak-${item.id}`}
-          >
-            <Button
-              variant="ghost"
-              size="icon"
-              className="text-indigo-500 hover:text-indigo-700 hover:bg-indigo-50 cursor-pointer h-8 w-8 transition-colors"
-              title={messages.actions.speak}
-            >
-              <Mic className="w-4 h-4" />
-            </Button>
-          </Link>
-          <Link
-            href={`/read/${item.id}`}
-            onClick={() => onSetActive(item.id)}
             data-testid={`library-action-read-${item.id}`}
           >
             <Button

--- a/src/app/(app)/library/page.tsx
+++ b/src/app/(app)/library/page.tsx
@@ -4,6 +4,7 @@ import {
   BookMarked,
   BookOpen,
   Check,
+  CheckSquare,
   ChevronDown,
   FileText,
   Headphones,
@@ -13,6 +14,7 @@ import {
   PenTool,
   Plus,
   Search,
+  Square,
   Tag,
   Trash2,
   Video,
@@ -72,10 +74,16 @@ function ContentRow({
   item,
   onDelete,
   onSetActive,
+  selectable,
+  selected,
+  onToggleSelect,
 }: {
   item: ContentItem;
   onDelete: (id: string) => void;
   onSetActive: (id: string) => void;
+  selectable?: boolean;
+  selected?: boolean;
+  onToggleSelect?: (id: string) => void;
 }) {
   const { updateContent } = useContentStore();
   const { messages } = useI18n('library');
@@ -109,6 +117,15 @@ function ContentRow({
       data-testid={`library-content-row-${item.id}`}
     >
       <CardContent className="flex flex-col sm:flex-row sm:items-start justify-between p-3 md:p-4 gap-2 md:gap-4">
+        {selectable && (
+          <button
+            type="button"
+            onClick={() => onToggleSelect?.(item.id)}
+            className="shrink-0 mt-0.5 cursor-pointer text-indigo-400 hover:text-indigo-600 transition-colors"
+          >
+            {selected ? <CheckSquare className="w-5 h-5 text-indigo-600" /> : <Square className="w-5 h-5" />}
+          </button>
+        )}
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-1.5 md:gap-2 mb-1 md:mb-2 flex-wrap">
             <h3 className="font-semibold text-indigo-900 text-sm md:text-base">{item.title}</h3>
@@ -259,11 +276,17 @@ function ContentGroup({
   items,
   onDelete,
   onSetActive,
+  selectable,
+  selectedIds,
+  onToggleSelect,
 }: {
   type: ContentType;
   items: ContentItem[];
   onDelete: (id: string) => void;
   onSetActive: (id: string) => void;
+  selectable?: boolean;
+  selectedIds?: Set<string>;
+  onToggleSelect?: (id: string) => void;
 }) {
   const { messages } = useI18n('library');
   const [showCount, setShowCount] = useState(ITEMS_PER_GROUP);
@@ -289,7 +312,15 @@ function ContentGroup({
       <AccordionContent>
         <div className="grid gap-2 pb-2">
           {visible.map((item) => (
-            <ContentRow key={item.id} item={item} onDelete={onDelete} onSetActive={onSetActive} />
+            <ContentRow
+              key={item.id}
+              item={item}
+              onDelete={onDelete}
+              onSetActive={onSetActive}
+              selectable={selectable}
+              selected={selectedIds?.has(item.id)}
+              onToggleSelect={onToggleSelect}
+            />
           ))}
           {remaining > 0 && (
             <Button
@@ -316,11 +347,17 @@ function WordBookGroup({
   items,
   onDelete,
   onSetActive,
+  selectable,
+  selectedIds,
+  onToggleSelect,
 }: {
   book: WordBook;
   items: ContentItem[];
   onDelete: (id: string) => void;
   onSetActive: (id: string) => void;
+  selectable?: boolean;
+  selectedIds?: Set<string>;
+  onToggleSelect?: (id: string) => void;
 }) {
   const { messages } = useI18n('library');
   const [showCount, setShowCount] = useState(ITEMS_PER_GROUP);
@@ -386,7 +423,15 @@ function WordBookGroup({
           </div>
 
           {visible.map((item) => (
-            <ContentRow key={item.id} item={item} onDelete={onDelete} onSetActive={onSetActive} />
+            <ContentRow
+              key={item.id}
+              item={item}
+              onDelete={onDelete}
+              onSetActive={onSetActive}
+              selectable={selectable}
+              selected={selectedIds?.has(item.id)}
+              onToggleSelect={onToggleSelect}
+            />
           ))}
           {remaining > 0 && (
             <Button
@@ -409,7 +454,8 @@ function WordBookGroup({
 // ─── Main Page ───────────────────────────────────────────────────────────────
 
 export default function LibraryPage() {
-  const { loadContents, getAllTags, setFilter, filter, deleteContent, setActiveContentId, items } = useContentStore();
+  const { loadContents, getAllTags, setFilter, filter, deleteContent, updateContent, setActiveContentId, items } =
+    useContentStore();
   const { importedIds, loadImportedState } = useWordBookStore();
   const { books: importedBooks, loadBooks } = useBookStore();
   const shadowReadingEnabled = useTTSStore((s) => s.shadowReadingEnabled);
@@ -419,6 +465,47 @@ export default function LibraryPage() {
   const [tagFilter, setTagFilter] = useState<string[]>([]);
   const [quickAddOpen, setQuickAddOpen] = useState(false);
   const [activeViewTab, setActiveViewTab] = useState<ViewTab>('all');
+  const [selectMode, setSelectMode] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [batchTagInput, setBatchTagInput] = useState('');
+  const [showBatchTagInput, setShowBatchTagInput] = useState(false);
+
+  const toggleSelect = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const handleExitSelectMode = () => {
+    setSelectMode(false);
+    setSelectedIds(new Set());
+    setShowBatchTagInput(false);
+    setBatchTagInput('');
+  };
+
+  const handleBatchDelete = () => {
+    for (const id of selectedIds) {
+      deleteContent(id);
+    }
+    handleExitSelectMode();
+  };
+
+  const handleBatchTag = () => {
+    const newTags = normalizeTags(batchTagInput);
+    if (newTags.length === 0) return;
+    for (const id of selectedIds) {
+      const item = items.find((i) => i.id === id);
+      if (item) {
+        const merged = [...new Set([...item.tags, ...newTags])];
+        updateContent(id, { tags: merged });
+      }
+    }
+    setShowBatchTagInput(false);
+    setBatchTagInput('');
+  };
 
   useEffect(() => {
     useTTSStore.getState().hydrate();
@@ -567,20 +654,37 @@ export default function LibraryPage() {
         </div>
         <div className="flex items-center gap-2 shrink-0">
           <Button
-            onClick={() => setQuickAddOpen(true)}
-            variant="outline"
+            onClick={() => (selectMode ? handleExitSelectMode() : setSelectMode(true))}
+            variant={selectMode ? 'default' : 'outline'}
             size="sm"
-            className="border-indigo-200 text-indigo-600 hover:bg-indigo-50 cursor-pointer"
+            className={
+              selectMode
+                ? 'bg-indigo-600 cursor-pointer'
+                : 'border-indigo-200 text-indigo-600 hover:bg-indigo-50 cursor-pointer'
+            }
           >
-            <Plus className="w-4 h-4 mr-1 md:mr-2" />
-            <span className="hidden sm:inline">{messages.page.quickAdd}</span>
-            <span className="sm:hidden">Add</span>
+            <CheckSquare className="w-4 h-4 mr-1" />
+            <span className="hidden sm:inline">{selectMode ? 'Cancel' : 'Select'}</span>
           </Button>
-          <Link href="/library/import">
-            <Button size="sm" className="bg-indigo-600 hover:bg-indigo-700 cursor-pointer">
-              {messages.page.importContent}
-            </Button>
-          </Link>
+          {!selectMode && (
+            <>
+              <Button
+                onClick={() => setQuickAddOpen(true)}
+                variant="outline"
+                size="sm"
+                className="border-indigo-200 text-indigo-600 hover:bg-indigo-50 cursor-pointer"
+              >
+                <Plus className="w-4 h-4 mr-1 md:mr-2" />
+                <span className="hidden sm:inline">{messages.page.quickAdd}</span>
+                <span className="sm:hidden">Add</span>
+              </Button>
+              <Link href="/library/import">
+                <Button size="sm" className="bg-indigo-600 hover:bg-indigo-700 cursor-pointer">
+                  {messages.page.importContent}
+                </Button>
+              </Link>
+            </>
+          )}
         </div>
       </div>
 
@@ -668,6 +772,62 @@ export default function LibraryPage() {
 
       <QuickAddDialog open={quickAddOpen} onOpenChange={setQuickAddOpen} />
 
+      {selectMode && selectedIds.size > 0 && (
+        <div className="sticky bottom-4 z-20 flex items-center justify-center">
+          <div className="flex items-center gap-2 bg-white border border-indigo-200 shadow-lg rounded-xl px-4 py-2.5">
+            <span className="text-sm font-medium text-indigo-700">{selectedIds.size} selected</span>
+            <div className="w-px h-5 bg-indigo-200" />
+            {showBatchTagInput ? (
+              <div className="flex items-center gap-1.5">
+                <Input
+                  value={batchTagInput}
+                  onChange={(e) => setBatchTagInput(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') handleBatchTag();
+                    if (e.key === 'Escape') setShowBatchTagInput(false);
+                  }}
+                  placeholder="tag1, tag2"
+                  className="h-7 w-40 text-xs bg-white border-indigo-200"
+                  autoFocus
+                />
+                <Button
+                  size="sm"
+                  onClick={handleBatchTag}
+                  className="h-7 bg-indigo-600 hover:bg-indigo-700 text-xs cursor-pointer"
+                >
+                  Apply
+                </Button>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => setShowBatchTagInput(false)}
+                  className="h-7 text-xs cursor-pointer"
+                >
+                  <X className="w-3.5 h-3.5" />
+                </Button>
+              </div>
+            ) : (
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => setShowBatchTagInput(true)}
+                className="h-7 text-xs border-indigo-200 text-indigo-600 cursor-pointer"
+              >
+                <Tag className="w-3.5 h-3.5 mr-1" /> Add Tags
+              </Button>
+            )}
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={handleBatchDelete}
+              className="h-7 text-xs border-red-200 text-red-600 hover:bg-red-50 cursor-pointer"
+            >
+              <Trash2 className="w-3.5 h-3.5 mr-1" /> Delete
+            </Button>
+          </div>
+        </div>
+      )}
+
       {hasAnyContent ? (
         <Accordion type="multiple" defaultValue={defaultAccordionValues} className="space-y-3">
           {/* Word Books section */}
@@ -682,6 +842,9 @@ export default function LibraryPage() {
                   items={bookItems}
                   onDelete={deleteContent}
                   onSetActive={handleSetActive}
+                  selectable={selectMode}
+                  selectedIds={selectedIds}
+                  onToggleSelect={toggleSelect}
                 />
               );
             })}
@@ -737,7 +900,15 @@ export default function LibraryPage() {
 
           {/* Phrases section */}
           {showPhrases && grouped.phrase.length > 0 && (
-            <ContentGroup type="phrase" items={grouped.phrase} onDelete={deleteContent} onSetActive={handleSetActive} />
+            <ContentGroup
+              type="phrase"
+              items={grouped.phrase}
+              onDelete={deleteContent}
+              onSetActive={handleSetActive}
+              selectable={selectMode}
+              selectedIds={selectedIds}
+              onToggleSelect={toggleSelect}
+            />
           )}
 
           {/* Sentences section */}
@@ -747,6 +918,9 @@ export default function LibraryPage() {
               items={grouped.sentence}
               onDelete={deleteContent}
               onSetActive={handleSetActive}
+              selectable={selectMode}
+              selectedIds={selectedIds}
+              onToggleSelect={toggleSelect}
             />
           )}
 
@@ -757,6 +931,9 @@ export default function LibraryPage() {
               items={grouped.article}
               onDelete={deleteContent}
               onSetActive={handleSetActive}
+              selectable={selectMode}
+              selectedIds={selectedIds}
+              onToggleSelect={toggleSelect}
             />
           )}
 
@@ -772,6 +949,9 @@ export default function LibraryPage() {
                   items={bookItems}
                   onDelete={deleteContent}
                   onSetActive={handleSetActive}
+                  selectable={selectMode}
+                  selectedIds={selectedIds}
+                  onToggleSelect={toggleSelect}
                 />
               );
             })}

--- a/src/app/(app)/library/page.tsx
+++ b/src/app/(app)/library/page.tsx
@@ -34,6 +34,7 @@ import { cn, normalizeTags } from '@/lib/utils';
 import { ALL_WORDBOOKS } from '@/lib/wordbooks';
 import { useBookStore } from '@/stores/book-store';
 import { useContentStore } from '@/stores/content-store';
+import { useShadowReadingStore } from '@/stores/shadow-reading-store';
 import { useTTSStore } from '@/stores/tts-store';
 import { useWordBookStore } from '@/stores/wordbook-store';
 import type { ContentItem, ContentType, Difficulty } from '@/types/content';
@@ -458,7 +459,8 @@ export default function LibraryPage() {
     useContentStore();
   const { importedIds, loadImportedState } = useWordBookStore();
   const { books: importedBooks, loadBooks } = useBookStore();
-  const shadowReadingEnabled = useTTSStore((s) => s.shadowReadingEnabled);
+  const shadowReadingEnabled = useShadowReadingStore((s) => s.enabled);
+  const startShadowSession = useShadowReadingStore((s) => s.startSession);
   const { messages } = useI18n('library');
   const [diffFilter, setDiffFilter] = useState<Difficulty | ''>('');
   const [viewMode, setViewMode] = useState<'all' | 'media'>('all');
@@ -532,6 +534,8 @@ export default function LibraryPage() {
 
   const handleSetActive = (id: string) => {
     if (shadowReadingEnabled) {
+      const item = items.find((i) => i.id === id);
+      startShadowSession(id, item?.title || '');
       setActiveContentId(id);
     }
   };

--- a/src/app/(app)/listen/[id]/page.tsx
+++ b/src/app/(app)/listen/[id]/page.tsx
@@ -5,6 +5,7 @@ import { nanoid } from 'nanoid';
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { CrossModuleNav } from '@/components/shared/cross-module-nav';
 import { PracticeCompleteBanner } from '@/components/shared/practice-complete-banner';
 import { RecommendationPanel } from '@/components/shared/recommendation-panel';
 import { TranslationBar } from '@/components/translation/translation-bar';
@@ -413,6 +414,7 @@ export default function ListenDetailPage() {
             )}
           </div>
         </div>
+        <CrossModuleNav contentId={content.id} currentModule="listen" />
         <TranslationBar module="listen" />
       </div>
 

--- a/src/app/(app)/listen/[id]/page.tsx
+++ b/src/app/(app)/listen/[id]/page.tsx
@@ -6,8 +6,10 @@ import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { CrossModuleNav } from '@/components/shared/cross-module-nav';
+import { PageSpinner } from '@/components/shared/page-spinner';
 import { PracticeCompleteBanner } from '@/components/shared/practice-complete-banner';
 import { RecommendationPanel } from '@/components/shared/recommendation-panel';
+import { ShadowReadingProgressBar } from '@/components/shared/shadow-reading-progress-bar';
 import { TranslationBar } from '@/components/translation/translation-bar';
 import { TranslationDisplay } from '@/components/translation/translation-display';
 import { Button } from '@/components/ui/button';
@@ -23,6 +25,7 @@ import { estimateSentenceHighlightTimings } from '@/lib/listen-highlight';
 import { splitSentences } from '@/lib/sentence-split';
 import { useContentStore } from '@/stores/content-store';
 import { usePracticeTranslationStore } from '@/stores/practice-translation-store';
+import { useShadowReadingStore } from '@/stores/shadow-reading-store';
 import { useTTSStore } from '@/stores/tts-store';
 import type { ContentItem } from '@/types/content';
 
@@ -89,9 +92,10 @@ export default function ListenDetailPage() {
   const showTranslation = usePracticeTranslationStore((s) => s.visibility.listen);
   const targetLang = useTTSStore((s) => s.targetLang);
   const recommendationsEnabled = useTTSStore((s) => s.recommendationsEnabled);
-  const shadowReadingEnabled = useTTSStore((s) => s.shadowReadingEnabled);
+  const shadowReadingSession = useShadowReadingStore((s) => s.session);
+  const markModuleProgress = useShadowReadingStore((s) => s.markModuleProgress);
   const [sessionCompleted, setSessionCompleted] = useState(false);
-  const { addContent, setActiveContentId } = useContentStore();
+  const { addContent } = useContentStore();
   const {
     sentenceTranslations,
     isLoading: translationLoading,
@@ -139,10 +143,10 @@ export default function ListenDetailPage() {
   }, [params.id]);
 
   useEffect(() => {
-    if (shadowReadingEnabled) {
-      setActiveContentId(params.id as string);
+    if (shadowReadingSession?.contentId === params.id) {
+      markModuleProgress('listen', 'in_progress');
     }
-  }, [params.id, shadowReadingEnabled, setActiveContentId]);
+  }, [params.id, shadowReadingSession?.contentId, markModuleProgress]);
 
   useEffect(() => {
     function handleGlobalStop() {
@@ -206,7 +210,10 @@ export default function ListenDetailPage() {
       completed: true,
     });
     setSessionCompleted(true);
-  }, [content]);
+    if (shadowReadingSession?.contentId === content.id) {
+      markModuleProgress('listen', 'completed');
+    }
+  }, [content, shadowReadingSession?.contentId, markModuleProgress]);
 
   const speakWithWordHighlight = useCallback(
     (text: string, rate: number) => {
@@ -294,6 +301,14 @@ export default function ListenDetailPage() {
   const handlePlay = () => {
     if (!content) return;
     if (isPlaying) {
+      const listenedMs = listenStartRef.current ? Date.now() - listenStartRef.current : 0;
+      const estimatedDurationMs = estimateListenDuration(content.text, speed) * 1000;
+      const listenedEnough = listenedMs > estimatedDurationMs * 0.5;
+
+      if (listenedEnough && !sessionCompleted) {
+        persistListenSession();
+      }
+
       kokoroShouldPersistCompletionRef.current = false;
       clearSentenceHighlightTimers();
       stop();
@@ -378,7 +393,7 @@ export default function ListenDetailPage() {
   });
 
   if (!content) {
-    return <div className="flex items-center justify-center h-64 text-indigo-400">Loading...</div>;
+    return <PageSpinner size="sm" className="min-h-[40vh]" />;
   }
 
   return (
@@ -414,7 +429,11 @@ export default function ListenDetailPage() {
             )}
           </div>
         </div>
-        <CrossModuleNav contentId={content.id} currentModule="listen" />
+        {shadowReadingSession?.contentId === content.id ? (
+          <ShadowReadingProgressBar contentId={content.id} currentModule="listen" showSpeakHint speakHref="/speak" />
+        ) : (
+          <CrossModuleNav contentId={content.id} currentModule="listen" />
+        )}
         <TranslationBar module="listen" />
       </div>
 

--- a/src/app/(app)/listen/error.tsx
+++ b/src/app/(app)/listen/error.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { AlertTriangle, Headphones, RotateCcw } from 'lucide-react';
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+
+export default function ListenError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  return (
+    <div className="flex items-center justify-center min-h-[50vh]">
+      <div className="flex flex-col items-center gap-4 max-w-md text-center px-4">
+        <div className="w-14 h-14 rounded-2xl bg-indigo-100 flex items-center justify-center">
+          <AlertTriangle className="w-7 h-7 text-indigo-500" />
+        </div>
+        <div className="space-y-1">
+          <h2 className="text-lg font-semibold text-indigo-900">Listening error</h2>
+          <p className="text-sm text-indigo-500">{error.message || 'Something went wrong with audio playback.'}</p>
+        </div>
+        <div className="flex gap-3">
+          <Button onClick={reset} variant="outline" className="cursor-pointer border-indigo-200 text-indigo-600">
+            <RotateCcw className="w-4 h-4 mr-2" />
+            Try Again
+          </Button>
+          <Link href="/library">
+            <Button variant="outline" className="cursor-pointer border-indigo-200 text-indigo-600">
+              <Headphones className="w-4 h-4 mr-2" />
+              Pick Content
+            </Button>
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/loading.tsx
+++ b/src/app/(app)/loading.tsx
@@ -1,12 +1,5 @@
-import { Loader2 } from 'lucide-react';
+import { PageSpinner } from '@/components/shared/page-spinner';
 
 export default function AppLoading() {
-  return (
-    <div className="flex items-center justify-center min-h-[50vh]">
-      <div className="flex flex-col items-center gap-3 text-indigo-400">
-        <Loader2 className="w-8 h-8 animate-spin" />
-        <p className="text-sm font-medium">Loading...</p>
-      </div>
-    </div>
-  );
+  return <PageSpinner size="lg" />;
 }

--- a/src/app/(app)/loading.tsx
+++ b/src/app/(app)/loading.tsx
@@ -1,0 +1,12 @@
+import { Loader2 } from 'lucide-react';
+
+export default function AppLoading() {
+  return (
+    <div className="flex items-center justify-center min-h-[50vh]">
+      <div className="flex flex-col items-center gap-3 text-indigo-400">
+        <Loader2 className="w-8 h-8 animate-spin" />
+        <p className="text-sm font-medium">Loading...</p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/login/page.tsx
+++ b/src/app/(app)/login/page.tsx
@@ -10,7 +10,7 @@ import { useAuthStore } from '@/stores/auth-store';
 
 function GoogleIcon({ className }: { className?: string }) {
   return (
-    <svg className={className} viewBox="0 0 24 24" fill="none">
+    <svg className={className} viewBox="0 0 24 24" fill="none" aria-label="Google">
       <path
         d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
         fill="#4285F4"
@@ -33,7 +33,7 @@ function GoogleIcon({ className }: { className?: string }) {
 
 function GitHubIcon({ className }: { className?: string }) {
   return (
-    <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+    <svg className={className} viewBox="0 0 24 24" fill="currentColor" aria-label="GitHub">
       <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0 1 12 6.844a9.59 9.59 0 0 1 2.504.337c1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0 0 22 12.017C22 6.484 17.522 2 12 2z" />
     </svg>
   );

--- a/src/app/(app)/not-found.tsx
+++ b/src/app/(app)/not-found.tsx
@@ -1,0 +1,27 @@
+import { FileQuestion, Home } from 'lucide-react';
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+
+export default function AppNotFound() {
+  return (
+    <div className="flex items-center justify-center min-h-[50vh]">
+      <div className="flex flex-col items-center gap-4 max-w-md text-center px-4">
+        <div className="w-14 h-14 rounded-2xl bg-indigo-100 flex items-center justify-center">
+          <FileQuestion className="w-7 h-7 text-indigo-500" />
+        </div>
+        <div className="space-y-1">
+          <h2 className="text-lg font-semibold text-indigo-900">Page Not Found</h2>
+          <p className="text-sm text-indigo-500">
+            The page you&apos;re looking for doesn&apos;t exist or has been moved.
+          </p>
+        </div>
+        <Link href="/dashboard">
+          <Button variant="outline" className="cursor-pointer border-indigo-200 text-indigo-600">
+            <Home className="w-4 h-4 mr-2" />
+            Back to Dashboard
+          </Button>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/read/[id]/page.tsx
+++ b/src/app/(app)/read/[id]/page.tsx
@@ -8,6 +8,7 @@ import { useParams, useRouter } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { flushSync } from 'react-dom';
 import { LiveReadingFeedback } from '@/components/read/live-reading-feedback';
+import { CrossModuleNav } from '@/components/shared/cross-module-nav';
 import { FormattedContentText } from '@/components/shared/formatted-content-text';
 import { PracticeCompleteBanner } from '@/components/shared/practice-complete-banner';
 import { RecommendationPanel } from '@/components/shared/recommendation-panel';
@@ -417,12 +418,13 @@ export default function ReadDetailPage() {
             <ArrowLeft className="w-5 h-5" />
           </Button>
         </Link>
-        <div className="min-w-0">
+        <div className="min-w-0 flex-1">
           <h1 className="text-xl md:text-2xl font-bold font-[var(--font-poppins)] text-indigo-900 truncate">
             {content.title}
           </h1>
           <p className="text-sm text-indigo-500">{content.type} · Read Aloud Mode</p>
         </div>
+        <CrossModuleNav contentId={content.id} currentModule="read" />
       </div>
 
       <Card className="bg-white border-slate-100 shadow-sm shrink-0">

--- a/src/app/(app)/read/[id]/page.tsx
+++ b/src/app/(app)/read/[id]/page.tsx
@@ -10,8 +10,10 @@ import { flushSync } from 'react-dom';
 import { LiveReadingFeedback } from '@/components/read/live-reading-feedback';
 import { CrossModuleNav } from '@/components/shared/cross-module-nav';
 import { FormattedContentText } from '@/components/shared/formatted-content-text';
+import { PageSpinner } from '@/components/shared/page-spinner';
 import { PracticeCompleteBanner } from '@/components/shared/practice-complete-banner';
 import { RecommendationPanel } from '@/components/shared/recommendation-panel';
+import { ShadowReadingProgressBar } from '@/components/shared/shadow-reading-progress-bar';
 import { PronunciationFeedback } from '@/components/speak/pronunciation-feedback';
 import { SpeechStats } from '@/components/speak/speech-stats';
 import { TranslationBar } from '@/components/translation/translation-bar';
@@ -19,6 +21,7 @@ import { TranslationDisplay } from '@/components/translation/translation-display
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { useFallbackSTT } from '@/hooks/use-fallback-stt';
+import { usePronunciation } from '@/hooks/use-pronunciation';
 import type { Recommendation } from '@/hooks/use-recommendations';
 import { useShortcuts } from '@/hooks/use-shortcuts';
 import { useTranslation } from '@/hooks/use-translation';
@@ -36,6 +39,7 @@ import { matchesShortcutEvent } from '@/lib/shortcut-utils';
 import { IS_TAURI } from '@/lib/tauri';
 import { useContentStore } from '@/stores/content-store';
 import { usePracticeTranslationStore } from '@/stores/practice-translation-store';
+import { useShadowReadingStore } from '@/stores/shadow-reading-store';
 import { useShortcutStore } from '@/stores/shortcut-store';
 import { useTTSStore } from '@/stores/tts-store';
 import type { ContentItem } from '@/types/content';
@@ -63,11 +67,13 @@ export default function ReadDetailPage() {
     typeof window !== 'undefined' && !IS_TAURI && !!(window.SpeechRecognition || window.webkitSpeechRecognition),
   );
   const [sessionCompleted, setSessionCompleted] = useState(false);
+  const pronunciation = usePronunciation({ referenceText: content?.text || '' });
   const showTranslation = usePracticeTranslationStore((s) => s.visibility.read);
   const targetLang = useTTSStore((s) => s.targetLang);
   const recommendationsEnabled = useTTSStore((s) => s.recommendationsEnabled);
-  const shadowReadingEnabled = useTTSStore((s) => s.shadowReadingEnabled);
-  const { addContent, setActiveContentId } = useContentStore();
+  const shadowReadingSession = useShadowReadingStore((s) => s.session);
+  const markModuleProgress = useShadowReadingStore((s) => s.markModuleProgress);
+  const { addContent } = useContentStore();
   const {
     sentenceTranslations,
     isLoading: translationLoading,
@@ -165,10 +171,10 @@ export default function ReadDetailPage() {
   }, [params.id]);
 
   useEffect(() => {
-    if (shadowReadingEnabled) {
-      setActiveContentId(params.id as string);
+    if (shadowReadingSession?.contentId === params.id) {
+      markModuleProgress('read', 'in_progress');
     }
-  }, [params.id, shadowReadingEnabled, setActiveContentId]);
+  }, [params.id, shadowReadingSession?.contentId, markModuleProgress]);
 
   const [speechError, setSpeechError] = useState<string | null>(null);
   const [isFallbackTranscribing, setIsFallbackTranscribing] = useState(false);
@@ -303,7 +309,12 @@ export default function ReadDetailPage() {
       completed: true,
     });
     setSessionCompleted(true);
-  }, [content]);
+    if (shadowReadingSession?.contentId === content.id) {
+      markModuleProgress('read', 'completed');
+    }
+
+    void pronunciation.assessRecognized(finalTranscript);
+  }, [content, pronunciation, shadowReadingSession?.contentId, markModuleProgress]);
 
   const finalizePracticeRef = useRef(finalizePractice);
   useEffect(() => {
@@ -368,6 +379,7 @@ export default function ReadDetailPage() {
     transcriptRef.current = '';
     interimTranscriptRef.current = '';
     hasPersistedResultRef.current = false;
+    pronunciation.clearResult();
     flushSync(() => {
       setTranscript('');
       setInterimTranscript('');
@@ -391,7 +403,7 @@ export default function ReadDetailPage() {
 
     window.addEventListener('keydown', onKeyDown, true);
     return () => window.removeEventListener('keydown', onKeyDown, true);
-  }, [handleReset]);
+  }, []);
 
   useShortcuts('read', {
     'read:toggle-recording': () => {
@@ -407,7 +419,7 @@ export default function ReadDetailPage() {
   });
 
   if (!content) {
-    return <div className="flex items-center justify-center h-64 text-indigo-400">Loading...</div>;
+    return <PageSpinner size="sm" className="min-h-[40vh]" />;
   }
 
   return (
@@ -424,7 +436,11 @@ export default function ReadDetailPage() {
           </h1>
           <p className="text-sm text-indigo-500">{content.type} · Read Aloud Mode</p>
         </div>
-        <CrossModuleNav contentId={content.id} currentModule="read" />
+        {shadowReadingSession?.contentId === content.id ? (
+          <ShadowReadingProgressBar contentId={content.id} currentModule="read" showSpeakHint speakHref="/speak" />
+        ) : (
+          <CrossModuleNav contentId={content.id} currentModule="read" />
+        )}
       </div>
 
       <Card className="bg-white border-slate-100 shadow-sm shrink-0">
@@ -554,8 +570,21 @@ export default function ReadDetailPage() {
 
             <Card className="bg-white border-slate-100 shadow-sm">
               <CardContent className="p-6">
-                <h3 className="font-semibold text-indigo-900 mb-4">Pronunciation Feedback</h3>
-                <PronunciationFeedback results={results} onPlayWord={handlePlayWord} />
+                <div className="flex items-center justify-between mb-4">
+                  <h3 className="font-semibold text-indigo-900">Pronunciation Feedback</h3>
+                  {pronunciation.isAssessing && (
+                    <span className="flex items-center gap-1.5 text-xs text-indigo-400">
+                      <Loader2 className="w-3 h-3 animate-spin" />
+                      Analyzing pronunciation...
+                    </span>
+                  )}
+                </div>
+                <PronunciationFeedback
+                  results={results}
+                  onPlayWord={handlePlayWord}
+                  pronunciationResult={pronunciation.result}
+                />
+                {pronunciation.error && <p className="mt-2 text-xs text-amber-600">{pronunciation.error}</p>}
               </CardContent>
             </Card>
 

--- a/src/app/(app)/read/error.tsx
+++ b/src/app/(app)/read/error.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { AlertTriangle, BookOpen, RotateCcw } from 'lucide-react';
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+
+export default function ReadError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  return (
+    <div className="flex items-center justify-center min-h-[50vh]">
+      <div className="flex flex-col items-center gap-4 max-w-md text-center px-4">
+        <div className="w-14 h-14 rounded-2xl bg-amber-100 flex items-center justify-center">
+          <AlertTriangle className="w-7 h-7 text-amber-500" />
+        </div>
+        <div className="space-y-1">
+          <h2 className="text-lg font-semibold text-indigo-900">Reading practice error</h2>
+          <p className="text-sm text-indigo-500">{error.message || 'Something went wrong loading this content.'}</p>
+        </div>
+        <div className="flex gap-3">
+          <Button onClick={reset} variant="outline" className="cursor-pointer border-indigo-200 text-indigo-600">
+            <RotateCcw className="w-4 h-4 mr-2" />
+            Try Again
+          </Button>
+          <Link href="/library">
+            <Button variant="outline" className="cursor-pointer border-indigo-200 text-indigo-600">
+              <BookOpen className="w-4 h-4 mr-2" />
+              Pick Content
+            </Button>
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/review/loading.tsx
+++ b/src/app/(app)/review/loading.tsx
@@ -1,0 +1,5 @@
+import { PageSpinner } from '@/components/shared/page-spinner';
+
+export default function ReviewLoading() {
+  return <PageSpinner />;
+}

--- a/src/app/(app)/settings/loading.tsx
+++ b/src/app/(app)/settings/loading.tsx
@@ -1,0 +1,19 @@
+import { Loader2 } from 'lucide-react';
+
+export default function SettingsLoading() {
+  return (
+    <div className="max-w-4xl mx-auto space-y-6 animate-pulse">
+      <div className="h-8 w-32 bg-indigo-100 rounded-lg" />
+      <div className="space-y-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="h-28 bg-white rounded-xl border border-slate-100 shadow-sm" />
+        ))}
+      </div>
+      <div className="flex items-center justify-center pt-4">
+        <div className="w-10 h-10 rounded-full bg-indigo-50 flex items-center justify-center">
+          <Loader2 className="w-5 h-5 animate-spin text-indigo-500" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -20,6 +20,7 @@ import {
   Mic,
   RefreshCw,
   Repeat,
+  RotateCcw,
   Sparkles,
   Star,
   Tag,
@@ -74,7 +75,7 @@ import { usePronunciationStore } from '@/stores/pronunciation-store';
 import { useProviderStore } from '@/stores/provider-store';
 import { useSyncStore } from '@/stores/sync-store';
 import { useTTSStore } from '@/stores/tts-store';
-import { PRACTICE_TRANSLATION_POLICY, type PracticeModule } from '@/types/translation';
+import type { PracticeModule } from '@/types/translation';
 
 // ─── Provider brand styles ────────────────────────────────────────────────────
 
@@ -1494,7 +1495,7 @@ function SettingsContent() {
   } = useTTSStore();
   const practiceTranslationVisibility = usePracticeTranslationStore((s) => s.visibility);
   const setPracticeTranslationVisible = usePracticeTranslationStore((s) => s.setVisible);
-  const resetTranslationToDefaults = usePracticeTranslationStore((s) => s.resetToDefaults);
+  const resetPracticeTranslation = usePracticeTranslationStore((s) => s.reset);
 
   const [authError, setAuthError] = useState<string | null>(null);
   const [authSuccess, setAuthSuccess] = useState<string | null>(null);
@@ -1938,12 +1939,10 @@ function SettingsContent() {
             <div className="space-y-3">
               {PRACTICE_TRANSLATION_MODULES.map((module) => {
                 const isVisible = practiceTranslationVisibility[module];
-                const defaultVisible = PRACTICE_TRANSLATION_POLICY[module].defaultVisible;
                 const label = translationMessages[`${module}Label` as keyof typeof translationMessages] as string;
                 const description = translationMessages[
                   `${module}Description` as keyof typeof translationMessages
                 ] as string;
-                const defaultLabel = defaultVisible ? translationMessages.defaultOn : translationMessages.defaultOff;
 
                 return (
                   <div
@@ -1959,19 +1958,14 @@ function SettingsContent() {
                         <Badge
                           variant="outline"
                           className={cn(
-                            'text-[10px] uppercase tracking-wide',
-                            isVisible
-                              ? 'border-emerald-200 bg-emerald-50 text-emerald-700'
-                              : 'border-slate-200 bg-white text-slate-400',
+                            'border-slate-200 bg-white text-[10px] uppercase tracking-wide',
+                            isVisible ? 'text-indigo-700' : 'text-slate-500',
                           )}
                         >
                           {isVisible ? translationMessages.currentOn : translationMessages.currentOff}
                         </Badge>
                       </div>
                       <p className="mt-0.5 text-xs leading-relaxed text-slate-400">{description}</p>
-                      <p className="mt-1 text-[11px] text-slate-400">
-                        {interpolate(translationMessages.defaultHint, { state: defaultLabel })}
-                      </p>
                     </div>
                     <Toggle
                       value={isVisible}
@@ -1984,14 +1978,16 @@ function SettingsContent() {
             </div>
           </div>
           <div className="flex items-center justify-between">
-            <p className="text-xs text-slate-400 flex-1">{translationMessages.footer}</p>
-            <button
-              type="button"
-              onClick={resetTranslationToDefaults}
-              className="shrink-0 ml-3 text-xs font-medium text-indigo-600 hover:text-indigo-800 cursor-pointer transition-colors"
+            <p className="text-xs text-slate-400">{translationMessages.footer}</p>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 gap-1 text-xs text-slate-400 hover:text-slate-600"
+              onClick={resetPracticeTranslation}
             >
-              {translationMessages.resetToDefaults}
-            </button>
+              <RotateCcw className="size-3" />
+              {translationMessages.resetToDefault}
+            </Button>
           </div>
         </div>
       </Section>

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -1494,6 +1494,7 @@ function SettingsContent() {
   } = useTTSStore();
   const practiceTranslationVisibility = usePracticeTranslationStore((s) => s.visibility);
   const setPracticeTranslationVisible = usePracticeTranslationStore((s) => s.setVisible);
+  const resetTranslationToDefaults = usePracticeTranslationStore((s) => s.resetToDefaults);
 
   const [authError, setAuthError] = useState<string | null>(null);
   const [authSuccess, setAuthSuccess] = useState<string | null>(null);
@@ -1942,6 +1943,7 @@ function SettingsContent() {
                 const description = translationMessages[
                   `${module}Description` as keyof typeof translationMessages
                 ] as string;
+                const defaultLabel = defaultVisible ? translationMessages.defaultOn : translationMessages.defaultOff;
 
                 return (
                   <div
@@ -1957,14 +1959,19 @@ function SettingsContent() {
                         <Badge
                           variant="outline"
                           className={cn(
-                            'border-slate-200 bg-white text-[10px] uppercase tracking-wide',
-                            defaultVisible ? 'text-emerald-700' : 'text-slate-500',
+                            'text-[10px] uppercase tracking-wide',
+                            isVisible
+                              ? 'border-emerald-200 bg-emerald-50 text-emerald-700'
+                              : 'border-slate-200 bg-white text-slate-400',
                           )}
                         >
-                          {defaultVisible ? translationMessages.defaultOn : translationMessages.defaultOff}
+                          {isVisible ? translationMessages.currentOn : translationMessages.currentOff}
                         </Badge>
                       </div>
                       <p className="mt-0.5 text-xs leading-relaxed text-slate-400">{description}</p>
+                      <p className="mt-1 text-[11px] text-slate-400">
+                        {interpolate(translationMessages.defaultHint, { state: defaultLabel })}
+                      </p>
                     </div>
                     <Toggle
                       value={isVisible}
@@ -1976,7 +1983,16 @@ function SettingsContent() {
               })}
             </div>
           </div>
-          <p className="text-xs text-slate-400">{translationMessages.footer}</p>
+          <div className="flex items-center justify-between">
+            <p className="text-xs text-slate-400 flex-1">{translationMessages.footer}</p>
+            <button
+              type="button"
+              onClick={resetTranslationToDefaults}
+              className="shrink-0 ml-3 text-xs font-medium text-indigo-600 hover:text-indigo-800 cursor-pointer transition-colors"
+            >
+              {translationMessages.resetToDefaults}
+            </button>
+          </div>
         </div>
       </Section>
 

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -73,6 +73,7 @@ import { useFavoriteStore } from '@/stores/favorite-store';
 import { usePracticeTranslationStore } from '@/stores/practice-translation-store';
 import { usePronunciationStore } from '@/stores/pronunciation-store';
 import { useProviderStore } from '@/stores/provider-store';
+import { useShadowReadingStore } from '@/stores/shadow-reading-store';
 import { useSyncStore } from '@/stores/sync-store';
 import { useTTSStore } from '@/stores/tts-store';
 import type { PracticeModule } from '@/types/translation';
@@ -1490,9 +1491,9 @@ function SettingsContent() {
     recommendationsCount,
     setRecommendationsEnabled,
     setRecommendationsCount,
-    shadowReadingEnabled,
-    setShadowReadingEnabled,
   } = useTTSStore();
+  const shadowReadingEnabled = useShadowReadingStore((s) => s.enabled);
+  const setShadowReadingEnabled = useShadowReadingStore((s) => s.setEnabled);
   const practiceTranslationVisibility = usePracticeTranslationStore((s) => s.visibility);
   const setPracticeTranslationVisible = usePracticeTranslationStore((s) => s.setVisible);
   const resetPracticeTranslation = usePracticeTranslationStore((s) => s.reset);

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -390,6 +390,8 @@ function AIProviderSection({
     setBaseUrl,
     setApiPath,
     setNoModelApi,
+    setProviderMaxTokens,
+    globalMaxTokens,
     activeProviderId,
     setActiveProvider,
   } = useProviderStore();
@@ -1012,6 +1014,67 @@ function AIProviderSection({
           )}
         </div>
 
+        {/* ── Per-provider max tokens ─────────────────────────────────────── */}
+        <div className="space-y-1.5">
+          <div className="flex items-center justify-between">
+            <p className="text-xs font-semibold text-slate-500 uppercase tracking-wide">
+              {providerMessages.maxTokensLabel}
+            </p>
+            <span className="text-xs font-mono text-slate-500">{config.maxTokens ?? globalMaxTokens} tokens</span>
+          </div>
+          <div className="flex items-center gap-3">
+            <label className="flex items-start gap-2 cursor-pointer group">
+              <div className="relative mt-0.5">
+                <input
+                  type="checkbox"
+                  checked={config.maxTokens != null}
+                  onChange={(e) => {
+                    if (e.target.checked) {
+                      setProviderMaxTokens(editingId, globalMaxTokens);
+                    } else {
+                      setProviderMaxTokens(editingId, undefined);
+                    }
+                  }}
+                  className="sr-only peer"
+                />
+                <div
+                  className={cn(
+                    'w-4 h-4 rounded border-2 flex items-center justify-center transition-colors',
+                    config.maxTokens != null
+                      ? 'bg-indigo-600 border-indigo-600'
+                      : 'border-slate-300 bg-white group-hover:border-slate-400',
+                  )}
+                >
+                  {config.maxTokens != null && <Check className="w-2.5 h-2.5 text-white" strokeWidth={3} />}
+                </div>
+              </div>
+              <span className="text-xs text-slate-600">{providerMessages.maxTokensOverride}</span>
+            </label>
+          </div>
+          {config.maxTokens != null && (
+            <div>
+              <Slider
+                value={[config.maxTokens]}
+                onValueChange={(v) => setProviderMaxTokens(editingId, v[0])}
+                min={256}
+                max={16384}
+                step={256}
+              />
+              <div className="flex justify-between text-[10px] text-slate-400 mt-1">
+                <span>256</span>
+                <span>4096</span>
+                <span>8192</span>
+                <span>16384</span>
+              </div>
+            </div>
+          )}
+          {config.maxTokens == null && (
+            <p className="text-[11px] text-slate-400">
+              {interpolate(providerMessages.maxTokensGlobalFallback, { value: globalMaxTokens })}
+            </p>
+          )}
+        </div>
+
         {/* ── Actions ──────────────────────────────────────────────────────── */}
         <div className="space-y-2 pt-1">
           {/* OAuth button */}
@@ -1353,6 +1416,43 @@ function Toggle({
   );
 }
 
+// ─── AI Output Section ──────────────────────────────────────────────────────────
+
+function AIOutputSection() {
+  const { messages: settingsMessages } = useI18n('settings');
+  const aiOutputMessages = settingsMessages.aiOutput;
+  const { globalMaxTokens, setGlobalMaxTokens } = useProviderStore();
+
+  return (
+    <Section title={settingsMessages.sections.aiOutput} icon={Zap}>
+      <div className="space-y-4">
+        <div>
+          <div className="flex items-center justify-between mb-2">
+            <p className="text-sm font-medium text-slate-700">{aiOutputMessages.maxTokensLabel}</p>
+            <span className="text-xs font-mono text-slate-500">
+              {globalMaxTokens} {aiOutputMessages.maxTokensValue}
+            </span>
+          </div>
+          <Slider
+            value={[globalMaxTokens]}
+            onValueChange={(v) => setGlobalMaxTokens(v[0])}
+            min={256}
+            max={16384}
+            step={256}
+          />
+          <div className="flex justify-between text-[10px] text-slate-400 mt-1">
+            <span>256</span>
+            <span>4096</span>
+            <span>8192</span>
+            <span>16384</span>
+          </div>
+          <p className="text-[11px] text-slate-400 mt-2 leading-relaxed">{aiOutputMessages.maxTokensDescription}</p>
+        </div>
+      </div>
+    </Section>
+  );
+}
+
 // ─── Main settings content ────────────────────────────────────────────────────
 
 function SettingsContent() {
@@ -1552,6 +1652,9 @@ function SettingsContent() {
         setAuthSuccess={setAuthSuccess}
         highlightProviderId={oauthSuccessProvider}
       />
+
+      {/* AI Output */}
+      <AIOutputSection />
 
       {/* Voice & Speech */}
       <Section title={settingsMessages.sections.voiceAndSpeech} icon={Volume2}>

--- a/src/app/(app)/speak/[scenarioId]/page.tsx
+++ b/src/app/(app)/speak/[scenarioId]/page.tsx
@@ -3,6 +3,7 @@
 import { ArrowLeft, Send } from 'lucide-react';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
+import { RecommendationPanel } from '@/components/shared/recommendation-panel';
 import { ConversationArea } from '@/components/speak/conversation-area';
 import { ScenarioGoals } from '@/components/speak/scenario-goals';
 import { VoiceInputButton } from '@/components/speak/voice-input-button';
@@ -10,7 +11,9 @@ import { TranslationBar } from '@/components/translation/translation-bar';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { useConversation } from '@/hooks/use-conversation';
+import { useI18n } from '@/lib/i18n/use-i18n';
 import { getScenarioById } from '@/lib/scenarios';
+import { useTTSStore } from '@/stores/tts-store';
 
 const difficultyColors: Record<string, string> = {
   beginner: 'bg-green-100 text-green-700 border-green-200',
@@ -19,9 +22,11 @@ const difficultyColors: Record<string, string> = {
 };
 
 export default function ConversationPage() {
+  const { messages: t } = useI18n('speak');
   const params = useParams();
   const scenarioId = params.scenarioId as string;
   const scenario = getScenarioById(scenarioId);
+  const recommendationsEnabled = useTTSStore((s) => s.recommendationsEnabled);
 
   const {
     messages,
@@ -51,10 +56,10 @@ export default function ConversationPage() {
   if (!scenario) {
     return (
       <div className="flex flex-col items-center justify-center h-64 gap-3">
-        <p className="text-indigo-400">Scenario not found</p>
+        <p className="text-indigo-400">{t.scenarios.notFound}</p>
         <Link href="/speak">
           <Button variant="outline" className="border-indigo-200 text-indigo-600 cursor-pointer">
-            Back to Scenarios
+            {t.scenarios.backToScenarios}
           </Button>
         </Link>
       </div>
@@ -99,7 +104,7 @@ export default function ConversationPage() {
           onToggle={handleToggleRecording}
         />
         {isFallbackTranscribing && (
-          <p className="text-xs text-amber-600 font-medium text-center">Processing your speech...</p>
+          <p className="text-xs text-amber-600 font-medium text-center">{t.conversation.processing}</p>
         )}
         <div className="flex items-center gap-2">
           <input
@@ -107,7 +112,7 @@ export default function ConversationPage() {
             value={textInput}
             onChange={(e) => setTextInput(e.target.value)}
             onKeyDown={handleKeyDown}
-            placeholder="Or type your response..."
+            placeholder={t.conversation.typeResponsePlaceholder}
             disabled={isStreaming || isRecording}
             className="flex-1 h-10 px-4 text-sm rounded-full border border-indigo-200 bg-white/80 backdrop-blur-sm text-indigo-900 placeholder:text-indigo-300 focus:outline-none focus:ring-2 focus:ring-indigo-400/50 focus:border-indigo-400 disabled:opacity-50 disabled:cursor-not-allowed"
           />
@@ -121,6 +126,10 @@ export default function ConversationPage() {
           </Button>
         </div>
       </div>
+
+      {recommendationsEnabled && (
+        <RecommendationPanel text={`${scenario.title}: ${scenario.goals.join(', ')}`} contentType="phrase" />
+      )}
     </div>
   );
 }

--- a/src/app/(app)/speak/[scenarioId]/page.tsx
+++ b/src/app/(app)/speak/[scenarioId]/page.tsx
@@ -45,6 +45,7 @@ export default function ConversationPage() {
         }
       : undefined,
     openingMessage: scenario?.openingMessage,
+    contentId: scenarioId,
   });
 
   if (!scenario) {

--- a/src/app/(app)/speak/error.tsx
+++ b/src/app/(app)/speak/error.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { AlertTriangle, Mic, RotateCcw } from 'lucide-react';
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+
+export default function SpeakError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  return (
+    <div className="flex items-center justify-center min-h-[50vh]">
+      <div className="flex flex-col items-center gap-4 max-w-md text-center px-4">
+        <div className="w-14 h-14 rounded-2xl bg-green-100 flex items-center justify-center">
+          <AlertTriangle className="w-7 h-7 text-green-600" />
+        </div>
+        <div className="space-y-1">
+          <h2 className="text-lg font-semibold text-indigo-900">Conversation error</h2>
+          <p className="text-sm text-indigo-500">{error.message || 'Something went wrong with the conversation.'}</p>
+        </div>
+        <div className="flex gap-3">
+          <Button onClick={reset} variant="outline" className="cursor-pointer border-indigo-200 text-indigo-600">
+            <RotateCcw className="w-4 h-4 mr-2" />
+            Try Again
+          </Button>
+          <Link href="/speak">
+            <Button variant="outline" className="cursor-pointer border-indigo-200 text-indigo-600">
+              <Mic className="w-4 h-4 mr-2" />
+              Back to Scenarios
+            </Button>
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/speak/free/page.tsx
+++ b/src/app/(app)/speak/free/page.tsx
@@ -3,12 +3,15 @@
 import { ArrowLeft, MessageCircle, Send } from 'lucide-react';
 import Link from 'next/link';
 import { useState } from 'react';
+import { RecommendationPanel } from '@/components/shared/recommendation-panel';
 import { ConversationArea } from '@/components/speak/conversation-area';
 import { VoiceInputButton } from '@/components/speak/voice-input-button';
 import { TranslationBar } from '@/components/translation/translation-bar';
 import { Button } from '@/components/ui/button';
 import { useConversation } from '@/hooks/use-conversation';
+import { useI18n } from '@/lib/i18n/use-i18n';
 import { useSpeakStore } from '@/stores/speak-store';
+import { useTTSStore } from '@/stores/tts-store';
 
 const TOPIC_SUGGESTIONS = [
   { label: 'Daily Life', emoji: '🏠', hint: "Let's talk about daily routines and everyday life." },
@@ -25,8 +28,10 @@ const FREE_OPENING =
   "Hi there! 👋 I'm your English conversation partner. Feel free to talk about anything you'd like — or pick a topic above to get started. What's on your mind?";
 
 export default function FreeConversationPage() {
+  const { messages: speakMessages } = useI18n('speak');
   const [selectedTopic, setSelectedTopic] = useState<string | null>(null);
   const messages = useSpeakStore((s) => s.messages);
+  const recommendationsEnabled = useTTSStore((s) => s.recommendationsEnabled);
 
   const {
     isStreaming,
@@ -60,8 +65,10 @@ export default function FreeConversationPage() {
             <MessageCircle className="w-4 h-4 text-indigo-600" />
           </div>
           <div>
-            <h1 className="text-lg font-bold font-[var(--font-poppins)] text-indigo-900">Free Conversation</h1>
-            <p className="text-xs text-indigo-400">Chat about anything you like</p>
+            <h1 className="text-lg font-bold font-[var(--font-poppins)] text-indigo-900">
+              {speakMessages.freeConversation.pageTitle}
+            </h1>
+            <p className="text-xs text-indigo-400">{speakMessages.freeConversation.pageSubtitle}</p>
           </div>
         </div>
         <TranslationBar module="speak" />
@@ -70,7 +77,9 @@ export default function FreeConversationPage() {
       {/* Topic suggestions - shown when conversation just started */}
       {!hasStarted && (
         <div className="shrink-0 mb-3">
-          <p className="text-xs font-medium text-indigo-400 mb-2 uppercase tracking-wide">Suggested Topics</p>
+          <p className="text-xs font-medium text-indigo-400 mb-2 uppercase tracking-wide">
+            {speakMessages.freeConversation.suggestedTopics}
+          </p>
           <div className="flex flex-wrap gap-2">
             {TOPIC_SUGGESTIONS.map((topic) => (
               <button
@@ -109,7 +118,7 @@ export default function FreeConversationPage() {
           onToggle={handleToggleRecording}
         />
         {isFallbackTranscribing && (
-          <p className="text-xs text-amber-600 font-medium text-center">Processing your speech...</p>
+          <p className="text-xs text-amber-600 font-medium text-center">{speakMessages.conversation.processing}</p>
         )}
         <div className="flex items-center gap-2">
           <input
@@ -117,7 +126,7 @@ export default function FreeConversationPage() {
             value={textInput}
             onChange={(e) => setTextInput(e.target.value)}
             onKeyDown={handleKeyDown}
-            placeholder="Type your message..."
+            placeholder={speakMessages.conversation.typePlaceholder}
             disabled={isStreaming || isRecording}
             className="flex-1 h-10 px-4 text-sm rounded-full border border-indigo-200 bg-white/80 backdrop-blur-sm text-indigo-900 placeholder:text-indigo-300 focus:outline-none focus:ring-2 focus:ring-indigo-400/50 focus:border-indigo-400 disabled:opacity-50 disabled:cursor-not-allowed"
           />
@@ -131,6 +140,8 @@ export default function FreeConversationPage() {
           </Button>
         </div>
       </div>
+
+      {recommendationsEnabled && selectedTopic && <RecommendationPanel text={selectedTopic} contentType="phrase" />}
     </div>
   );
 }

--- a/src/app/(app)/speak/page.tsx
+++ b/src/app/(app)/speak/page.tsx
@@ -3,24 +3,25 @@
 import { MessageCircle, Mic } from 'lucide-react';
 import Link from 'next/link';
 import { ScenarioGrid } from '@/components/speak/scenario-grid';
+import { useI18n } from '@/lib/i18n/use-i18n';
 
 export default function SpeakPage() {
+  const { messages } = useI18n('speak');
+
   return (
     <div className="max-w-4xl mx-auto px-4 py-6 space-y-8">
-      {/* Header */}
       <div>
         <div className="flex items-center gap-3 mb-1">
           <div className="w-10 h-10 rounded-xl bg-teal-100 flex items-center justify-center">
             <MessageCircle className="w-5 h-5 text-teal-600" />
           </div>
           <div>
-            <h1 className="text-2xl font-bold font-[var(--font-poppins)] text-indigo-900">Speak</h1>
-            <p className="text-sm text-indigo-400">Practice English through conversation with AI</p>
+            <h1 className="text-2xl font-bold font-[var(--font-poppins)] text-indigo-900">{messages.page.title}</h1>
+            <p className="text-sm text-indigo-400">{messages.page.subtitle}</p>
           </div>
         </div>
       </div>
 
-      {/* Free Conversation CTA */}
       <Link href="/speak/free" className="block group">
         <div className="relative overflow-hidden rounded-2xl bg-gradient-to-br from-indigo-500 via-indigo-600 to-purple-600 p-6 shadow-lg shadow-indigo-200/50 transition-all duration-300 group-hover:shadow-xl group-hover:shadow-indigo-300/50 group-hover:scale-[1.01]">
           <div className="absolute top-0 right-0 w-32 h-32 bg-white/5 rounded-full -translate-y-8 translate-x-8" />
@@ -30,13 +31,18 @@ export default function SpeakPage() {
               <Mic className="w-8 h-8 text-white" />
             </div>
             <div className="flex-1 min-w-0">
-              <h2 className="text-xl font-bold text-white mb-1">Start Free Conversation</h2>
-              <p className="text-indigo-100 text-sm leading-relaxed">
-                Chat with AI about anything — daily life, hobbies, news, or whatever you like. No topic restrictions.
-              </p>
+              <h2 className="text-xl font-bold text-white mb-1">{messages.freeConversation.title}</h2>
+              <p className="text-indigo-100 text-sm leading-relaxed">{messages.freeConversation.description}</p>
             </div>
             <div className="shrink-0 w-10 h-10 rounded-full bg-white/15 flex items-center justify-center transition-transform duration-300 group-hover:translate-x-1">
-              <svg className="w-5 h-5 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <svg
+                className="w-5 h-5 text-white"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+                aria-hidden="true"
+              >
                 <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
               </svg>
             </div>
@@ -44,12 +50,11 @@ export default function SpeakPage() {
         </div>
       </Link>
 
-      {/* Scenario Section */}
       <div>
         <div className="flex items-center gap-2 mb-4">
           <div className="w-1 h-5 rounded-full bg-indigo-400" />
-          <h2 className="text-lg font-semibold text-indigo-900">Or pick a scenario</h2>
-          <p className="text-sm text-indigo-400 ml-1">for guided practice</p>
+          <h2 className="text-lg font-semibold text-indigo-900">{messages.scenarios.sectionTitle}</h2>
+          <p className="text-sm text-indigo-400 ml-1">{messages.scenarios.sectionSubtitle}</p>
         </div>
         <ScenarioGrid getHref={(scenario) => `/speak/${scenario.id}`} />
       </div>

--- a/src/app/(app)/write/[id]/page.tsx
+++ b/src/app/(app)/write/[id]/page.tsx
@@ -206,11 +206,22 @@ export default function WriteDetailPage() {
     return () => window.removeEventListener('keydown', handleGlobalKey);
   }, [state.mode]);
 
+  const [isReviewMode, setIsReviewMode] = useState(false);
+
   const handleReset = () => {
     if (content) {
       dispatch({ type: 'INIT', text: content.text });
+      setIsReviewMode(false);
     }
     inputRef.current?.focus();
+  };
+
+  const handleReviewErrors = () => {
+    if (state.errorWords.length > 0) {
+      dispatch({ type: 'INIT', text: state.errorWords.join(' ') });
+      setIsReviewMode(true);
+      inputRef.current?.focus();
+    }
   };
 
   const focusInput = () => {
@@ -271,7 +282,14 @@ export default function WriteDetailPage() {
           </Button>
         </Link>
         <div className="flex-1 min-w-0">
-          <h1 className="text-2xl font-bold font-[var(--font-poppins)] text-indigo-900 truncate">{content.title}</h1>
+          <div className="flex items-center gap-2">
+            <h1 className="text-2xl font-bold font-[var(--font-poppins)] text-indigo-900 truncate">{content.title}</h1>
+            {isReviewMode && (
+              <span className="shrink-0 inline-flex items-center gap-1 rounded-full bg-orange-100 px-2 py-0.5 text-xs font-semibold text-orange-700">
+                <Target className="w-3 h-3" /> Error Review
+              </span>
+            )}
+          </div>
           <p className="text-sm text-indigo-500">{content.type} · Write Mode</p>
         </div>
         <CrossModuleNav contentId={content.id} currentModule="write" />
@@ -490,9 +508,14 @@ export default function WriteDetailPage() {
               </div>
             )}
 
-            <div className="flex gap-4 justify-center">
+            <div className="flex gap-4 justify-center flex-wrap">
+              {state.errorWords.length > 0 && (
+                <Button onClick={handleReviewErrors} className="bg-orange-500 hover:bg-orange-600 cursor-pointer">
+                  <Target className="w-4 h-4 mr-2" /> Review Error Words
+                </Button>
+              )}
               <Button onClick={handleReset} className="bg-indigo-600 hover:bg-indigo-700 cursor-pointer">
-                <RotateCcw className="w-4 h-4 mr-2" /> Try Again
+                <RotateCcw className="w-4 h-4 mr-2" /> {isReviewMode ? 'Full Text Again' : 'Try Again'}
               </Button>
               <Link href="/dashboard">
                 <Button variant="outline" className="border-green-300 text-green-700 hover:bg-green-50 cursor-pointer">

--- a/src/app/(app)/write/[id]/page.tsx
+++ b/src/app/(app)/write/[id]/page.tsx
@@ -7,8 +7,10 @@ import { useParams, useRouter } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react';
 import { CrossModuleNav } from '@/components/shared/cross-module-nav';
 import { FormattedContentText } from '@/components/shared/formatted-content-text';
+import { PageSpinner } from '@/components/shared/page-spinner';
 import { fireConfetti } from '@/components/shared/practice-complete-banner';
 import { RecommendationPanel } from '@/components/shared/recommendation-panel';
+import { ShadowReadingProgressBar } from '@/components/shared/shadow-reading-progress-bar';
 import { TranslationBar } from '@/components/translation/translation-bar';
 import { TranslationDisplay } from '@/components/translation/translation-display';
 import { Button } from '@/components/ui/button';
@@ -23,6 +25,7 @@ import { db } from '@/lib/db';
 import { matchesShortcutEvent } from '@/lib/shortcut-utils';
 import { useContentStore } from '@/stores/content-store';
 import { usePracticeTranslationStore } from '@/stores/practice-translation-store';
+import { useShadowReadingStore } from '@/stores/shadow-reading-store';
 import { useShortcutStore } from '@/stores/shortcut-store';
 import { useTTSStore } from '@/stores/tts-store';
 import type { ContentItem } from '@/types/content';
@@ -58,8 +61,9 @@ export default function WriteDetailPage() {
   const showTranslation = usePracticeTranslationStore((s) => s.visibility.write);
   const targetLang = useTTSStore((s) => s.targetLang);
   const recommendationsEnabled = useTTSStore((s) => s.recommendationsEnabled);
-  const shadowReadingEnabled = useTTSStore((s) => s.shadowReadingEnabled);
-  const { addContent, setActiveContentId } = useContentStore();
+  const shadowReadingSession = useShadowReadingStore((s) => s.session);
+  const markModuleProgress = useShadowReadingStore((s) => s.markModuleProgress);
+  const { addContent } = useContentStore();
   const { speak } = useTTS();
   const {
     sentenceTranslations,
@@ -107,10 +111,10 @@ export default function WriteDetailPage() {
   }, [params.id]);
 
   useEffect(() => {
-    if (shadowReadingEnabled) {
-      setActiveContentId(params.id as string);
+    if (shadowReadingSession?.contentId === params.id) {
+      markModuleProgress('write', 'in_progress');
     }
-  }, [params.id, shadowReadingEnabled, setActiveContentId]);
+  }, [params.id, shadowReadingSession?.contentId, markModuleProgress]);
 
   useEffect(() => {
     if (state.mode === 'typing') {
@@ -137,7 +141,7 @@ export default function WriteDetailPage() {
     };
   }, [state.isShaking]);
 
-  // Auto-scroll to cursor position for long articles
+  // biome-ignore lint/correctness/useExhaustiveDependencies: scroll on cursor position change is intentional
   useEffect(() => {
     if (state.mode === 'typing' && cursorRef.current) {
       cursorRef.current.scrollIntoView({
@@ -147,9 +151,19 @@ export default function WriteDetailPage() {
     }
   }, [state.currentWordIndex, state.currentCharIndex, state.mode]);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: moduleProgress checked at completion time, not as trigger
   useEffect(() => {
     if (state.mode === 'finished' && content) {
-      fireConfetti();
+      const isShadowContent = shadowReadingSession?.contentId === content.id;
+      const willTriggerShadowCompletion =
+        isShadowContent &&
+        shadowReadingSession.moduleProgress.listen === 'completed' &&
+        shadowReadingSession.moduleProgress.read === 'completed';
+
+      if (!willTriggerShadowCompletion) {
+        fireConfetti();
+      }
+
       const session = {
         id: nanoid(),
         contentId: content.id,
@@ -165,6 +179,9 @@ export default function WriteDetailPage() {
         completed: true,
       };
       void savePracticeSession(session);
+      if (isShadowContent) {
+        markModuleProgress('write', 'completed');
+      }
     }
   }, [
     state.mode,
@@ -175,6 +192,8 @@ export default function WriteDetailPage() {
     state.errorCount,
     state.wpm,
     state.accuracy,
+    shadowReadingSession?.contentId,
+    markModuleProgress,
     state.words.length,
   ]);
 
@@ -208,13 +227,13 @@ export default function WriteDetailPage() {
 
   const [isReviewMode, setIsReviewMode] = useState(false);
 
-  const handleReset = () => {
+  const handleReset = useCallback(() => {
     if (content) {
       dispatch({ type: 'INIT', text: content.text });
       setIsReviewMode(false);
     }
     inputRef.current?.focus();
-  };
+  }, [content]);
 
   const handleReviewErrors = () => {
     if (state.errorWords.length > 0) {
@@ -267,7 +286,7 @@ export default function WriteDetailPage() {
   }, [content?.text, state.words]);
 
   if (!content) {
-    return <div className="flex items-center justify-center h-64 text-indigo-400">Loading...</div>;
+    return <PageSpinner size="sm" className="min-h-[40vh]" />;
   }
 
   const fullText = state.words.join(' ');
@@ -292,7 +311,11 @@ export default function WriteDetailPage() {
           </div>
           <p className="text-sm text-indigo-500">{content.type} · Write Mode</p>
         </div>
-        <CrossModuleNav contentId={content.id} currentModule="write" />
+        {shadowReadingSession?.contentId === content.id ? (
+          <ShadowReadingProgressBar contentId={content.id} currentModule="write" showSpeakHint speakHref="/speak" />
+        ) : (
+          <CrossModuleNav contentId={content.id} currentModule="write" />
+        )}
       </div>
 
       <Card className="bg-white border-slate-100 shadow-sm">

--- a/src/app/(app)/write/[id]/page.tsx
+++ b/src/app/(app)/write/[id]/page.tsx
@@ -5,6 +5,7 @@ import { nanoid } from 'nanoid';
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react';
+import { CrossModuleNav } from '@/components/shared/cross-module-nav';
 import { FormattedContentText } from '@/components/shared/formatted-content-text';
 import { fireConfetti } from '@/components/shared/practice-complete-banner';
 import { RecommendationPanel } from '@/components/shared/recommendation-panel';
@@ -269,10 +270,11 @@ export default function WriteDetailPage() {
             <ArrowLeft className="w-5 h-5" />
           </Button>
         </Link>
-        <div>
-          <h1 className="text-2xl font-bold font-[var(--font-poppins)] text-indigo-900">{content.title}</h1>
+        <div className="flex-1 min-w-0">
+          <h1 className="text-2xl font-bold font-[var(--font-poppins)] text-indigo-900 truncate">{content.title}</h1>
           <p className="text-sm text-indigo-500">{content.type} · Write Mode</p>
         </div>
+        <CrossModuleNav contentId={content.id} currentModule="write" />
       </div>
 
       <Card className="bg-white border-slate-100 shadow-sm">

--- a/src/app/(app)/write/error.tsx
+++ b/src/app/(app)/write/error.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { AlertTriangle, PenTool, RotateCcw } from 'lucide-react';
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+
+export default function WriteError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  return (
+    <div className="flex items-center justify-center min-h-[50vh]">
+      <div className="flex flex-col items-center gap-4 max-w-md text-center px-4">
+        <div className="w-14 h-14 rounded-2xl bg-purple-100 flex items-center justify-center">
+          <AlertTriangle className="w-7 h-7 text-purple-500" />
+        </div>
+        <div className="space-y-1">
+          <h2 className="text-lg font-semibold text-indigo-900">Writing practice error</h2>
+          <p className="text-sm text-indigo-500">{error.message || 'Something went wrong loading this content.'}</p>
+        </div>
+        <div className="flex gap-3">
+          <Button onClick={reset} variant="outline" className="cursor-pointer border-indigo-200 text-indigo-600">
+            <RotateCcw className="w-4 h-4 mr-2" />
+            Try Again
+          </Button>
+          <Link href="/library">
+            <Button variant="outline" className="cursor-pointer border-indigo-200 text-indigo-600">
+              <PenTool className="w-4 h-4 mr-2" />
+              Pick Content
+            </Button>
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -520,12 +520,15 @@ function maybeHandleMockChat(
 }
 
 export async function POST(req: NextRequest) {
+  const DEFAULT_MAX_TOKENS = 4096;
+
   const {
     messages,
     provider = 'groq',
     context,
     userLevel,
     providerConfigs = {},
+    maxTokens: requestedMaxTokens,
   }: {
     messages: Array<ChatUIMessage | LegacyChatMessage>;
     provider?: ProviderId;
@@ -540,7 +543,10 @@ export async function POST(req: NextRequest) {
     };
     userLevel?: string;
     providerConfigs?: Partial<Record<ProviderId, Partial<ProviderConfig>>>;
+    maxTokens?: number;
   } = await req.json();
+
+  const maxTokens = requestedMaxTokens && requestedMaxTokens > 0 ? requestedMaxTokens : DEFAULT_MAX_TOKENS;
 
   if (!Array.isArray(messages)) {
     return new Response(JSON.stringify({ error: 'Messages are required' }), {
@@ -682,6 +688,7 @@ export async function POST(req: NextRequest) {
         system: systemPrompt,
         messages: modelMessages,
         tools,
+        maxOutputTokens: maxTokens,
         stopWhen: stepCountIs(3),
       });
 
@@ -727,7 +734,12 @@ export async function POST(req: NextRequest) {
       if (hitError) {
         // Tool calling failed — retry without tools for a text-only response
         const noToolMessages = await convertToModelMessages(uiMessages);
-        const fallback = streamText({ model, system: systemPrompt, messages: noToolMessages });
+        const fallback = streamText({
+          model,
+          system: systemPrompt,
+          messages: noToolMessages,
+          maxOutputTokens: maxTokens,
+        });
         writer.merge(fallback.toUIMessageStream());
       }
     },

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -694,7 +694,7 @@ export async function POST(req: NextRequest) {
 
       const uiStream = result.toUIMessageStream();
       const reader = uiStream.getReader();
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      // biome-ignore lint/suspicious/noExplicitAny: stream chunk types from AI SDK are not easily narrowed
       const earlyBuffer: any[] = [];
       let hitError = false;
 

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { AlertTriangle, RotateCcw } from 'lucide-react';
+
+export default function GlobalError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  return (
+    <html lang="en">
+      <body className="bg-[#EEF2FF] font-sans antialiased">
+        <div className="flex items-center justify-center min-h-screen">
+          <div className="flex flex-col items-center gap-5 max-w-md text-center px-6">
+            <div className="w-16 h-16 rounded-2xl bg-red-100 flex items-center justify-center">
+              <AlertTriangle className="w-8 h-8 text-red-500" />
+            </div>
+            <div className="space-y-2">
+              <h1 className="text-xl font-bold text-[#312E81]">Something went wrong</h1>
+              <p className="text-sm text-[#818CF8] leading-relaxed">
+                {error.message || 'An unexpected error occurred. Please try again.'}
+              </p>
+              {error.digest && <p className="text-xs text-slate-400 font-mono">Error ID: {error.digest}</p>}
+            </div>
+            <button
+              onClick={reset}
+              type="button"
+              className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl border border-[#4F46E5]/20 text-[#4F46E5] text-sm font-medium hover:bg-[#4F46E5]/5 transition-colors cursor-pointer"
+            >
+              <RotateCcw className="w-4 h-4" />
+              Try Again
+            </button>
+          </div>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/src/components/chat/blocks/reading-block.tsx
+++ b/src/components/chat/blocks/reading-block.tsx
@@ -51,8 +51,13 @@ export function ReadingBlockComponent({ block, onWordClick, onComprehensionCheck
                 {seg.text.split(/\s+/).map((word, i) => (
                   <span key={i}>
                     <span
+                      role="button"
+                      tabIndex={0}
                       className="hover:bg-indigo-50 hover:text-indigo-700 rounded px-0.5 cursor-pointer transition-colors"
                       onClick={() => handleWordClick(word)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') handleWordClick(word);
+                      }}
                     >
                       {word}
                     </span>{' '}

--- a/src/components/chat/chat-panel.tsx
+++ b/src/components/chat/chat-panel.tsx
@@ -2,7 +2,19 @@
 
 import { useChat } from '@ai-sdk/react';
 import { type ChatRequestOptions, DefaultChatTransport, lastAssistantMessageIsCompleteWithToolCalls } from 'ai';
-import { BarChart3, BookOpen, Bot, Headphones, Languages, MessageSquare, PenLine, Send, X } from 'lucide-react';
+import {
+  AlertTriangle,
+  BarChart3,
+  BookOpen,
+  Bot,
+  Headphones,
+  Languages,
+  MessageSquare,
+  PenLine,
+  Send,
+  Settings,
+  X,
+} from 'lucide-react';
 import { usePathname, useRouter } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ChatHistory } from '@/components/chat/chat-history';
@@ -33,6 +45,78 @@ function cefrToDifficulty(level: CEFRLevel | null): 'beginner' | 'intermediate' 
   if (level === 'A1' || level === 'A2') return 'beginner';
   if (level === 'B1' || level === 'B2') return 'intermediate';
   return 'advanced';
+}
+
+interface ParsedError {
+  title: string;
+  description: string;
+  action?: { label: string; href?: string; onClick?: string };
+}
+
+function parseProviderError(message: string): ParsedError | null {
+  const lower = message.toLowerCase();
+
+  if (lower.includes('max_tokens') || lower.includes('credits') || lower.includes('can only afford')) {
+    const tokenMatch = message.match(/requested up to (\d+) tokens.*afford (\d+)/i);
+    return {
+      title: 'Token limit exceeded',
+      description: tokenMatch
+        ? `Requested ${tokenMatch[1]} tokens but only ${tokenMatch[2]} available. Reduce "Max Output Tokens" in Settings or add credits.`
+        : 'The request exceeds your token limit. Reduce "Max Output Tokens" in Settings or upgrade your plan.',
+      action: { label: 'Open Settings', href: '/settings' },
+    };
+  }
+
+  if (lower.includes('rate limit') || lower.includes('rate_limit') || lower.includes('too many requests')) {
+    return {
+      title: 'Rate limited',
+      description: 'Too many requests. Please wait a moment before sending another message.',
+    };
+  }
+
+  if (lower.includes('invalid api key') || lower.includes('invalid_api_key') || lower.includes('unauthorized')) {
+    return {
+      title: 'Invalid API key',
+      description: 'Your API key may be expired or incorrect. Please check your key in Settings.',
+      action: { label: 'Open Settings', href: '/settings' },
+    };
+  }
+
+  if (
+    lower.includes('insufficient') &&
+    (lower.includes('quota') || lower.includes('balance') || lower.includes('funds'))
+  ) {
+    return {
+      title: 'Insufficient balance',
+      description: 'Your account balance is too low. Please add credits or switch to a different provider.',
+      action: { label: 'Open Settings', href: '/settings' },
+    };
+  }
+
+  if (lower.includes('model not found') || lower.includes('model_not_found')) {
+    return {
+      title: 'Model not available',
+      description: 'The selected model is not available. Please choose a different model in Settings.',
+      action: { label: 'Open Settings', href: '/settings' },
+    };
+  }
+
+  if (lower.includes('context length') || lower.includes('context_length_exceeded')) {
+    return {
+      title: 'Message too long',
+      description:
+        'The conversation is too long for this model. Try starting a new conversation or using a model with a larger context window.',
+    };
+  }
+
+  if (lower.includes('timeout') || lower.includes('timed out')) {
+    return {
+      title: 'Request timeout',
+      description: 'The AI provider took too long to respond. Please try again.',
+    };
+  }
+
+  return null;
 }
 
 export function ChatPanel({ onClose }: ChatPanelProps) {
@@ -440,11 +524,42 @@ export function ChatPanel({ onClose }: ChatPanelProps) {
               {toolNotice}
             </div>
           )}
-          {error && renderedMessages.at(-1)?.role !== 'assistant' && (
-            <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700">
-              {error.message.startsWith('{') ? 'Something went wrong. Please try again.' : error.message}
-            </div>
-          )}
+          {error &&
+            renderedMessages.at(-1)?.role !== 'assistant' &&
+            (() => {
+              const rawMsg = error.message.startsWith('{') ? '' : error.message;
+              const parsed = rawMsg ? parseProviderError(rawMsg) : null;
+
+              if (parsed) {
+                return (
+                  <div className="rounded-xl border border-red-200 bg-red-50 px-3.5 py-3 text-xs">
+                    <div className="flex items-start gap-2">
+                      <AlertTriangle className="w-4 h-4 text-red-500 shrink-0 mt-0.5" />
+                      <div className="flex-1 min-w-0">
+                        <p className="font-semibold text-red-800">{parsed.title}</p>
+                        <p className="mt-0.5 text-red-700 leading-relaxed">{parsed.description}</p>
+                        {parsed.action?.href && (
+                          <button
+                            type="button"
+                            onClick={() => router.push(parsed.action!.href!)}
+                            className="mt-2 inline-flex items-center gap-1 rounded-md border border-red-300 bg-white px-2.5 py-1 text-[11px] font-medium text-red-800 hover:bg-red-100 cursor-pointer transition-colors"
+                          >
+                            <Settings className="w-3 h-3" />
+                            {parsed.action.label}
+                          </button>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                );
+              }
+
+              return (
+                <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700">
+                  {rawMsg || 'Something went wrong. Please try again.'}
+                </div>
+              );
+            })()}
           {renderedMessages.length === 0 && (
             <div className="text-center py-6">
               <Bot className="w-8 h-8 mx-auto mb-2 text-indigo-300" />

--- a/src/components/chat/chat-panel.tsx
+++ b/src/components/chat/chat-panel.tsx
@@ -72,6 +72,8 @@ export function ChatPanel({ onClose }: ChatPanelProps) {
 
   const activeProviderId = useProviderStore((s) => s.activeProviderId);
   const providers = useProviderStore((s) => s.providers);
+  const globalMaxTokens = useProviderStore((s) => s.globalMaxTokens);
+  const effectiveMaxTokens = providers[activeProviderId]?.maxTokens ?? globalMaxTokens;
   const activeConfig = providers[activeProviderId];
   const providerDef = PROVIDER_REGISTRY[activeProviderId];
   const ollamaModelStatus = useProviderStore((s) => s.ollamaModelStatus);
@@ -173,10 +175,11 @@ export function ChatPanel({ onClose }: ChatPanelProps) {
           providerConfigs: providers,
           context,
           userLevel: currentLevel,
+          maxTokens: effectiveMaxTokens,
         },
       };
     },
-    [activeContentItem, activeProviderId, buildApiHeaders, chatMode, currentLevel, providers],
+    [activeContentItem, activeProviderId, buildApiHeaders, chatMode, currentLevel, effectiveMaxTokens, providers],
   );
 
   const updateProviderConfig = useCallback(

--- a/src/components/chat/chat-voice-input.tsx
+++ b/src/components/chat/chat-voice-input.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { Mic, MicOff } from 'lucide-react';
-import { useCallback } from 'react';
+import { Loader2, Mic, MicOff } from 'lucide-react';
+import { useCallback, useState } from 'react';
+import { useFallbackSTT } from '@/hooks/use-fallback-stt';
 import { useVoiceRecognition } from '@/hooks/use-voice-recognition';
 
 interface ChatVoiceInputProps {
@@ -9,6 +10,9 @@ interface ChatVoiceInputProps {
 }
 
 export function ChatVoiceInput({ onTranscript }: ChatVoiceInputProps) {
+  const [fallbackInterim, setFallbackInterim] = useState('');
+  const [isTranscribing, setIsTranscribing] = useState(false);
+
   const handleResult = useCallback(
     (text: string, isFinal: boolean) => {
       if (isFinal && text.trim()) {
@@ -18,32 +22,81 @@ export function ChatVoiceInput({ onTranscript }: ChatVoiceInputProps) {
     [onTranscript],
   );
 
-  const { isListening, interimTranscript, isSupported, startListening, stopListening } = useVoiceRecognition({
+  const {
+    isListening,
+    interimTranscript,
+    isSupported: nativeSupported,
+    startListening,
+    stopListening,
+  } = useVoiceRecognition({
     lang: 'en-US',
     continuous: false,
     interimResults: true,
     onResult: handleResult,
   });
 
-  if (!isSupported) return null;
+  const fallbackSTT = useFallbackSTT({
+    lang: 'en',
+    onTranscript: useCallback(
+      (text: string) => {
+        setIsTranscribing(false);
+        setFallbackInterim('');
+        if (text.trim()) onTranscript(text.trim());
+      },
+      [onTranscript],
+    ),
+    onInterimTranscript: useCallback((text: string) => {
+      setFallbackInterim(text);
+    }, []),
+    onError: useCallback(() => {
+      setIsTranscribing(false);
+      setFallbackInterim('');
+    }, []),
+  });
+
+  const isFallbackRecording = fallbackSTT.isRecording;
+  const activeListening = nativeSupported ? isListening : isFallbackRecording;
+  const displayInterim = nativeSupported ? interimTranscript : fallbackInterim;
+
+  const handleToggle = useCallback(() => {
+    if (nativeSupported) {
+      if (isListening) stopListening();
+      else startListening();
+    } else {
+      if (isFallbackRecording) {
+        fallbackSTT.stopRecording();
+        setIsTranscribing(true);
+      } else {
+        void fallbackSTT.startRecording();
+      }
+    }
+  }, [nativeSupported, isListening, isFallbackRecording, startListening, stopListening, fallbackSTT]);
+
+  if (isTranscribing) {
+    return (
+      <div className="flex items-center gap-2">
+        <Loader2 className="w-4 h-4 text-indigo-500 animate-spin" />
+      </div>
+    );
+  }
 
   return (
     <div className="flex items-center gap-2">
-      {isListening && interimTranscript && (
-        <span className="text-xs text-slate-400 truncate max-w-[200px] italic">{interimTranscript}</span>
+      {activeListening && displayInterim && (
+        <span className="text-xs text-slate-400 truncate max-w-[200px] italic">{displayInterim}</span>
       )}
       <button
         type="button"
-        onClick={isListening ? stopListening : startListening}
+        onClick={handleToggle}
         className={`p-1.5 rounded-lg transition-colors cursor-pointer ${
-          isListening
+          activeListening
             ? 'bg-red-100 text-red-600 animate-pulse'
             : 'text-slate-400 hover:text-indigo-600 hover:bg-indigo-50'
         }`}
-        aria-label={isListening ? 'Stop listening' : 'Start voice input'}
-        title={isListening ? 'Stop listening' : 'Voice input'}
+        aria-label={activeListening ? 'Stop listening' : 'Start voice input'}
+        title={activeListening ? 'Stop listening' : 'Voice input'}
       >
-        {isListening ? <MicOff className="w-4 h-4" /> : <Mic className="w-4 h-4" />}
+        {activeListening ? <MicOff className="w-4 h-4" /> : <Mic className="w-4 h-4" />}
       </button>
     </div>
   );

--- a/src/components/dashboard/mini-heatmap.tsx
+++ b/src/components/dashboard/mini-heatmap.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useMemo } from 'react';
+
+interface Props {
+  data: { date: string; count: number }[];
+  days?: number;
+}
+
+function getColor(count: number): string {
+  if (count === 0) return 'bg-slate-100';
+  if (count === 1) return 'bg-indigo-200';
+  if (count <= 3) return 'bg-indigo-400';
+  if (count <= 5) return 'bg-indigo-500';
+  return 'bg-indigo-700';
+}
+
+export function MiniHeatmap({ data, days = 56 }: Props) {
+  const recentData = useMemo(() => {
+    const slice = data.slice(-days);
+    const grid: { date: string; count: number }[][] = [];
+    let week: { date: string; count: number }[] = [];
+
+    const firstDate = slice.length > 0 ? new Date(slice[0].date) : new Date();
+    const startDow = firstDate.getDay();
+    for (let i = 0; i < startDow; i++) {
+      week.push({ date: '', count: -1 });
+    }
+
+    for (const d of slice) {
+      week.push(d);
+      if (week.length === 7) {
+        grid.push(week);
+        week = [];
+      }
+    }
+    if (week.length > 0) grid.push(week);
+    return grid;
+  }, [data, days]);
+
+  const totalSessions = data.slice(-days).reduce((s, d) => s + d.count, 0);
+
+  if (totalSessions === 0) {
+    return <p className="text-xs text-indigo-400 py-2">No activity yet</p>;
+  }
+
+  return (
+    <div className="flex gap-[2px]">
+      {recentData.map((week, wi) => (
+        <div key={wi} className="flex flex-col gap-[2px]">
+          {week.map((d, di) => (
+            <div
+              key={di}
+              className={`w-[10px] h-[10px] rounded-[2px] ${d.count < 0 ? 'bg-transparent' : getColor(d.count)}`}
+              title={d.date ? `${d.date}: ${d.count} sessions` : ''}
+            />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/dashboard/mini-heatmap.tsx
+++ b/src/components/dashboard/mini-heatmap.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useMemo } from 'react';
+import { useI18n } from '@/lib/i18n/use-i18n';
 
 interface Props {
   data: { date: string; count: number }[];
@@ -16,6 +17,7 @@ function getColor(count: number): string {
 }
 
 export function MiniHeatmap({ data, days = 56 }: Props) {
+  const { messages: t } = useI18n('dashboard');
   const recentData = useMemo(() => {
     const slice = data.slice(-days);
     const grid: { date: string; count: number }[][] = [];
@@ -41,7 +43,7 @@ export function MiniHeatmap({ data, days = 56 }: Props) {
   const totalSessions = data.slice(-days).reduce((s, d) => s + d.count, 0);
 
   if (totalSessions === 0) {
-    return <p className="text-xs text-indigo-400 py-2">No activity yet</p>;
+    return <p className="text-xs text-indigo-400 py-2">{t.miniAnalytics.noActivity}</p>;
   }
 
   return (
@@ -52,7 +54,7 @@ export function MiniHeatmap({ data, days = 56 }: Props) {
             <div
               key={di}
               className={`w-[10px] h-[10px] rounded-[2px] ${d.count < 0 ? 'bg-transparent' : getColor(d.count)}`}
-              title={d.date ? `${d.date}: ${d.count} sessions` : ''}
+              title={d.date ? `${d.date}: ${d.count} ${t.miniAnalytics.sessions}` : ''}
             />
           ))}
         </div>

--- a/src/components/dashboard/mini-module-breakdown.tsx
+++ b/src/components/dashboard/mini-module-breakdown.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { BookOpen, Headphones, Mic, PenTool } from 'lucide-react';
+import { useMemo } from 'react';
+import { useI18n } from '@/lib/i18n/use-i18n';
+
+interface Props {
+  data: Record<string, number>;
+}
+
+const MODULE_STYLE: Record<string, { icon: typeof Headphones; color: string; bg: string }> = {
+  listen: { icon: Headphones, color: 'text-indigo-600', bg: 'bg-indigo-100' },
+  speak: { icon: Mic, color: 'text-green-600', bg: 'bg-green-100' },
+  read: { icon: BookOpen, color: 'text-amber-600', bg: 'bg-amber-100' },
+  write: { icon: PenTool, color: 'text-purple-600', bg: 'bg-purple-100' },
+};
+
+export function MiniModuleBreakdown({ data }: Props) {
+  const { messages: t } = useI18n('dashboard');
+  const total = Object.values(data).reduce((s, n) => s + n, 0);
+
+  const moduleLabels = useMemo<Record<string, string>>(
+    () => ({
+      listen: t.modules.listen.label,
+      speak: t.modules.speak.label,
+      read: t.modules.read.label,
+      write: t.modules.write.label,
+    }),
+    [t],
+  );
+
+  if (total === 0) {
+    return <p className="text-xs text-indigo-400 py-2">{t.miniAnalytics.noSessions}</p>;
+  }
+
+  const entries = Object.entries(MODULE_STYLE)
+    .map(([key, style]) => ({
+      key,
+      count: data[key] || 0,
+      pct: total > 0 ? Math.round(((data[key] || 0) / total) * 100) : 0,
+      label: moduleLabels[key],
+      ...style,
+    }))
+    .filter((e) => e.count > 0);
+
+  return (
+    <div className="space-y-2">
+      <div className="flex rounded-full overflow-hidden h-2.5 bg-slate-100">
+        {entries.map((e) => (
+          <div key={e.key} className={`${e.bg} transition-all`} style={{ width: `${e.pct}%` }} />
+        ))}
+      </div>
+      <div className="flex flex-wrap gap-x-4 gap-y-1">
+        {entries.map((e) => {
+          const Icon = e.icon;
+          return (
+            <span key={e.key} className="flex items-center gap-1 text-xs">
+              <Icon className={`w-3 h-3 ${e.color}`} />
+              <span className="text-indigo-600">{e.label}</span>
+              <span className="font-medium text-indigo-900">{e.count}</span>
+              <span className="text-indigo-400">({e.pct}%)</span>
+            </span>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/mini-review-forecast.tsx
+++ b/src/components/dashboard/mini-review-forecast.tsx
@@ -1,24 +1,29 @@
 'use client';
 
+import { useI18n } from '@/lib/i18n/use-i18n';
+
 interface Props {
   data: { date: string; count: number }[];
 }
 
 export function MiniReviewForecast({ data }: Props) {
+  const { messages: t } = useI18n('dashboard');
   const total = data.reduce((s, d) => s + d.count, 0);
   const today = data[0]?.count ?? 0;
   const max = Math.max(...data.map((d) => d.count), 1);
 
   if (total === 0) {
-    return <p className="text-xs text-indigo-400 py-2">No upcoming reviews</p>;
+    return <p className="text-xs text-indigo-400 py-2">{t.miniAnalytics.noUpcomingReviews}</p>;
   }
 
   return (
     <div className="space-y-2">
       <div className="flex items-baseline gap-2">
         <span className="text-2xl font-bold text-indigo-900">{today}</span>
-        <span className="text-xs text-indigo-500">due today</span>
-        <span className="text-xs text-indigo-400 ml-auto">{total} this week</span>
+        <span className="text-xs text-indigo-500">{t.miniAnalytics.dueToday}</span>
+        <span className="text-xs text-indigo-400 ml-auto">
+          {total} {t.miniAnalytics.thisWeek}
+        </span>
       </div>
       <div className="flex items-end gap-1 h-8">
         {data.map((d) => (

--- a/src/components/dashboard/mini-review-forecast.tsx
+++ b/src/components/dashboard/mini-review-forecast.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+interface Props {
+  data: { date: string; count: number }[];
+}
+
+export function MiniReviewForecast({ data }: Props) {
+  const total = data.reduce((s, d) => s + d.count, 0);
+  const today = data[0]?.count ?? 0;
+  const max = Math.max(...data.map((d) => d.count), 1);
+
+  if (total === 0) {
+    return <p className="text-xs text-indigo-400 py-2">No upcoming reviews</p>;
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-baseline gap-2">
+        <span className="text-2xl font-bold text-indigo-900">{today}</span>
+        <span className="text-xs text-indigo-500">due today</span>
+        <span className="text-xs text-indigo-400 ml-auto">{total} this week</span>
+      </div>
+      <div className="flex items-end gap-1 h-8">
+        {data.map((d) => (
+          <div key={d.date} className="flex-1 flex flex-col items-center gap-0.5">
+            <div
+              className="w-full rounded-sm bg-indigo-400 min-h-[2px] transition-all"
+              style={{ height: `${(d.count / max) * 100}%` }}
+            />
+            <span className="text-[9px] text-indigo-400 leading-none">
+              {new Date(d.date).toLocaleDateString('en', { weekday: 'narrow' })}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/favorites/favorites-review.tsx
+++ b/src/components/favorites/favorites-review.tsx
@@ -4,6 +4,7 @@ import { ArrowLeft, Volume2 } from 'lucide-react';
 import Link from 'next/link';
 import { useMemo, useState } from 'react';
 import { Rating } from 'ts-fsrs';
+import { PageSpinner } from '@/components/shared/page-spinner';
 import { Button } from '@/components/ui/button';
 import { previewRatings } from '@/lib/fsrs';
 import { cn } from '@/lib/utils';
@@ -24,7 +25,7 @@ export function FavoritesReview() {
   const totalCount = dueItems.length;
 
   if (!isLoaded) {
-    return <div className="h-64 flex items-center justify-center text-slate-400">Loading...</div>;
+    return <PageSpinner size="sm" className="min-h-[40vh]" />;
   }
 
   if (totalCount === 0 || currentIndex >= totalCount) {

--- a/src/components/import/local-media-upload.tsx
+++ b/src/components/import/local-media-upload.tsx
@@ -9,6 +9,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { useI18n } from '@/lib/i18n/use-i18n';
+import { saveMediaBlob } from '@/lib/media-storage';
 import { normalizeTags } from '@/lib/utils';
 import { useContentStore } from '@/stores/content-store';
 import { useProviderStore } from '@/stores/provider-store';
@@ -146,8 +147,9 @@ export function LocalMediaUpload({ compact, onImported }: LocalMediaUploadProps)
     setSaving(true);
 
     const now = Date.now();
+    const contentId = nanoid();
     const item: ContentItem = {
-      id: nanoid(),
+      id: contentId,
       title: title.trim() || file?.name || m.fallbackTitle,
       text: result.text,
       type: 'article',
@@ -156,7 +158,7 @@ export function LocalMediaUpload({ compact, onImported }: LocalMediaUploadProps)
       source: 'imported',
       difficulty,
       metadata: {
-        audioUrl: result.audioUrl,
+        audioUrl: `idb:${contentId}`,
         sourceFilename: file?.name,
         platform: 'local',
         videoDuration: result.duration,
@@ -170,6 +172,9 @@ export function LocalMediaUpload({ compact, onImported }: LocalMediaUploadProps)
       updatedAt: now,
     };
 
+    if (file) {
+      await saveMediaBlob(contentId, file);
+    }
     await addContent(item);
     setSaving(false);
 

--- a/src/components/layout/command-palette.tsx
+++ b/src/components/layout/command-palette.tsx
@@ -1,11 +1,22 @@
 'use client';
 
-import { BookOpen, Headphones, Heart, MessageCircle, Play, Settings2, SquarePen } from 'lucide-react';
+import {
+  BookOpen,
+  Headphones,
+  Heart,
+  Library,
+  MessageCircle,
+  Play,
+  RotateCcw,
+  Settings2,
+  SquarePen,
+} from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import { useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from '@/components/ui/command';
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog';
 import { formatKeyCombo } from '@/hooks/use-shortcuts';
+import { db } from '@/lib/db';
 import { isMac } from '@/lib/utils';
 import { useChatStore } from '@/stores/chat-store';
 import { useShortcutStore } from '@/stores/shortcut-store';
@@ -21,6 +32,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
   const setPaused = useShortcutStore((s) => s.setPaused);
   const searchKey = formatKeyCombo(getKey('global:command-palette'));
   const defaultSearchKey = isMac() ? 'Command+K' : 'Ctrl+K';
+  const [lastPracticeHref, setLastPracticeHref] = useState<string | null>(null);
 
   useEffect(() => {
     setPaused(open);
@@ -29,6 +41,23 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
       setPaused(false);
     };
   }, [open, setPaused]);
+
+  const loadLastPractice = useCallback(async () => {
+    try {
+      const sessions = await db.sessions.toArray();
+      const completed = sessions.filter((s) => s.completed);
+      if (completed.length === 0) return;
+      const latest = completed.sort((a, b) => (b.endTime ?? b.startTime) - (a.endTime ?? a.startTime))[0];
+      const mod = latest.module === 'speak' ? 'read' : latest.module || 'write';
+      setLastPracticeHref(`/${mod}/${latest.contentId}`);
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
+  useEffect(() => {
+    if (open) loadLastPractice();
+  }, [open, loadLastPractice]);
 
   const items = useMemo(
     () => [
@@ -43,6 +72,18 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
         label: 'Toggle Chat',
         icon: MessageCircle,
         action: () => useChatStore.getState().toggleOpen(),
+      },
+      {
+        id: 'global:nav-review',
+        label: "Go to Today's Review",
+        icon: RotateCcw,
+        action: () => router.push('/review/today'),
+      },
+      {
+        id: 'global:nav-library',
+        label: 'Go to Library',
+        icon: Library,
+        action: () => router.push('/library'),
       },
       {
         id: 'global:nav-listen',
@@ -80,8 +121,18 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
         icon: Play,
         action: () => router.push('/favorites/review'),
       },
+      ...(lastPracticeHref
+        ? [
+            {
+              id: 'global:continue-last',
+              label: 'Continue Last Practice',
+              icon: Play,
+              action: () => router.push(lastPracticeHref),
+            },
+          ]
+        : []),
     ],
-    [router],
+    [router, lastPracticeHref],
   );
 
   return (

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -14,6 +14,7 @@ import {
   Library,
   MessageCircle,
   PenTool,
+  RotateCcw,
   Settings,
   X,
   Zap,
@@ -246,6 +247,7 @@ export function Sidebar({ open = false, onOpenChange }: SidebarProps = {}) {
         { href: '/speak', label: messages.items.speak, icon: MessageCircle },
         { href: '/read', label: messages.items.read, icon: BookOpen },
         { href: '/write', label: messages.items.write, icon: PenTool },
+        { href: '/review/today', label: messages.items.todayReview, icon: RotateCcw },
       ],
     },
     {

--- a/src/components/settings/data-backup.tsx
+++ b/src/components/settings/data-backup.tsx
@@ -1,11 +1,33 @@
 'use client';
 
-import { AlertCircle, ArrowDownToLine, ArrowUpFromLine, Check, Database, Download, Upload } from 'lucide-react';
+import {
+  AlertCircle,
+  ArrowDownToLine,
+  ArrowUpFromLine,
+  Check,
+  Database,
+  Download,
+  HardDrive,
+  Upload,
+} from 'lucide-react';
 import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { db } from '@/lib/db';
 import { useI18n } from '@/lib/i18n/use-i18n';
+
+const BACKUP_SCHEMA_VERSION = 1;
+
+const SETTINGS_KEYS = [
+  'echotype_practice_translation',
+  'echotype_tts_settings',
+  'echotype_shortcut_store',
+  'echotype_daily_plan',
+  'echotype_chat_store',
+  'echotype_language',
+  'echotype_assessment',
+  'echotype_provider_store',
+];
 
 export function DataBackup() {
   const { messages } = useI18n('settings');
@@ -44,6 +66,61 @@ export function DataBackup() {
     setTimeout(() => setExportStatus(null), 3000);
   };
 
+  const handleExportFull = async () => {
+    const [contents, records, sessions, books, conversations, favorites, favoriteFolders, lookupHistory] =
+      await Promise.all([
+        db.contents.toArray(),
+        db.records.toArray(),
+        db.sessions.toArray(),
+        db.books.toArray(),
+        db.conversations.toArray(),
+        db.favorites.toArray(),
+        db.favoriteFolders.toArray(),
+        db.lookupHistory.toArray(),
+      ]);
+
+    const settings: Record<string, unknown> = {};
+    for (const key of SETTINGS_KEYS) {
+      try {
+        const val = localStorage.getItem(key);
+        if (val) settings[key] = JSON.parse(val);
+      } catch {
+        /* skip invalid */
+      }
+    }
+
+    const backup = {
+      _echotype_backup: true,
+      _version: BACKUP_SCHEMA_VERSION,
+      _exportedAt: new Date().toISOString(),
+      contents,
+      records,
+      sessions,
+      books,
+      conversations,
+      favorites,
+      favoriteFolders,
+      lookupHistory,
+      settings,
+    };
+
+    const total =
+      contents.length +
+      records.length +
+      sessions.length +
+      books.length +
+      conversations.length +
+      favorites.length +
+      favoriteFolders.length +
+      lookupHistory.length;
+
+    downloadJson(backup, `echotype-full-backup-${new Date().toISOString().slice(0, 10)}.json`);
+    setExportStatus(
+      messages.dataBackup.exportedFullBackup.replace('{{tables}}', '8').replace('{{total}}', String(total)),
+    );
+    setTimeout(() => setExportStatus(null), 4000);
+  };
+
   const handleImport = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     if (!file) return;
@@ -54,7 +131,44 @@ export function DataBackup() {
     try {
       const text = await file.text();
       const data = JSON.parse(text);
-      if (Array.isArray(data)) {
+
+      if (data._echotype_backup) {
+        const modeLabel = mergeMode === 'merge' ? messages.dataBackup.merge : messages.dataBackup.overwrite;
+        let total = 0;
+        let tables = 0;
+
+        async function restoreTable(table: import('dexie').Table, items: unknown[] | undefined) {
+          if (!items?.length) return;
+          if (mergeMode === 'overwrite') await table.clear();
+          await table.bulkPut(items);
+          total += items.length;
+          tables++;
+        }
+
+        await restoreTable(db.contents, data.contents);
+        await restoreTable(db.records, data.records);
+        await restoreTable(db.sessions, data.sessions);
+        await restoreTable(db.books, data.books);
+        await restoreTable(db.conversations, data.conversations);
+        await restoreTable(db.favorites, data.favorites);
+        await restoreTable(db.favoriteFolders, data.favoriteFolders);
+        await restoreTable(db.lookupHistory, data.lookupHistory);
+
+        if (data.settings && typeof data.settings === 'object') {
+          for (const [key, val] of Object.entries(data.settings)) {
+            if (SETTINGS_KEYS.includes(key)) {
+              localStorage.setItem(key, JSON.stringify(val));
+            }
+          }
+        }
+
+        setImportStatus(
+          messages.dataBackup.importedFullBackup
+            .replace('{{tables}}', String(tables))
+            .replace('{{total}}', String(total))
+            .replace('{{mode}}', modeLabel),
+        );
+      } else if (Array.isArray(data)) {
         if (mergeMode === 'overwrite') await db.contents.clear();
         await db.contents.bulkPut(data);
         setImportStatus(
@@ -89,7 +203,7 @@ export function DataBackup() {
 
   return (
     <div className="space-y-4">
-      <div className="grid gap-4 md:grid-cols-2">
+      <div className="grid gap-4 md:grid-cols-3">
         <Card className="border-slate-100 bg-white">
           <CardContent className="space-y-3 pt-4">
             <div className="flex items-center gap-2">
@@ -122,6 +236,24 @@ export function DataBackup() {
             >
               <Download className="mr-2 h-4 w-4" />
               {messages.dataBackup.exportLearningData}
+            </Button>
+          </CardContent>
+        </Card>
+
+        <Card className="border-indigo-100 bg-gradient-to-br from-indigo-50/50 to-white">
+          <CardContent className="space-y-3 pt-4">
+            <div className="flex items-center gap-2">
+              <HardDrive className="h-5 w-5 text-indigo-600" />
+              <h4 className="font-medium text-indigo-900">{messages.dataBackup.exportFullBackup}</h4>
+            </div>
+            <p className="text-xs text-indigo-500">{messages.dataBackup.exportFullBackupDescription}</p>
+            <Button
+              onClick={handleExportFull}
+              variant="outline"
+              className="w-full cursor-pointer border-indigo-300 text-indigo-700 font-medium"
+            >
+              <Download className="mr-2 h-4 w-4" />
+              {messages.dataBackup.exportFullBackup}
             </Button>
           </CardContent>
         </Card>

--- a/src/components/shared/content-list.tsx
+++ b/src/components/shared/content-list.tsx
@@ -8,9 +8,11 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { db } from '@/lib/db';
+import { useI18n } from '@/lib/i18n/use-i18n';
 import { cn } from '@/lib/utils';
 import { ALL_WORDBOOKS } from '@/lib/wordbooks';
 import { useContentStore } from '@/stores/content-store';
+import { useShadowReadingStore } from '@/stores/shadow-reading-store';
 import { useTTSStore } from '@/stores/tts-store';
 import { useWordBookStore } from '@/stores/wordbook-store';
 import type { ContentItem, ContentType } from '@/types/content';
@@ -130,6 +132,7 @@ function ContentRow({
   iconBg,
   sessionCount,
   isActive,
+  onNavigate,
 }: {
   module: string;
   item: ContentItem;
@@ -138,9 +141,11 @@ function ContentRow({
   iconBg: string;
   sessionCount: number;
   isActive: boolean;
+  onNavigate?: () => void;
 }) {
+  const { messages: srMessages } = useI18n('shadowReading');
   return (
-    <Link href={href}>
+    <Link href={href} onClick={onNavigate}>
       <Card
         data-testid={`${module}-content-row-${item.id}`}
         className={cn(
@@ -171,7 +176,11 @@ function ContentRow({
                   {item.category}
                 </Badge>
               )}
-              {isActive && <Badge className="bg-indigo-100 text-indigo-600 text-[10px] md:text-xs">Practicing</Badge>}
+              {isActive && (
+                <Badge className="bg-indigo-100 text-indigo-600 text-[10px] md:text-xs">
+                  {srMessages.contentList.practicing}
+                </Badge>
+              )}
             </div>
             <p className="text-xs md:text-sm text-indigo-500 line-clamp-1">{item.text}</p>
             {item.tags.length > 0 && (
@@ -219,8 +228,9 @@ interface ContentListProps {
 export function ContentList({ title, description, module, icon: Icon, iconBg, iconColor }: ContentListProps) {
   const { loadContents, setFilter, filter } = useContentStore();
   const allItems = useContentStore((s) => s.items);
-  const activeContentId = useContentStore((s) => s.activeContentId);
-  const shadowReadingEnabled = useTTSStore((s) => s.shadowReadingEnabled);
+  const shadowReadingEnabled = useShadowReadingStore((s) => s.enabled);
+  const shadowSession = useShadowReadingStore((s) => s.session);
+  const startOrSwitchSession = useShadowReadingStore((s) => s.startOrSwitchSession);
   const [activeTab, setActiveTab] = useState<ViewTab>('wordbook');
   const [sessionCounts, setSessionCounts] = useState<Record<string, number>>({});
   const activeItemRef = useRef<HTMLDivElement>(null);
@@ -304,10 +314,10 @@ export function ContentList({ title, description, module, icon: Icon, iconBg, ic
 
   // Scroll active item into view when shadow reading is enabled
   useEffect(() => {
-    if (shadowReadingEnabled && activeContentId && activeItemRef.current) {
+    if (shadowReadingEnabled && shadowSession?.contentId && activeItemRef.current) {
       activeItemRef.current.scrollIntoView({ behavior: 'smooth', block: 'center' });
     }
-  }, [shadowReadingEnabled, activeContentId]);
+  }, [shadowReadingEnabled, shadowSession?.contentId]);
 
   // Clear content store type filter when switching tabs (to not interfere)
   useEffect(() => {
@@ -418,7 +428,7 @@ export function ContentList({ title, description, module, icon: Icon, iconBg, ic
       ) : (
         <div className="grid gap-3">
           {tabItems.map((item) => {
-            const isActive = shadowReadingEnabled && activeContentId === item.id;
+            const isActive = shadowReadingEnabled && shadowSession?.contentId === item.id;
             return (
               <div key={item.id} ref={isActive ? activeItemRef : undefined}>
                 <ContentRow
@@ -429,6 +439,9 @@ export function ContentList({ title, description, module, icon: Icon, iconBg, ic
                   iconBg={iconBg}
                   sessionCount={sessionCounts[item.id] || 0}
                   isActive={isActive}
+                  onNavigate={
+                    shadowReadingEnabled && !shadowSession ? () => startOrSwitchSession(item.id, item.title) : undefined
+                  }
                 />
               </div>
             );

--- a/src/components/shared/cross-module-nav.tsx
+++ b/src/components/shared/cross-module-nav.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { BookOpen, Headphones, Mic, PenLine } from 'lucide-react';
+import Link from 'next/link';
+import { cn } from '@/lib/utils';
+
+type Module = 'listen' | 'read' | 'speak' | 'write';
+
+const MODULE_CONFIG: Record<Module, { icon: typeof Headphones; label: string; path: string }> = {
+  listen: { icon: Headphones, label: 'Listen', path: '/listen' },
+  read: { icon: BookOpen, label: 'Read', path: '/read' },
+  speak: { icon: Mic, label: 'Speak', path: '/read' },
+  write: { icon: PenLine, label: 'Write', path: '/write' },
+};
+
+const CONTENT_MODULES: Module[] = ['listen', 'read', 'write'];
+
+interface CrossModuleNavProps {
+  contentId: string;
+  currentModule: Module;
+}
+
+export function CrossModuleNav({ contentId, currentModule }: CrossModuleNavProps) {
+  const otherModules = CONTENT_MODULES.filter((m) => m !== currentModule);
+
+  return (
+    <div className="flex items-center gap-1">
+      {otherModules.map((mod) => {
+        const { icon: Icon, label, path } = MODULE_CONFIG[mod];
+        return (
+          <Link
+            key={mod}
+            href={`${path}/${contentId}`}
+            title={`Practice in ${label} mode`}
+            className={cn(
+              'flex items-center gap-1 px-2 py-1 rounded-lg text-xs font-medium transition-colors',
+              'text-indigo-500 hover:text-indigo-700 hover:bg-indigo-50',
+            )}
+          >
+            <Icon className="w-3.5 h-3.5" />
+            <span className="hidden sm:inline">{label}</span>
+          </Link>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/shared/page-spinner.tsx
+++ b/src/components/shared/page-spinner.tsx
@@ -1,0 +1,25 @@
+import { Loader2 } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface PageSpinnerProps {
+  className?: string;
+  size?: 'sm' | 'md' | 'lg';
+}
+
+const sizes = {
+  sm: { container: 'min-h-[30vh]', icon: 'w-5 h-5', ring: 'w-10 h-10' },
+  md: { container: 'min-h-[50vh]', icon: 'w-6 h-6', ring: 'w-12 h-12' },
+  lg: { container: 'min-h-[60vh]', icon: 'w-8 h-8', ring: 'w-16 h-16' },
+};
+
+export function PageSpinner({ className, size = 'md' }: PageSpinnerProps) {
+  const s = sizes[size];
+
+  return (
+    <div className={cn('flex items-center justify-center', s.container, className)}>
+      <div className={cn('rounded-full bg-indigo-50 flex items-center justify-center', s.ring)}>
+        <Loader2 className={cn('animate-spin text-indigo-500', s.icon)} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/shared/recommendation-panel.tsx
+++ b/src/components/shared/recommendation-panel.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { type Recommendation, useRecommendations } from '@/hooks/use-recommendations';
+import { useI18n } from '@/lib/i18n/use-i18n';
 import type { ContentItem } from '@/types/content';
 
 interface RecommendationPanelProps {
@@ -62,6 +63,8 @@ function RecommendationCard({
 export function RecommendationPanel({ content, text, contentType, onNavigate }: RecommendationPanelProps) {
   const { recommendations, isLoading, error, fetchRecommendations } = useRecommendations();
   const [collapsed, setCollapsed] = useState(true);
+  const { messages } = useI18n('practiceFeatures');
+  const t = messages.recommendations;
 
   const resolvedText = text ?? content?.text ?? '';
   const resolvedType = contentType ?? content?.type ?? 'sentence';
@@ -85,7 +88,7 @@ export function RecommendationPanel({ content, text, contentType, onNavigate }: 
           <div className="w-7 h-7 rounded-lg bg-indigo-50 flex items-center justify-center">
             <Sparkles className="w-3.5 h-3.5 text-indigo-500" />
           </div>
-          <span className="text-sm font-semibold text-slate-700">Recommendations</span>
+          <span className="text-sm font-semibold text-slate-700">{t.title}</span>
           {recommendations.length > 0 && (
             <span className="text-xs text-slate-400 bg-slate-100 px-2 py-0.5 rounded-full">
               {recommendations.length}
@@ -127,7 +130,7 @@ export function RecommendationPanel({ content, text, contentType, onNavigate }: 
               {isLoading ? (
                 <div className="flex items-center justify-center gap-2 py-8 text-slate-400">
                   <Loader2 className="w-4 h-4 animate-spin" />
-                  <span className="text-sm">Generating recommendations...</span>
+                  <span className="text-sm">{t.generating}</span>
                 </div>
               ) : error ? (
                 <div className="text-center py-6">
@@ -141,7 +144,7 @@ export function RecommendationPanel({ content, text, contentType, onNavigate }: 
                         className="inline-flex items-center gap-1 text-xs text-indigo-500 hover:text-indigo-600 font-medium"
                       >
                         <Settings className="w-3 h-3" />
-                        Go to Settings
+                        {t.goToSettings}
                       </Link>
                     ) : (
                       <Button
@@ -150,7 +153,7 @@ export function RecommendationPanel({ content, text, contentType, onNavigate }: 
                         className="text-indigo-500 hover:text-indigo-600 h-auto p-0 cursor-pointer"
                         onClick={() => fetchRecommendations(resolvedText, resolvedType)}
                       >
-                        Retry
+                        {t.retry}
                       </Button>
                     )}
                   </div>
@@ -163,14 +166,14 @@ export function RecommendationPanel({ content, text, contentType, onNavigate }: 
                 </div>
               ) : (
                 <div className="text-center py-6 text-slate-400 text-sm">
-                  No recommendations available.{' '}
+                  {t.empty}{' '}
                   <Button
                     variant="ghost"
                     size="sm"
                     className="text-indigo-500 hover:text-indigo-600 h-auto p-0 cursor-pointer"
                     onClick={() => fetchRecommendations(resolvedText, resolvedType)}
                   >
-                    Try again
+                    {t.tryAgain}
                   </Button>
                 </div>
               )}

--- a/src/components/shared/recommendation-panel.tsx
+++ b/src/components/shared/recommendation-panel.tsx
@@ -9,7 +9,9 @@ import { type Recommendation, useRecommendations } from '@/hooks/use-recommendat
 import type { ContentItem } from '@/types/content';
 
 interface RecommendationPanelProps {
-  content: ContentItem;
+  content?: ContentItem;
+  text?: string;
+  contentType?: string;
   onNavigate?: (item: Recommendation) => void;
 }
 
@@ -57,19 +59,23 @@ function RecommendationCard({
   );
 }
 
-export function RecommendationPanel({ content, onNavigate }: RecommendationPanelProps) {
+export function RecommendationPanel({ content, text, contentType, onNavigate }: RecommendationPanelProps) {
   const { recommendations, isLoading, error, fetchRecommendations } = useRecommendations();
   const [collapsed, setCollapsed] = useState(true);
 
+  const resolvedText = text ?? content?.text ?? '';
+  const resolvedType = contentType ?? content?.type ?? 'sentence';
+
   useEffect(() => {
+    if (!resolvedText) return;
     const timer = setTimeout(() => {
-      fetchRecommendations(content.text, content.type);
+      fetchRecommendations(resolvedText, resolvedType);
     }, 1500);
     return () => clearTimeout(timer);
-  }, [content.text, content.type, fetchRecommendations]);
+  }, [resolvedText, resolvedType, fetchRecommendations]);
 
   const handleRefresh = () => {
-    fetchRecommendations(`${content.text} ${Date.now()}`, content.type);
+    fetchRecommendations(`${resolvedText} ${Date.now()}`, resolvedType);
   };
 
   return (
@@ -142,7 +148,7 @@ export function RecommendationPanel({ content, onNavigate }: RecommendationPanel
                         variant="ghost"
                         size="sm"
                         className="text-indigo-500 hover:text-indigo-600 h-auto p-0 cursor-pointer"
-                        onClick={() => fetchRecommendations(content.text, content.type)}
+                        onClick={() => fetchRecommendations(resolvedText, resolvedType)}
                       >
                         Retry
                       </Button>
@@ -162,7 +168,7 @@ export function RecommendationPanel({ content, onNavigate }: RecommendationPanel
                     variant="ghost"
                     size="sm"
                     className="text-indigo-500 hover:text-indigo-600 h-auto p-0 cursor-pointer"
-                    onClick={() => fetchRecommendations(content.text, content.type)}
+                    onClick={() => fetchRecommendations(resolvedText, resolvedType)}
                   >
                     Try again
                   </Button>

--- a/src/components/shared/shadow-reading-completion.tsx
+++ b/src/components/shared/shadow-reading-completion.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import { BookOpen, Check, Headphones, Mic, PartyPopper, PenLine, RotateCcw, Trophy } from 'lucide-react';
+import Link from 'next/link';
+import { useEffect, useRef } from 'react';
+import { fireConfetti } from '@/components/shared/practice-complete-banner';
+import { Button } from '@/components/ui/button';
+import { useI18n } from '@/lib/i18n/use-i18n';
+import { playSessionCompleteSound } from '@/lib/sounds';
+import { cn } from '@/lib/utils';
+import { SHADOW_MODULES, type ShadowModule, useShadowReadingStore } from '@/stores/shadow-reading-store';
+
+type CompletionMessages = {
+  durationSeconds: string;
+  durationMinsSecs: string;
+  durationMins: string;
+  durationHoursMins: string;
+  durationHours: string;
+  [key: string]: string;
+};
+
+const MODULE_ICONS: Record<ShadowModule, typeof Headphones> = {
+  listen: Headphones,
+  read: BookOpen,
+  write: PenLine,
+};
+
+const MODULE_COLORS: Record<ShadowModule, string> = {
+  listen: 'bg-blue-50 text-blue-600',
+  read: 'bg-emerald-50 text-emerald-600',
+  write: 'bg-amber-50 text-amber-600',
+};
+
+function formatDuration(startMs: number, endMs: number, t: CompletionMessages): string {
+  const diffSec = Math.floor((endMs - startMs) / 1000);
+  if (diffSec < 60) return t.durationSeconds.replace('{{count}}', String(diffSec));
+  const mins = Math.floor(diffSec / 60);
+  const secs = diffSec % 60;
+  if (mins < 60) {
+    return secs > 0
+      ? t.durationMinsSecs.replace('{{mins}}', String(mins)).replace('{{secs}}', String(secs))
+      : t.durationMins.replace('{{mins}}', String(mins));
+  }
+  const hours = Math.floor(mins / 60);
+  const remainMins = mins % 60;
+  return remainMins > 0
+    ? t.durationHoursMins.replace('{{hours}}', String(hours)).replace('{{mins}}', String(remainMins))
+    : t.durationHours.replace('{{hours}}', String(hours));
+}
+
+export function ShadowReadingCompletion() {
+  const session = useShadowReadingStore((s) => s.session);
+  const showModal = useShadowReadingStore((s) => s.showCompletionModal);
+  const dismissCompletion = useShadowReadingStore((s) => s.dismissCompletion);
+  const startSession = useShadowReadingStore((s) => s.startSession);
+  const { messages } = useI18n('shadowReading');
+  const compMessages = messages.completion;
+  const firedRef = useRef(false);
+
+  useEffect(() => {
+    if (showModal && !firedRef.current) {
+      firedRef.current = true;
+      fireConfetti();
+      playSessionCompleteSound();
+    }
+    if (!showModal) {
+      firedRef.current = false;
+    }
+  }, [showModal]);
+
+  if (!showModal || !session) return null;
+
+  const duration = session.completedAt
+    ? formatDuration(session.startedAt, session.completedAt, compMessages as CompletionMessages)
+    : '';
+
+  const moduleLabels: Record<ShadowModule, string> = {
+    listen: compMessages.listenDone,
+    read: compMessages.readDone,
+    write: compMessages.writeDone,
+  };
+
+  const handleRepeat = () => {
+    startSession(session.contentId, session.contentTitle);
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm animate-in fade-in duration-300">
+      <div className="bg-white rounded-2xl shadow-2xl max-w-md w-full mx-4 overflow-hidden animate-in zoom-in-95 slide-in-from-bottom-4 duration-500">
+        <div className="bg-gradient-to-br from-indigo-500 to-violet-600 px-6 py-8 text-center">
+          <div className="w-16 h-16 mx-auto bg-white/20 rounded-full flex items-center justify-center mb-4">
+            <Trophy className="w-8 h-8 text-white" />
+          </div>
+          <h2 className="text-xl font-bold text-white">{compMessages.title}</h2>
+          <p className="text-indigo-100 text-sm mt-1">{compMessages.subtitle}</p>
+        </div>
+
+        <div className="px-6 py-5 space-y-4">
+          <div className="flex items-center gap-2 text-sm">
+            <PartyPopper className="w-4 h-4 text-indigo-500 shrink-0" />
+            <span className="text-slate-500">{compMessages.contentLabel}</span>
+            <span className="text-slate-700 font-medium truncate">{session.contentTitle}</span>
+          </div>
+
+          {duration && (
+            <p className="text-xs text-slate-400">{compMessages.timeSpent.replace('{{duration}}', duration)}</p>
+          )}
+
+          <div className="space-y-2">
+            <p className="text-xs font-medium text-slate-500 uppercase tracking-wide">{compMessages.moduleSummary}</p>
+            <div className="grid grid-cols-3 gap-2">
+              {SHADOW_MODULES.map((mod) => {
+                const Icon = MODULE_ICONS[mod];
+                return (
+                  <div
+                    key={mod}
+                    className={cn('flex flex-col items-center gap-1 rounded-lg py-2.5 px-2', MODULE_COLORS[mod])}
+                  >
+                    <div className="relative">
+                      <Icon className="w-5 h-5" />
+                      <Check className="w-3 h-3 absolute -bottom-0.5 -right-1 text-green-500" strokeWidth={3} />
+                    </div>
+                    <span className="text-[11px] font-medium">{moduleLabels[mod]}</span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+
+        <div className="px-6 pb-6 space-y-2">
+          <Link href="/library" className="block" onClick={dismissCompletion}>
+            <Button className="w-full bg-indigo-600 hover:bg-indigo-700 cursor-pointer">
+              {compMessages.startAnother}
+            </Button>
+          </Link>
+          <div className="grid grid-cols-2 gap-2">
+            <Link href={`/listen/${session.contentId}`} onClick={handleRepeat}>
+              <Button
+                variant="outline"
+                size="sm"
+                className="w-full text-xs border-indigo-200 text-indigo-600 hover:bg-indigo-50 cursor-pointer"
+              >
+                <RotateCcw className="w-3 h-3 mr-1" />
+                {compMessages.repeatPractice}
+              </Button>
+            </Link>
+            <Link href={`/speak/free`} onClick={dismissCompletion}>
+              <Button
+                variant="outline"
+                size="sm"
+                className="w-full text-xs border-indigo-200 text-indigo-600 hover:bg-indigo-50 cursor-pointer"
+              >
+                <Mic className="w-3 h-3 mr-1" />
+                {compMessages.trySpeaking}
+              </Button>
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/shared/shadow-reading-progress-bar.tsx
+++ b/src/components/shared/shadow-reading-progress-bar.tsx
@@ -1,0 +1,236 @@
+'use client';
+
+import { AnimatePresence, motion } from 'framer-motion';
+import { ArrowRight, BookOpen, Check, Headphones, Mic, PenLine } from 'lucide-react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useEffect, useRef, useState } from 'react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { useI18n } from '@/lib/i18n/use-i18n';
+import { playModuleCompleteSound } from '@/lib/sounds';
+import { cn } from '@/lib/utils';
+import {
+  type ModuleStatus,
+  SHADOW_MODULES,
+  type ShadowModule,
+  useShadowReadingStore,
+} from '@/stores/shadow-reading-store';
+
+const MODULE_CONFIG: Record<ShadowModule | 'speak', { icon: typeof Headphones; path: string }> = {
+  listen: { icon: Headphones, path: '/listen' },
+  read: { icon: BookOpen, path: '/read' },
+  write: { icon: PenLine, path: '/write' },
+  speak: { icon: Mic, path: '/speak' },
+};
+
+function StepConnector({ status, animate }: { status: ModuleStatus; animate?: boolean }) {
+  return (
+    <div className="flex-1 h-0.5 mx-1 relative overflow-hidden">
+      <div
+        className={cn(
+          'h-full rounded-full transition-colors',
+          status === 'completed' ? 'bg-green-400' : 'bg-slate-200',
+        )}
+      />
+      {animate && status === 'completed' && (
+        <motion.div
+          className="absolute inset-0 rounded-full bg-green-300"
+          initial={{ scaleX: 0, originX: 0 }}
+          animate={{ scaleX: [0, 1, 1], opacity: [1, 1, 0] }}
+          transition={{ duration: 0.6, ease: 'easeOut' }}
+        />
+      )}
+    </div>
+  );
+}
+
+function CompletedCheckmark({ justCompleted }: { justCompleted: boolean }) {
+  if (justCompleted) {
+    return (
+      <motion.div
+        initial={{ scale: 0, rotate: -90 }}
+        animate={{ scale: 1, rotate: 0 }}
+        transition={{ type: 'spring', stiffness: 300, damping: 15, delay: 0.1 }}
+      >
+        <div className="w-4 h-4 bg-green-500 rounded-full flex items-center justify-center">
+          <Check className="w-2.5 h-2.5 text-white" strokeWidth={3} />
+        </div>
+      </motion.div>
+    );
+  }
+  return <Check className="w-3.5 h-3.5" />;
+}
+
+interface ShadowReadingProgressBarProps {
+  contentId: string;
+  currentModule: ShadowModule;
+  showSpeakHint?: boolean;
+  speakHref?: string;
+}
+
+export function ShadowReadingProgressBar({
+  contentId,
+  currentModule,
+  showSpeakHint,
+  speakHref,
+}: ShadowReadingProgressBarProps) {
+  const session = useShadowReadingStore((s) => s.session);
+  const getNextIncompleteModule = useShadowReadingStore((s) => s.getNextIncompleteModule);
+  const { messages } = useI18n('shadowReading');
+  const pbMessages = messages.progressBar;
+
+  const pathname = usePathname();
+  const [justCompletedModule, setJustCompletedModule] = useState<ShadowModule | null>(null);
+  const [showNextPrompt, setShowNextPrompt] = useState(false);
+  const prevProgressRef = useRef<Record<ShadowModule, ModuleStatus> | null>(null);
+
+  useEffect(() => {
+    setShowNextPrompt(false);
+  }, [pathname]);
+
+  useEffect(() => {
+    if (!session) {
+      prevProgressRef.current = null;
+      return;
+    }
+
+    const prev = prevProgressRef.current;
+    prevProgressRef.current = { ...session.moduleProgress };
+
+    if (!prev) return;
+
+    for (const mod of SHADOW_MODULES) {
+      if (prev[mod] !== 'completed' && session.moduleProgress[mod] === 'completed') {
+        setJustCompletedModule(mod);
+        playModuleCompleteSound();
+        const nextMod = getNextIncompleteModule();
+        if (nextMod) {
+          setShowNextPrompt(true);
+        }
+        const timer = setTimeout(() => {
+          setJustCompletedModule(null);
+        }, 2000);
+        return () => clearTimeout(timer);
+      }
+    }
+  }, [session, getNextIncompleteModule]);
+
+  if (!session || session.contentId !== contentId) return null;
+
+  const moduleLabels: Record<ShadowModule | 'speak', string> = {
+    listen: pbMessages.listen,
+    read: pbMessages.read,
+    write: pbMessages.write,
+    speak: pbMessages.speakOptional,
+  };
+
+  const completedCount = SHADOW_MODULES.filter((m) => session.moduleProgress[m] === 'completed').length;
+  const progressPercent = Math.round((completedCount / SHADOW_MODULES.length) * 100);
+  const nextModule = getNextIncompleteModule();
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-0 bg-white/80 backdrop-blur-sm border border-slate-200 rounded-xl px-3 py-2 shadow-sm relative">
+        {SHADOW_MODULES.map((mod, index) => {
+          const status = session.moduleProgress[mod];
+          const { icon: Icon, path } = MODULE_CONFIG[mod];
+          const label = moduleLabels[mod];
+          const isCurrent = mod === currentModule;
+          const isJustCompleted = justCompletedModule === mod;
+
+          const stepContent = (
+            <motion.div
+              className={cn(
+                'flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-xs font-medium transition-all',
+                isCurrent && status !== 'completed' && 'bg-indigo-100 text-indigo-700',
+                status === 'completed' && 'text-green-600',
+                !isCurrent && status !== 'completed' && 'text-slate-400',
+                !isCurrent && 'hover:text-indigo-600 hover:bg-indigo-50/50',
+              )}
+              animate={isJustCompleted ? { scale: [1, 1.2, 1] } : undefined}
+              transition={{ duration: 0.4 }}
+            >
+              {status === 'completed' ? (
+                <CompletedCheckmark justCompleted={isJustCompleted} />
+              ) : (
+                <Icon className="w-3.5 h-3.5" />
+              )}
+              <span className="hidden sm:inline">{label}</span>
+            </motion.div>
+          );
+
+          return (
+            <div key={mod} className="flex items-center">
+              {index > 0 && (
+                <StepConnector
+                  status={SHADOW_MODULES[index - 1] ? session.moduleProgress[SHADOW_MODULES[index - 1]] : 'pending'}
+                  animate={justCompletedModule === SHADOW_MODULES[index - 1]}
+                />
+              )}
+              {isCurrent ? (
+                stepContent
+              ) : (
+                <Link href={`${path}/${contentId}`} title={pbMessages.practiceIn.replace('{{module}}', label)}>
+                  {stepContent}
+                </Link>
+              )}
+            </div>
+          );
+        })}
+
+        {showSpeakHint && speakHref && (
+          <>
+            <StepConnector status="pending" />
+            <Link
+              href={speakHref}
+              className="flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-xs font-medium text-slate-300 hover:text-indigo-400 transition-colors border border-dashed border-slate-200 hover:border-indigo-200"
+            >
+              <Mic className="w-3.5 h-3.5" />
+              <span className="hidden sm:inline">{moduleLabels.speak}</span>
+              <Badge variant="outline" className="text-[9px] px-1 py-0 h-3.5 border-slate-200 text-slate-400">
+                {pbMessages.optional}
+              </Badge>
+            </Link>
+          </>
+        )}
+
+        <div className="ml-2 text-[10px] text-slate-400 font-medium tabular-nums">{progressPercent}%</div>
+      </div>
+
+      <AnimatePresence>
+        {showNextPrompt && nextModule && (
+          <motion.div
+            initial={{ opacity: 0, y: -8, height: 0 }}
+            animate={{ opacity: 1, y: 0, height: 'auto' }}
+            exit={{ opacity: 0, y: -8, height: 0 }}
+            transition={{ type: 'spring', stiffness: 400, damping: 25 }}
+          >
+            <Link
+              href={`${MODULE_CONFIG[nextModule].path}/${contentId}`}
+              onClick={() => setShowNextPrompt(false)}
+              className="flex items-center justify-between gap-2 bg-indigo-50 hover:bg-indigo-100 border border-indigo-200 rounded-lg px-3 py-2 transition-colors group"
+            >
+              <div className="flex items-center gap-2">
+                <div className="w-5 h-5 rounded-full bg-green-100 flex items-center justify-center">
+                  <Check className="w-3 h-3 text-green-600" />
+                </div>
+                <span className="text-xs font-medium text-indigo-700">
+                  {pbMessages.moduleCompleted.replace('{{module}}', moduleLabels[justCompletedModule ?? currentModule])}
+                </span>
+              </div>
+              <Button
+                size="sm"
+                variant="ghost"
+                className="h-6 text-xs text-indigo-600 hover:text-indigo-800 gap-1 px-2"
+              >
+                {pbMessages.continueToNext.replace('{{module}}', moduleLabels[nextModule])}
+                <ArrowRight className="w-3 h-3 group-hover:translate-x-0.5 transition-transform" />
+              </Button>
+            </Link>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/src/components/shared/shadow-reading-status-bar.tsx
+++ b/src/components/shared/shadow-reading-status-bar.tsx
@@ -1,0 +1,235 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { AlertTriangle, ArrowRightLeft, BookOpen, Headphones, PenLine, Repeat, X } from 'lucide-react';
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { useI18n } from '@/lib/i18n/use-i18n';
+import { cn } from '@/lib/utils';
+import { SHADOW_MODULES, type ShadowModule, useShadowReadingStore } from '@/stores/shadow-reading-store';
+
+const MODULE_ICONS: Record<ShadowModule, typeof Headphones> = {
+  listen: Headphones,
+  read: BookOpen,
+  write: PenLine,
+};
+
+const MODULE_PATHS: Record<ShadowModule, string> = {
+  listen: '/listen',
+  read: '/read',
+  write: '/write',
+};
+
+function formatElapsed(startMs: number, nowMs: number): string {
+  const diffSec = Math.floor((nowMs - startMs) / 1000);
+  const mins = Math.floor(diffSec / 60);
+  const secs = diffSec % 60;
+  return `${mins}:${secs.toString().padStart(2, '0')}`;
+}
+
+export function ShadowReadingStatusBar() {
+  const session = useShadowReadingStore((s) => s.session);
+  const clearSession = useShadowReadingStore((s) => s.clearSession);
+  const getCompletedCount = useShadowReadingStore((s) => s.getCompletedCount);
+  const getNextIncompleteModule = useShadowReadingStore((s) => s.getNextIncompleteModule);
+  const showConfirm = useShadowReadingStore((s) => s.showEndConfirm);
+  const requestEndSession = useShadowReadingStore((s) => s.requestEndSession);
+  const cancelEndSession = useShadowReadingStore((s) => s.cancelEndSession);
+  const pendingSwitch = useShadowReadingStore((s) => s.pendingSwitch);
+  const confirmSwitch = useShadowReadingStore((s) => s.confirmSwitch);
+  const cancelSwitch = useShadowReadingStore((s) => s.cancelSwitch);
+  const { messages } = useI18n('shadowReading');
+  const sbMessages = messages.statusBar;
+
+  const [elapsed, setElapsed] = useState('0:00');
+
+  useEffect(() => {
+    if (!session || session.completedAt) return;
+    const update = () => setElapsed(formatElapsed(session.startedAt, Date.now()));
+    update();
+    const interval = setInterval(update, 1000);
+    return () => clearInterval(interval);
+  }, [session, session?.completedAt]);
+
+  if (!session) return null;
+
+  const completedCount = getCompletedCount();
+  const nextModule = getNextIncompleteModule();
+  const progressPercent = Math.round((completedCount / SHADOW_MODULES.length) * 100);
+
+  const moduleLabels: Record<ShadowModule, string> = {
+    listen: messages.progressBar.listen,
+    read: messages.progressBar.read,
+    write: messages.progressBar.write,
+  };
+
+  return (
+    <>
+      <div className="bg-gradient-to-r from-indigo-50 to-violet-50 border-b border-indigo-100 px-4 py-2">
+        <div className="max-w-6xl mx-auto flex items-center gap-3">
+          <motion.div
+            animate={{ rotate: [0, 15, -15, 0] }}
+            transition={{ duration: 0.6, delay: 0.2, ease: 'easeInOut' }}
+          >
+            <Repeat className="w-4 h-4 text-indigo-500 shrink-0" />
+          </motion.div>
+
+          <div className="flex items-center gap-2 flex-1 min-w-0">
+            <span className="text-xs font-semibold text-indigo-700">{sbMessages.title}</span>
+            <span className="text-xs text-indigo-500 truncate">{session.contentTitle}</span>
+
+            <div className="hidden sm:flex items-center gap-1 ml-2">
+              {SHADOW_MODULES.map((mod) => {
+                const status = session.moduleProgress[mod];
+                const Icon = MODULE_ICONS[mod];
+                return (
+                  <Link key={mod} href={`${MODULE_PATHS[mod]}/${session.contentId}`} title={moduleLabels[mod]}>
+                    <motion.div
+                      className={cn(
+                        'w-5 h-5 rounded-full flex items-center justify-center transition-colors cursor-pointer hover:ring-2 hover:ring-indigo-300',
+                        status === 'completed' && 'bg-green-100 text-green-600',
+                        status === 'in_progress' && 'bg-indigo-100 text-indigo-600',
+                        status === 'pending' && 'bg-slate-100 text-slate-400',
+                      )}
+                      animate={status === 'completed' ? { scale: [1, 1.15, 1] } : undefined}
+                      transition={{ duration: 0.3 }}
+                    >
+                      <Icon className="w-3 h-3" />
+                    </motion.div>
+                  </Link>
+                );
+              })}
+            </div>
+
+            <span className="text-[11px] text-indigo-400 ml-1 tabular-nums">
+              {sbMessages.progress.replace('{{completed}}', String(completedCount))}
+            </span>
+
+            <div className="hidden sm:block w-16 h-1.5 bg-indigo-100 rounded-full overflow-hidden ml-1">
+              <motion.div
+                className="h-full bg-indigo-500 rounded-full"
+                initial={{ width: 0 }}
+                animate={{ width: `${progressPercent}%` }}
+                transition={{ duration: 0.5, ease: 'easeOut' }}
+              />
+            </div>
+
+            <span className="text-[10px] text-indigo-300 tabular-nums ml-1">{elapsed}</span>
+          </div>
+
+          <div className="flex items-center gap-1.5 shrink-0">
+            {nextModule && (
+              <Link href={`${MODULE_PATHS[nextModule]}/${session.contentId}`}>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="h-6 text-[11px] text-indigo-600 hover:text-indigo-800 hover:bg-indigo-100 px-2"
+                >
+                  {sbMessages.nextModule.replace('{{module}}', moduleLabels[nextModule])}
+                </Button>
+              </Link>
+            )}
+            <Button
+              size="sm"
+              variant="ghost"
+              className="h-6 w-6 p-0 text-slate-400 hover:text-red-500 hover:bg-red-50 transition-colors"
+              onClick={requestEndSession}
+              title={sbMessages.endSession}
+            >
+              <X className="w-3.5 h-3.5" />
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      {/* End Session Confirmation */}
+      <Dialog
+        open={showConfirm}
+        onOpenChange={(open) => {
+          if (!open) cancelEndSession();
+        }}
+      >
+        <DialogContent className="sm:max-w-sm">
+          <DialogHeader>
+            <div className="flex items-center gap-2">
+              <div className="w-8 h-8 rounded-full bg-amber-100 flex items-center justify-center shrink-0">
+                <AlertTriangle className="w-4 h-4 text-amber-600" />
+              </div>
+              <DialogTitle className="text-base">{sbMessages.endSessionConfirmTitle}</DialogTitle>
+            </div>
+            <DialogDescription className="text-sm mt-2">{sbMessages.endSessionConfirmDesc}</DialogDescription>
+          </DialogHeader>
+
+          <div className="flex items-center gap-1.5 py-2">
+            {SHADOW_MODULES.map((mod) => {
+              const status = session.moduleProgress[mod];
+              const Icon = MODULE_ICONS[mod];
+              return (
+                <div
+                  key={mod}
+                  className={cn(
+                    'flex items-center gap-1 px-2 py-1 rounded-md text-xs',
+                    status === 'completed' && 'bg-green-50 text-green-700',
+                    status === 'in_progress' && 'bg-indigo-50 text-indigo-700',
+                    status === 'pending' && 'bg-slate-50 text-slate-400',
+                  )}
+                >
+                  <Icon className="w-3 h-3" />
+                  <span>{moduleLabels[mod]}</span>
+                </div>
+              );
+            })}
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" size="sm" onClick={cancelEndSession}>
+              {sbMessages.endSessionCancel}
+            </Button>
+            <Button variant="destructive" size="sm" onClick={clearSession}>
+              {sbMessages.endSessionConfirmAction}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Switch Session Confirmation */}
+      <Dialog
+        open={!!pendingSwitch}
+        onOpenChange={(open) => {
+          if (!open) cancelSwitch();
+        }}
+      >
+        <DialogContent className="sm:max-w-sm">
+          <DialogHeader>
+            <div className="flex items-center gap-2">
+              <div className="w-8 h-8 rounded-full bg-indigo-100 flex items-center justify-center shrink-0">
+                <ArrowRightLeft className="w-4 h-4 text-indigo-600" />
+              </div>
+              <DialogTitle className="text-base">{sbMessages.switchSessionTitle}</DialogTitle>
+            </div>
+            <DialogDescription className="text-sm mt-2">
+              {sbMessages.switchSessionDesc.replace('{{current}}', session.contentTitle)}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" size="sm" onClick={cancelSwitch}>
+              {sbMessages.switchSessionCancel}
+            </Button>
+            <Button size="sm" className="bg-indigo-600 hover:bg-indigo-700" onClick={confirmSwitch}>
+              {sbMessages.switchSessionConfirm}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/components/shared/word-book-practice.tsx
+++ b/src/components/shared/word-book-practice.tsx
@@ -21,6 +21,7 @@ import { nanoid } from 'nanoid';
 import Link from 'next/link';
 import { useParams, useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { PageSpinner } from '@/components/shared/page-spinner';
 import { fireConfetti } from '@/components/shared/practice-complete-banner';
 import { WordDictionaryInfo } from '@/components/shared/word-dictionary-info';
 import { TranslationBar } from '@/components/translation/translation-bar';
@@ -977,7 +978,7 @@ export function WordBookPractice({ module }: WordBookPracticeProps) {
   const config = moduleConfig[module];
 
   if (loading) {
-    return <div className="flex items-center justify-center h-64 text-indigo-400">Loading...</div>;
+    return <PageSpinner size="sm" className="min-h-[40vh]" />;
   }
 
   if ((!book && !bookInfo) || items.length === 0) {

--- a/src/components/shared/word-dictionary-info.tsx
+++ b/src/components/shared/word-dictionary-info.tsx
@@ -5,6 +5,23 @@ import { useWordDictionary } from '@/hooks/use-word-dictionary';
 import { usePracticeTranslationStore } from '@/stores/practice-translation-store';
 import type { PracticeModule } from '@/types/translation';
 
+const POS_ABBR: Record<string, string> = {
+  noun: 'n.',
+  verb: 'v.',
+  adjective: 'adj.',
+  adverb: 'adv.',
+  pronoun: 'pron.',
+  preposition: 'prep.',
+  conjunction: 'conj.',
+  interjection: 'interj.',
+  determiner: 'det.',
+  exclamation: 'excl.',
+};
+
+function abbreviatePos(pos: string): string {
+  return POS_ABBR[pos.toLowerCase()] || pos;
+}
+
 interface WordDictionaryInfoProps {
   word: string;
   targetLang: string;
@@ -13,10 +30,11 @@ interface WordDictionaryInfoProps {
 
 export function WordDictionaryInfo({ word, targetLang, module }: WordDictionaryInfoProps) {
   const showTranslation = usePracticeTranslationStore((s) => s.isVisible(module));
-  const { phonetic, pos, translation, isLoading } = useWordDictionary(word, targetLang, true);
+  const { phonetic, pos, meanings, translation, isLoading } = useWordDictionary(word, targetLang, true);
 
+  const hasMeanings = showTranslation && meanings.length > 0;
   const hasPhoneticOrPos = phonetic || pos;
-  const hasTranslation = showTranslation && translation;
+  const hasFallbackTranslation = showTranslation && !hasMeanings && translation;
 
   if (isLoading) {
     return (
@@ -26,7 +44,7 @@ export function WordDictionaryInfo({ word, targetLang, module }: WordDictionaryI
     );
   }
 
-  if (!hasPhoneticOrPos && !hasTranslation) return null;
+  if (!hasPhoneticOrPos && !hasMeanings && !hasFallbackTranslation) return null;
 
   return (
     <div className="space-y-0.5">
@@ -37,7 +55,17 @@ export function WordDictionaryInfo({ word, targetLang, module }: WordDictionaryI
           {pos && <span className="text-xs text-slate-400">{pos}</span>}
         </div>
       )}
-      {hasTranslation && (
+      {hasMeanings && (
+        <div className="space-y-0.5">
+          {meanings.map((m) => (
+            <p key={m.pos} className="min-h-[1.25rem] text-[15px] text-indigo-400/80 text-center">
+              <span className="font-semibold text-indigo-500/70">{abbreviatePos(m.pos)}</span>{' '}
+              <span className="font-medium">{m.definition}</span>
+            </p>
+          ))}
+        </div>
+      )}
+      {hasFallbackTranslation && (
         <p className="min-h-[1.25rem] text-[15px] text-indigo-400/80 text-center font-medium">{translation}</p>
       )}
     </div>

--- a/src/components/speak/conversation-area.tsx
+++ b/src/components/speak/conversation-area.tsx
@@ -3,6 +3,7 @@
 import { MessageCircle } from 'lucide-react';
 import { useEffect, useRef } from 'react';
 import { ScrollArea } from '@/components/ui/scroll-area';
+import { useI18n } from '@/lib/i18n/use-i18n';
 import type { ConversationMessage } from '@/types/scenario';
 import { MessageBubble } from './message-bubble';
 
@@ -14,6 +15,7 @@ interface ConversationAreaProps {
 }
 
 export function ConversationArea({ messages, onPlayVoice, onToggleTranslation }: ConversationAreaProps) {
+  const { messages: t } = useI18n('speak');
   const scrollRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -30,8 +32,8 @@ export function ConversationArea({ messages, onPlayVoice, onToggleTranslation }:
             <div className="w-14 h-14 rounded-full bg-indigo-100 flex items-center justify-center mx-auto mb-3">
               <MessageCircle className="w-7 h-7 text-indigo-400" />
             </div>
-            <p className="font-medium text-indigo-500">Ready to practice?</p>
-            <p className="text-indigo-300 mt-1">Tap the microphone to start speaking</p>
+            <p className="font-medium text-indigo-500">{t.conversation.readyToStart}</p>
+            <p className="text-indigo-300 mt-1">{t.conversation.tapMicrophone}</p>
           </div>
         )}
         {messages.map((msg) => (

--- a/src/components/speak/message-bubble.tsx
+++ b/src/components/speak/message-bubble.tsx
@@ -3,6 +3,7 @@
 import { motion } from 'framer-motion';
 import { Bot, Languages, Loader2, Volume2, VolumeX } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
+import { useI18n } from '@/lib/i18n/use-i18n';
 import type { ConversationMessage } from '@/types/scenario';
 
 interface MessageBubbleProps {
@@ -12,6 +13,7 @@ interface MessageBubbleProps {
 }
 
 export function MessageBubble({ message, onPlayVoice, onToggleTranslation }: MessageBubbleProps) {
+  const { messages: t } = useI18n('speak');
   const isUser = message.role === 'user' || message.role === 'recording';
 
   // Color scheme based on role
@@ -45,11 +47,11 @@ export function MessageBubble({ message, onPlayVoice, onToggleTranslation }: Mes
         >
           {message.role === 'assistant' ? (
             <div className="prose prose-sm prose-indigo max-w-none [&>p]:m-0 whitespace-pre-wrap">
-              <ReactMarkdown>{message.content || 'Thinking...'}</ReactMarkdown>
+              <ReactMarkdown>{message.content || t.conversation.thinking}</ReactMarkdown>
             </div>
           ) : (
             <span className="whitespace-pre-wrap">
-              {message.content || (message.role === 'recording' ? 'Listening...' : '')}
+              {message.content || (message.role === 'recording' ? t.conversation.listening : '')}
             </span>
           )}
         </div>
@@ -63,7 +65,7 @@ export function MessageBubble({ message, onPlayVoice, onToggleTranslation }: Mes
               className={`h-6 w-6 flex items-center justify-center rounded-md transition-colors cursor-pointer ${
                 message.isPlaying ? btnActive : btnBase
               }`}
-              title={message.isPlaying ? 'Stop voice' : 'Play voice'}
+              title={message.isPlaying ? t.conversation.stopVoice : t.conversation.playVoice}
             >
               {message.isPlaying ? (
                 <VolumeX className="w-3.5 h-3.5 animate-pulse" />
@@ -77,7 +79,7 @@ export function MessageBubble({ message, onPlayVoice, onToggleTranslation }: Mes
               className={`h-6 w-6 flex items-center justify-center rounded-md transition-colors cursor-pointer ${
                 message.translationEnabled ? btnActive : btnBase
               }`}
-              title="Toggle translation"
+              title={t.conversation.toggleTranslation}
             >
               <Languages className="w-3.5 h-3.5" />
             </button>
@@ -89,7 +91,7 @@ export function MessageBubble({ message, onPlayVoice, onToggleTranslation }: Mes
           <div className={`mt-1 text-sm px-2 ${isUser ? 'text-right' : ''}`}>
             {message.isTranslating ? (
               <span className={`${translationColor} inline-flex items-center gap-1`}>
-                <Loader2 className="w-3 h-3 animate-spin" /> Translating...
+                <Loader2 className="w-3 h-3 animate-spin" /> {t.conversation.translating}
               </span>
             ) : message.translationError ? (
               <span className="text-amber-600 text-xs">{message.translationError}</span>

--- a/src/components/speak/phoneme-display.tsx
+++ b/src/components/speak/phoneme-display.tsx
@@ -4,6 +4,7 @@ import { AnimatePresence, motion } from 'framer-motion';
 import { ChevronDown, ChevronUp, Volume2 } from 'lucide-react';
 import { useState } from 'react';
 import { Button } from '@/components/ui/button';
+import { useI18n } from '@/lib/i18n/use-i18n';
 import type { PronunciationWord } from '@/lib/pronunciation';
 
 function scoreColor(score: number): { bg: string; text: string; border: string } {
@@ -111,21 +112,25 @@ interface PhonemeDisplayProps {
 }
 
 export function PhonemeDisplay({ words, onPlayWord }: PhonemeDisplayProps) {
+  const { messages: t } = useI18n('speak');
+
   if (words.length === 0) return null;
 
   return (
     <div className="space-y-2">
       <div className="flex items-center gap-2 mb-3">
-        <h4 className="text-xs font-semibold text-slate-500 uppercase tracking-wide">Phoneme Analysis</h4>
+        <h4 className="text-xs font-semibold text-slate-500 uppercase tracking-wide">
+          {t.pronunciation.phonemeAnalysis}
+        </h4>
         <div className="flex items-center gap-2 text-[10px] text-slate-400">
           <span className="flex items-center gap-1">
-            <span className="w-2 h-2 rounded-full bg-green-500" /> Good
+            <span className="w-2 h-2 rounded-full bg-green-500" /> {t.pronunciation.phonemeLegend.good}
           </span>
           <span className="flex items-center gap-1">
-            <span className="w-2 h-2 rounded-full bg-amber-500" /> Fair
+            <span className="w-2 h-2 rounded-full bg-amber-500" /> {t.pronunciation.phonemeLegend.fair}
           </span>
           <span className="flex items-center gap-1">
-            <span className="w-2 h-2 rounded-full bg-red-500" /> Needs work
+            <span className="w-2 h-2 rounded-full bg-red-500" /> {t.pronunciation.phonemeLegend.needsWork}
           </span>
         </div>
       </div>

--- a/src/components/speak/pronunciation-feedback.tsx
+++ b/src/components/speak/pronunciation-feedback.tsx
@@ -11,35 +11,37 @@ import {
   Volume2,
   XCircle,
 } from 'lucide-react';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { useI18n } from '@/lib/i18n/use-i18n';
 import type { WordAccuracy, WordResult } from '@/lib/levenshtein';
 import type { PronunciationResult } from '@/lib/pronunciation';
 import { PhonemeDisplay } from './phoneme-display';
 import { PronunciationTips } from './pronunciation-tips';
 
-const accuracyConfig: Record<
+const accuracyStyle: Record<
   WordAccuracy,
   {
     bg: string;
     text: string;
     border: string;
     icon: typeof CheckCircle2;
-    label: string;
   }
 > = {
-  correct: {
-    bg: 'bg-green-50',
-    text: 'text-green-700',
-    border: 'border-green-200',
-    icon: CheckCircle2,
-    label: 'Correct',
-  },
-  close: { bg: 'bg-amber-50', text: 'text-amber-700', border: 'border-amber-200', icon: AlertCircle, label: 'Close' },
-  wrong: { bg: 'bg-red-50', text: 'text-red-700', border: 'border-red-200', icon: XCircle, label: 'Wrong' },
-  missing: { bg: 'bg-gray-50', text: 'text-gray-400', border: 'border-gray-200', icon: MinusCircle, label: 'Missed' },
-  extra: { bg: 'bg-purple-50', text: 'text-purple-600', border: 'border-purple-200', icon: PlusCircle, label: 'Extra' },
+  correct: { bg: 'bg-green-50', text: 'text-green-700', border: 'border-green-200', icon: CheckCircle2 },
+  close: { bg: 'bg-amber-50', text: 'text-amber-700', border: 'border-amber-200', icon: AlertCircle },
+  wrong: { bg: 'bg-red-50', text: 'text-red-700', border: 'border-red-200', icon: XCircle },
+  missing: { bg: 'bg-gray-50', text: 'text-gray-400', border: 'border-gray-200', icon: MinusCircle },
+  extra: { bg: 'bg-purple-50', text: 'text-purple-600', border: 'border-purple-200', icon: PlusCircle },
+};
+
+const accuracyLabelKeys: Record<WordAccuracy, 'correct' | 'close' | 'wrong' | 'missed' | 'extra'> = {
+  correct: 'correct',
+  close: 'close',
+  wrong: 'wrong',
+  missing: 'missed',
+  extra: 'extra',
 };
 
 interface WordBadgeProps {
@@ -49,7 +51,8 @@ interface WordBadgeProps {
 }
 
 function WordBadge({ result, index, onPlayWord }: WordBadgeProps) {
-  const config = accuracyConfig[result.accuracy];
+  const { messages: t } = useI18n('speak');
+  const style = accuracyStyle[result.accuracy];
   const hasDetail = result.accuracy !== 'correct';
 
   const badge = (
@@ -61,7 +64,7 @@ function WordBadge({ result, index, onPlayWord }: WordBadgeProps) {
       className={`
         inline-flex items-center gap-1 px-2.5 py-1.5 rounded-lg text-sm font-medium
         border cursor-pointer transition-shadow duration-200 hover:shadow-md
-        ${config.bg} ${config.text} ${config.border}
+        ${style.bg} ${style.text} ${style.border}
         ${result.accuracy === 'extra' ? 'line-through opacity-70' : ''}
         ${result.accuracy === 'missing' ? 'opacity-60' : ''}
       `}
@@ -80,7 +83,9 @@ function WordBadge({ result, index, onPlayWord }: WordBadgeProps) {
         <TooltipContent className="max-w-[250px] bg-indigo-900 text-white text-xs px-3 py-2 rounded-lg" sideOffset={6}>
           <p>{result.hint}</p>
           {result.recognized && result.accuracy !== 'extra' && (
-            <p className="mt-1 opacity-70">You said: &ldquo;{result.recognized}&rdquo;</p>
+            <p className="mt-1 opacity-70">
+              {t.pronunciation.youSaid} &ldquo;{result.recognized}&rdquo;
+            </p>
           )}
         </TooltipContent>
       </Tooltip>
@@ -95,8 +100,20 @@ interface PronunciationFeedbackProps {
 }
 
 export function PronunciationFeedback({ results, onPlayWord, pronunciationResult }: PronunciationFeedbackProps) {
+  const { messages: t } = useI18n('speak');
   const [showDetails, setShowDetails] = useState(false);
   const problemWords = results.filter((r) => r.accuracy !== 'correct' && r.accuracy !== 'extra');
+
+  const accuracyLabels = useMemo<Record<WordAccuracy, string>>(
+    () => ({
+      correct: t.stats.correct,
+      close: t.stats.close,
+      wrong: t.stats.wrong,
+      missing: t.stats.missed,
+      extra: t.stats.extra,
+    }),
+    [t],
+  );
 
   return (
     <div className="space-y-4">
@@ -107,13 +124,14 @@ export function PronunciationFeedback({ results, onPlayWord, pronunciationResult
       </div>
 
       <div className="flex gap-3 text-xs text-indigo-500 flex-wrap">
-        {Object.entries(accuracyConfig).map(([key, config]) => {
+        {(Object.keys(accuracyStyle) as WordAccuracy[]).map((key) => {
+          const style = accuracyStyle[key];
           const count = results.filter((r) => r.accuracy === key).length;
           if (count === 0) return null;
           return (
             <span key={key} className="flex items-center gap-1">
-              <span className={`w-2.5 h-2.5 rounded-sm ${config.bg} ${config.border} border`} />
-              {config.label} ({count})
+              <span className={`w-2.5 h-2.5 rounded-sm ${style.bg} ${style.border} border`} />
+              {accuracyLabels[key]} ({count})
             </span>
           );
         })}
@@ -127,7 +145,8 @@ export function PronunciationFeedback({ results, onPlayWord, pronunciationResult
             className="flex items-center gap-1.5 text-sm text-indigo-600 hover:text-indigo-800 transition-colors cursor-pointer"
           >
             {showDetails ? <ChevronUp className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />}
-            {showDetails ? 'Hide' : 'Show'} detailed feedback ({problemWords.length} issues)
+            {showDetails ? t.pronunciation.hideDetails : t.pronunciation.showDetails} {t.pronunciation.detailedFeedback}{' '}
+            ({problemWords.length} {t.pronunciation.issues})
           </button>
 
           <AnimatePresence>
@@ -141,20 +160,20 @@ export function PronunciationFeedback({ results, onPlayWord, pronunciationResult
               >
                 <div className="mt-3 space-y-2">
                   {problemWords.map((r, i) => {
-                    const config = accuracyConfig[r.accuracy];
-                    const Icon = config.icon;
+                    const style = accuracyStyle[r.accuracy];
+                    const Icon = style.icon;
                     return (
                       <motion.div
                         key={`detail-${r.word}-${i}`}
                         initial={{ opacity: 0, x: -12 }}
                         animate={{ opacity: 1, x: 0 }}
                         transition={{ delay: i * 0.05 }}
-                        className={`flex items-start gap-3 p-3 rounded-lg border ${config.bg} ${config.border}`}
+                        className={`flex items-start gap-3 p-3 rounded-lg border ${style.bg} ${style.border}`}
                       >
-                        <Icon className={`w-4 h-4 mt-0.5 shrink-0 ${config.text}`} />
+                        <Icon className={`w-4 h-4 mt-0.5 shrink-0 ${style.text}`} />
                         <div className="flex-1 min-w-0">
                           <div className="flex items-center gap-2">
-                            <span className={`font-semibold ${config.text}`}>{r.word}</span>
+                            <span className={`font-semibold ${style.text}`}>{r.word}</span>
                             {r.recognized && (
                               <span className="text-xs text-gray-500">→ &ldquo;{r.recognized}&rdquo;</span>
                             )}
@@ -179,12 +198,10 @@ export function PronunciationFeedback({ results, onPlayWord, pronunciationResult
         </div>
       )}
 
-      {/* Phoneme-level analysis from pronunciation assessment */}
       {pronunciationResult && pronunciationResult.words.length > 0 && (
         <PhonemeDisplay words={pronunciationResult.words} onPlayWord={onPlayWord} />
       )}
 
-      {/* Pronunciation tips */}
       {pronunciationResult && pronunciationResult.tips.length > 0 && (
         <PronunciationTips tips={pronunciationResult.tips} />
       )}

--- a/src/components/speak/pronunciation-tips.tsx
+++ b/src/components/speak/pronunciation-tips.tsx
@@ -2,12 +2,15 @@
 
 import { motion } from 'framer-motion';
 import { Lightbulb } from 'lucide-react';
+import { useI18n } from '@/lib/i18n/use-i18n';
 
 interface PronunciationTipsProps {
   tips: string[];
 }
 
 export function PronunciationTips({ tips }: PronunciationTipsProps) {
+  const { messages: t } = useI18n('speak');
+
   if (tips.length === 0) return null;
 
   return (
@@ -19,7 +22,7 @@ export function PronunciationTips({ tips }: PronunciationTipsProps) {
     >
       <div className="flex items-center gap-2 mb-3">
         <Lightbulb className="w-4 h-4 text-indigo-500" />
-        <h4 className="text-sm font-semibold text-indigo-800">Pronunciation Tips</h4>
+        <h4 className="text-sm font-semibold text-indigo-800">{t.pronunciation.tips}</h4>
       </div>
       <ul className="space-y-2">
         {tips.map((tip, i) => (

--- a/src/components/speak/scenario-card.tsx
+++ b/src/components/speak/scenario-card.tsx
@@ -17,6 +17,7 @@ import {
 } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent } from '@/components/ui/card';
+import { useI18n } from '@/lib/i18n/use-i18n';
 import { cn } from '@/lib/utils';
 import type { Scenario } from '@/types/scenario';
 
@@ -55,6 +56,7 @@ interface ScenarioCardProps {
 }
 
 export function ScenarioCard({ scenario, onClick, isRecommended = false }: ScenarioCardProps) {
+  const { messages: t } = useI18n('speak');
   const Icon = iconMap[scenario.icon] || MessageCircle;
 
   return (
@@ -85,7 +87,9 @@ export function ScenarioCard({ scenario, onClick, isRecommended = false }: Scena
                 {scenario.difficulty}
               </Badge>
               {isRecommended && (
-                <Badge className="bg-indigo-100 text-indigo-600 text-[10px] px-1.5 py-0">Recommended</Badge>
+                <Badge className="bg-indigo-100 text-indigo-600 text-[10px] px-1.5 py-0">
+                  {t.scenarios.recommended}
+                </Badge>
               )}
             </div>
           </div>

--- a/src/components/speak/scenario-goals.tsx
+++ b/src/components/speak/scenario-goals.tsx
@@ -5,21 +5,22 @@ import { ChevronDown, Target } from 'lucide-react';
 import { useState } from 'react';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent } from '@/components/ui/card';
+import { useI18n } from '@/lib/i18n/use-i18n';
 
 interface ScenarioGoalsProps {
   goals: string[];
   difficulty: 'beginner' | 'intermediate' | 'advanced';
 }
 
-const difficultyConfig = {
-  beginner: { label: 'Beginner', className: 'bg-green-100 text-green-700 border-green-200' },
-  intermediate: { label: 'Intermediate', className: 'bg-yellow-100 text-yellow-700 border-yellow-200' },
-  advanced: { label: 'Advanced', className: 'bg-red-100 text-red-700 border-red-200' },
+const difficultyClassName = {
+  beginner: 'bg-green-100 text-green-700 border-green-200',
+  intermediate: 'bg-yellow-100 text-yellow-700 border-yellow-200',
+  advanced: 'bg-red-100 text-red-700 border-red-200',
 };
 
 export function ScenarioGoals({ goals, difficulty }: ScenarioGoalsProps) {
+  const { messages: t } = useI18n('speak');
   const [expanded, setExpanded] = useState(false);
-  const config = difficultyConfig[difficulty];
 
   return (
     <Card className="bg-indigo-50/50 border-indigo-100">
@@ -31,9 +32,9 @@ export function ScenarioGoals({ goals, difficulty }: ScenarioGoalsProps) {
         >
           <div className="flex items-center gap-2">
             <Target className="w-4 h-4 text-indigo-500" />
-            <span className="text-sm font-medium text-indigo-800">Conversation Goals</span>
-            <Badge variant="outline" className={`text-[10px] px-1.5 py-0 ${config.className}`}>
-              {config.label}
+            <span className="text-sm font-medium text-indigo-800">{t.scenarios.conversationGoals}</span>
+            <Badge variant="outline" className={`text-[10px] px-1.5 py-0 ${difficultyClassName[difficulty]}`}>
+              {t.scenarios.difficulty[difficulty]}
             </Badge>
           </div>
           <motion.div animate={{ rotate: expanded ? 0 : -90 }} transition={{ duration: 0.2 }}>

--- a/src/components/speak/scenario-grid.tsx
+++ b/src/components/speak/scenario-grid.tsx
@@ -1,19 +1,12 @@
 'use client';
 
 import Link from 'next/link';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Badge } from '@/components/ui/badge';
+import { useI18n } from '@/lib/i18n/use-i18n';
 import { BUILTIN_SCENARIOS } from '@/lib/scenarios';
 import type { Scenario, ScenarioCategory } from '@/types/scenario';
 import { ScenarioCard } from './scenario-card';
-
-const categories: { value: ScenarioCategory | 'all'; label: string }[] = [
-  { value: 'all', label: 'All' },
-  { value: 'daily', label: 'Daily' },
-  { value: 'work', label: 'Work' },
-  { value: 'travel', label: 'Travel' },
-  { value: 'social', label: 'Social' },
-];
 
 interface ScenarioGridProps {
   scenarios?: Scenario[];
@@ -28,7 +21,19 @@ export function ScenarioGrid({
   getHref,
   highlightedIds = [],
 }: ScenarioGridProps) {
+  const { messages: t } = useI18n('speak');
   const [activeCategory, setActiveCategory] = useState<ScenarioCategory | 'all'>('all');
+
+  const categories = useMemo<{ value: ScenarioCategory | 'all'; label: string }[]>(
+    () => [
+      { value: 'all', label: t.scenarios.categories.all },
+      { value: 'daily', label: t.scenarios.categories.daily },
+      { value: 'work', label: t.scenarios.categories.work },
+      { value: 'travel', label: t.scenarios.categories.travel },
+      { value: 'social', label: t.scenarios.categories.social },
+    ],
+    [t],
+  );
 
   const filtered = activeCategory === 'all' ? scenarios : scenarios.filter((s) => s.category === activeCategory);
 
@@ -67,7 +72,7 @@ export function ScenarioGrid({
         )}
       </div>
       {filtered.length === 0 && (
-        <div className="text-center py-12 text-slate-400 text-sm">No scenarios in this category yet.</div>
+        <div className="text-center py-12 text-slate-400 text-sm">{t.scenarios.noScenariosInCategory}</div>
       )}
     </div>
   );

--- a/src/components/speak/speech-stats.tsx
+++ b/src/components/speak/speech-stats.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from 'framer-motion';
 import { Minus, TrendingDown, TrendingUp } from 'lucide-react';
+import { useI18n } from '@/lib/i18n/use-i18n';
 import type { WordResult } from '@/lib/levenshtein';
 import { calculateStats } from '@/lib/levenshtein';
 
@@ -45,11 +46,17 @@ function AccuracyRing({ accuracy }: { accuracy: number }) {
   );
 }
 
-function getEncouragement(accuracy: number): { message: string; icon: typeof TrendingUp } {
-  if (accuracy >= 90) return { message: 'Excellent pronunciation!', icon: TrendingUp };
-  if (accuracy >= 70) return { message: 'Good job! Keep practicing.', icon: TrendingUp };
-  if (accuracy >= 50) return { message: 'Getting there! Focus on the highlighted words.', icon: Minus };
-  return { message: 'Keep trying! Listen to each word and try again.', icon: TrendingDown };
+function getEncouragementIcon(accuracy: number) {
+  if (accuracy >= 70) return TrendingUp;
+  if (accuracy >= 50) return Minus;
+  return TrendingDown;
+}
+
+function getEncouragementKey(accuracy: number): 'excellentPronunciation' | 'goodJob' | 'gettingThere' | 'keepTrying' {
+  if (accuracy >= 90) return 'excellentPronunciation';
+  if (accuracy >= 70) return 'goodJob';
+  if (accuracy >= 50) return 'gettingThere';
+  return 'keepTrying';
 }
 
 interface SpeechStatsProps {
@@ -57,14 +64,16 @@ interface SpeechStatsProps {
 }
 
 export function SpeechStats({ results }: SpeechStatsProps) {
+  const { messages: t } = useI18n('speak');
   const stats = calculateStats(results);
-  const { message, icon: Icon } = getEncouragement(stats.accuracy);
+  const Icon = getEncouragementIcon(stats.accuracy);
+  const message = t.stats[getEncouragementKey(stats.accuracy)];
 
   const statItems = [
-    { label: 'Correct', value: stats.correct, color: 'text-green-600', bg: 'bg-green-50' },
-    { label: 'Close', value: stats.close, color: 'text-amber-600', bg: 'bg-amber-50' },
-    { label: 'Wrong', value: stats.wrong, color: 'text-red-600', bg: 'bg-red-50' },
-    { label: 'Missed', value: stats.missing, color: 'text-gray-500', bg: 'bg-gray-50' },
+    { label: t.stats.correct, value: stats.correct, color: 'text-green-600', bg: 'bg-green-50' },
+    { label: t.stats.close, value: stats.close, color: 'text-amber-600', bg: 'bg-amber-50' },
+    { label: t.stats.wrong, value: stats.wrong, color: 'text-red-600', bg: 'bg-red-50' },
+    { label: t.stats.missed, value: stats.missing, color: 'text-gray-500', bg: 'bg-gray-50' },
   ].filter((s) => s.value > 0);
 
   return (
@@ -92,8 +101,8 @@ export function SpeechStats({ results }: SpeechStatsProps) {
         </div>
 
         <div className="text-xs text-indigo-400">
-          {stats.total} words total
-          {stats.extra > 0 && ` · ${stats.extra} extra words detected`}
+          {stats.total} {t.stats.wordsTotal}
+          {stats.extra > 0 && ` · ${stats.extra} ${t.stats.extraWordsDetected}`}
         </div>
       </div>
     </motion.div>

--- a/src/components/speak/voice-input-button.tsx
+++ b/src/components/speak/voice-input-button.tsx
@@ -3,6 +3,7 @@
 import { motion } from 'framer-motion';
 import { Loader2, Mic, MicOff } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { useI18n } from '@/lib/i18n/use-i18n';
 
 interface VoiceInputButtonProps {
   isRecording: boolean;
@@ -11,6 +12,7 @@ interface VoiceInputButtonProps {
 }
 
 export function VoiceInputButton({ isRecording, isDisabled, onToggle }: VoiceInputButtonProps) {
+  const { messages: t } = useI18n('speak');
   return (
     <div className="flex flex-col items-center gap-2">
       <motion.div
@@ -38,7 +40,7 @@ export function VoiceInputButton({ isRecording, isDisabled, onToggle }: VoiceInp
         </Button>
       </motion.div>
       <span className="text-xs text-slate-400">
-        {isRecording ? 'Tap to stop' : isDisabled ? 'AI is responding...' : 'Tap to speak'}
+        {isRecording ? t.voiceInput.tapToStop : isDisabled ? t.voiceInput.aiResponding : t.voiceInput.tapToSpeak}
       </span>
     </div>
   );

--- a/src/components/translation/translation-display.tsx
+++ b/src/components/translation/translation-display.tsx
@@ -4,6 +4,7 @@ import { Loader2, RefreshCw, Settings } from 'lucide-react';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import type { SentenceTranslation } from '@/hooks/use-translation';
+import { useI18n } from '@/lib/i18n/use-i18n';
 import { cn } from '@/lib/utils';
 
 interface TranslationDisplayProps {
@@ -30,6 +31,9 @@ export function TranslationDisplay({
   error,
   onRetry,
 }: TranslationDisplayProps) {
+  const { messages } = useI18n('practiceFeatures');
+  const t = messages.translationDisplay;
+
   const content =
     sentenceTranslations && sentenceTranslations.length > 0 ? (
       <div className="space-y-2">
@@ -49,7 +53,7 @@ export function TranslationDisplay({
       {isLoading ? (
         show ? (
           <span className="inline-flex items-center gap-1">
-            <Loader2 className="w-3 h-3 animate-spin" /> Translating...
+            <Loader2 className="w-3 h-3 animate-spin" /> {t.translating}
           </span>
         ) : null
       ) : error ? (
@@ -62,7 +66,7 @@ export function TranslationDisplay({
                 className="inline-flex items-center gap-1 text-xs text-indigo-500 hover:text-indigo-600 font-medium"
               >
                 <Settings className="w-3 h-3" />
-                Go to Settings
+                {t.goToSettings}
               </Link>
             ) : onRetry ? (
               <Button
@@ -72,7 +76,7 @@ export function TranslationDisplay({
                 className="h-6 px-2 text-xs text-indigo-500 hover:text-indigo-600 cursor-pointer"
               >
                 <RefreshCw className="w-3 h-3 mr-1" />
-                Retry
+                {t.retry}
               </Button>
             ) : null}
           </div>

--- a/src/hooks/__tests__/use-word-dictionary.test.ts
+++ b/src/hooks/__tests__/use-word-dictionary.test.ts
@@ -188,6 +188,7 @@ describe('useWordDictionary', () => {
     expect(hook.current.translation).toBe('');
     expect(hook.current.phonetic).toBe('');
     expect(hook.current.pos).toBe('');
+    expect(hook.current.meanings).toEqual([]);
     expect(hook.current.isLoading).toBe(false);
   });
 
@@ -375,5 +376,73 @@ describe('useWordDictionary', () => {
     expect(hook.current.translation).toBe('');
     expect(hook.current.phonetic).toBe('');
     expect(hook.current.pos).toBe('');
+    expect(hook.current.meanings).toEqual([]);
+  });
+
+  it('fetches multiple meanings with batch translation', async () => {
+    mockFetch.mockImplementation((url: string, options?: { body?: string }) => {
+      if (typeof url === 'string' && url.includes('dictionaryapi.dev')) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve([
+              {
+                word: 'prompt',
+                phonetic: '/pɹɒmpt/',
+                phonetics: [{ text: '/pɹɒmpt/' }],
+                meanings: [
+                  {
+                    partOfSpeech: 'noun',
+                    definitions: [{ definition: 'A reminder or cue.' }, { definition: 'A time limit.' }],
+                  },
+                  {
+                    partOfSpeech: 'verb',
+                    definitions: [{ definition: 'To lead someone toward what they should say or do.' }],
+                  },
+                  {
+                    partOfSpeech: 'adjective',
+                    definitions: [{ definition: 'Quick; acting without delay.' }],
+                  },
+                ],
+              },
+            ]),
+        });
+      }
+      const body = options?.body ? JSON.parse(options.body) : {};
+      if (body.sentences) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              translations: body.sentences.map((s: string) => {
+                if (s.includes('reminder')) return '提醒或暗示。';
+                if (s.includes('time limit')) return '时间限制。';
+                if (s.includes('lead someone')) return '引导某人说或做应该做的事。';
+                if (s.includes('Quick')) return '迅速的；毫不拖延的。';
+                return '';
+              }),
+            }),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ translation: '提示' }),
+      });
+    });
+
+    const hook = runtime.renderHook(() => useWordDictionary('prompt', 'zh-CN', true));
+
+    await waitFor(() => {
+      expect(hook.current.isLoading).toBe(false);
+    });
+
+    expect(hook.current.phonetic).toBe('/pɹɒmpt/');
+    expect(hook.current.pos).toBe('noun');
+    expect(hook.current.translation).toBe('提示');
+    expect(hook.current.meanings).toHaveLength(3);
+    expect(hook.current.meanings[0].pos).toBe('noun');
+    expect(hook.current.meanings[0].definition).toContain('提醒或暗示');
+    expect(hook.current.meanings[1].pos).toBe('verb');
+    expect(hook.current.meanings[2].pos).toBe('adjective');
   });
 });

--- a/src/hooks/use-conversation.ts
+++ b/src/hooks/use-conversation.ts
@@ -6,6 +6,7 @@ import { useFallbackSTT } from '@/hooks/use-fallback-stt';
 import { useShortcuts } from '@/hooks/use-shortcuts';
 import { useTTS } from '@/hooks/use-tts';
 import { useVoiceRecognition } from '@/hooks/use-voice-recognition';
+import { savePracticeSession } from '@/lib/daily-plan-progress';
 import { PROVIDER_REGISTRY } from '@/lib/providers';
 import { IS_TAURI } from '@/lib/tauri';
 import { usePracticeTranslationStore } from '@/stores/practice-translation-store';
@@ -25,9 +26,11 @@ interface UseConversationOptions {
   openingMessage?: string;
   /** Topic hint prepended to first user message for free mode */
   topicHint?: string;
+  /** Content ID to associate with the session for progress tracking */
+  contentId?: string;
 }
 
-export function useConversation({ scenario, openingMessage, topicHint }: UseConversationOptions = {}) {
+export function useConversation({ scenario, openingMessage, topicHint, contentId }: UseConversationOptions = {}) {
   const [textInput, setTextInput] = useState('');
   const [isFallbackTranscribing, setIsFallbackTranscribing] = useState(false);
 
@@ -35,6 +38,10 @@ export function useConversation({ scenario, openingMessage, topicHint }: UseConv
   const useNative = useRef(
     typeof window !== 'undefined' && !IS_TAURI && !!(window.SpeechRecognition || window.webkitSpeechRecognition),
   );
+
+  const sessionStartRef = useRef<number>(0);
+  const sessionIdRef = useRef(nanoid());
+  const userTurnCountRef = useRef(0);
 
   const messages = useSpeakStore((s) => s.messages);
   const isStreaming = useSpeakStore((s) => s.isStreaming);
@@ -69,6 +76,39 @@ export function useConversation({ scenario, openingMessage, topicHint }: UseConv
   const topicHintRef = useRef(topicHint);
   topicHintRef.current = topicHint;
 
+  const saveSpeakSession = useCallback(() => {
+    const effectiveContentId = contentId || scenario?.title || 'free-conversation';
+    const turns = userTurnCountRef.current;
+    if (turns < 2 || !sessionStartRef.current) return;
+
+    const allMsgs = useSpeakStore.getState().messages;
+    const userWords = allMsgs
+      .filter((m) => m.role === 'user')
+      .reduce((sum, m) => sum + m.content.split(/\s+/).filter(Boolean).length, 0);
+
+    const elapsed = (Date.now() - sessionStartRef.current) / 1000;
+    const wpm = elapsed > 0 ? Math.round((userWords / elapsed) * 60) : 0;
+
+    void savePracticeSession({
+      id: sessionIdRef.current,
+      contentId: effectiveContentId,
+      module: 'speak',
+      startTime: sessionStartRef.current,
+      endTime: Date.now(),
+      totalChars: userWords,
+      correctChars: userWords,
+      wrongChars: 0,
+      totalWords: userWords,
+      wpm,
+      accuracy: 100,
+      completed: true,
+    });
+
+    sessionIdRef.current = nanoid();
+    sessionStartRef.current = 0;
+    userTurnCountRef.current = 0;
+  }, [contentId, scenario?.title]);
+
   // Helper: finalize a recording message and send to AI
   const finalizeRecording = useCallback((finalText: string) => {
     if (!finalText.trim()) {
@@ -77,6 +117,9 @@ export function useConversation({ scenario, openingMessage, topicHint }: UseConv
       });
       return;
     }
+
+    if (!sessionStartRef.current) sessionStartRef.current = Date.now();
+    userTurnCountRef.current++;
 
     const currentMessages = useSpeakStore.getState().messages;
     const updatedMessages = currentMessages.map((m) =>
@@ -404,6 +447,8 @@ export function useConversation({ scenario, openingMessage, topicHint }: UseConv
   }, [handlePlayVoice]);
 
   const handleResetConversation = useCallback(() => {
+    saveSpeakSession();
+
     abortRef.current?.abort();
     if (useNative.current) {
       stopListening();
@@ -430,6 +475,7 @@ export function useConversation({ scenario, openingMessage, topicHint }: UseConv
     clearAllPlaying,
     openingMessage,
     resetConversation,
+    saveSpeakSession,
     setIsRecording,
     setIsStreaming,
     stop,
@@ -457,6 +503,9 @@ export function useConversation({ scenario, openingMessage, topicHint }: UseConv
     const text = textInput.trim();
     if (!text || isStreaming || isRecording) return;
 
+    if (!sessionStartRef.current) sessionStartRef.current = Date.now();
+    userTurnCountRef.current++;
+
     stop();
     const userMsg = { id: nanoid(), role: 'user' as const, content: text, timestamp: Date.now() };
     addMessage(userMsg);
@@ -480,11 +529,13 @@ export function useConversation({ scenario, openingMessage, topicHint }: UseConv
   );
 
   useEffect(() => {
+    const saveRef = saveSpeakSession;
     return () => {
+      saveRef();
       abortRef.current?.abort();
       stop();
     };
-  }, [stop]);
+  }, [stop, saveSpeakSession]);
 
   return {
     messages,

--- a/src/hooks/use-media-url.ts
+++ b/src/hooks/use-media-url.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react';
+import { getMediaBlobUrl } from '@/lib/media-storage';
+
+const IDB_PREFIX = 'idb:';
+
+export function useMediaUrl(audioUrl: string | undefined): string | null {
+  const [resolvedUrl, setResolvedUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!audioUrl) {
+      setResolvedUrl(null);
+      return;
+    }
+
+    if (!audioUrl.startsWith(IDB_PREFIX)) {
+      setResolvedUrl(audioUrl);
+      return;
+    }
+
+    const contentId = audioUrl.slice(IDB_PREFIX.length);
+    let cancelled = false;
+
+    getMediaBlobUrl(contentId).then((url) => {
+      if (!cancelled) setResolvedUrl(url);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [audioUrl]);
+
+  return resolvedUrl;
+}

--- a/src/hooks/use-translation.ts
+++ b/src/hooks/use-translation.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { db, type TranslationCacheEntry } from '@/lib/db';
 import { PROVIDER_REGISTRY } from '@/lib/providers';
 import { splitSentences } from '@/lib/sentence-split';
 import { useProviderStore } from '@/stores/provider-store';
@@ -18,6 +19,37 @@ type TranslationResponse = {
   translations?: string[];
 };
 
+const CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+function makeCacheKey(text: string, targetLang: string): string {
+  return `${text}::${targetLang}`;
+}
+
+const memCache = new Map<string, SentenceTranslation[]>();
+
+async function getFromDb(key: string): Promise<SentenceTranslation[] | null> {
+  try {
+    const entry = await db.translationCache.get(key);
+    if (!entry) return null;
+    if (Date.now() - entry.createdAt > CACHE_TTL_MS) {
+      db.translationCache.delete(key).catch(() => {});
+      return null;
+    }
+    return entry.translations;
+  } catch {
+    return null;
+  }
+}
+
+async function saveToDb(key: string, translations: SentenceTranslation[]): Promise<void> {
+  try {
+    const entry: TranslationCacheEntry = { key, translations, createdAt: Date.now() };
+    await db.translationCache.put(entry);
+  } catch {
+    /* IndexedDB may be unavailable in some contexts */
+  }
+}
+
 function normalizeOptions(options: boolean | TranslationOptions) {
   if (typeof options === 'boolean') {
     return { visible: options, shouldPrefetch: false };
@@ -32,7 +64,7 @@ export function useTranslation(text: string, targetLang: string, options: boolea
   const [sentenceTranslations, setSentenceTranslations] = useState<SentenceTranslation[] | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const cacheRef = useRef<Map<string, SentenceTranslation[]>>(new Map());
+  const abortRef = useRef<AbortController | null>(null);
   const activeProviderId = useProviderStore((s) => s.activeProviderId);
   const activeApiKey = useProviderStore((s) => {
     const config = s.providers[s.activeProviderId];
@@ -42,17 +74,36 @@ export function useTranslation(text: string, targetLang: string, options: boolea
   const providerConfigs = useProviderStore((s) => s.providers);
   const isReady = Boolean(sentenceTranslations?.length || translation);
 
+  const applyResult = useCallback((result: SentenceTranslation[]) => {
+    setSentenceTranslations(result);
+    setTranslation(result.map((s) => s.translation).join(' '));
+  }, []);
+
   const fetchTranslation = useCallback(async () => {
     if (!text || !targetLang) return;
     if (!visible && !shouldPrefetch) return;
 
-    const cacheKey = `${text}::${targetLang}`;
-    const cached = cacheRef.current.get(cacheKey);
-    if (cached) {
-      setSentenceTranslations(cached);
-      setTranslation(cached.map((s) => s.translation).join(' '));
+    const cacheKey = makeCacheKey(text, targetLang);
+
+    // 1. Memory cache (instant)
+    const memHit = memCache.get(cacheKey);
+    if (memHit) {
+      applyResult(memHit);
       return;
     }
+
+    // 2. IndexedDB cache (async but local)
+    const dbHit = await getFromDb(cacheKey);
+    if (dbHit) {
+      memCache.set(cacheKey, dbHit);
+      applyResult(dbHit);
+      return;
+    }
+
+    // 3. Network fetch
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
 
     setIsLoading(true);
     setError(null);
@@ -75,6 +126,7 @@ export function useTranslation(text: string, targetLang: string, options: boolea
         method: 'POST',
         headers,
         body: JSON.stringify(payload),
+        signal: controller.signal,
       });
 
       const data = (await res.json()) as TranslationResponse;
@@ -84,29 +136,40 @@ export function useTranslation(text: string, targetLang: string, options: boolea
       }
 
       const translations = Array.isArray(data.translations) ? data.translations : undefined;
+      let result: SentenceTranslation[];
 
       if (translations) {
-        const result: SentenceTranslation[] = sentences.map((s, i) => ({
+        result = sentences.map((s, i) => ({
           original: s,
           translation: translations[i] || '',
         }));
-        cacheRef.current.set(cacheKey, result);
-        setSentenceTranslations(result);
-        setTranslation(result.map((s) => s.translation).join(' '));
       } else if (data.translation) {
-        // Fallback: single string translation
-        const result: SentenceTranslation[] = [{ original: text, translation: data.translation }];
-        cacheRef.current.set(cacheKey, result);
-        setSentenceTranslations(result);
-        setTranslation(data.translation);
+        result = [{ original: text, translation: data.translation }];
+      } else {
+        return;
       }
+
+      memCache.set(cacheKey, result);
+      void saveToDb(cacheKey, result);
+      applyResult(result);
     } catch (err) {
+      if ((err as Error).name === 'AbortError') return;
       console.error('Translation fetch error:', err);
       setError('Network error, please try again');
     } finally {
       setIsLoading(false);
     }
-  }, [visible, shouldPrefetch, text, targetLang, activeProviderId, activeApiKey, activeHeaderKey, providerConfigs]);
+  }, [
+    visible,
+    shouldPrefetch,
+    text,
+    targetLang,
+    activeProviderId,
+    activeApiKey,
+    activeHeaderKey,
+    providerConfigs,
+    applyResult,
+  ]);
 
   useEffect(() => {
     if (!shouldPrefetch || visible || !text || !targetLang) return;

--- a/src/hooks/use-word-dictionary.ts
+++ b/src/hooks/use-word-dictionary.ts
@@ -1,22 +1,39 @@
 import { useEffect, useRef, useState } from 'react';
 
+interface DictionaryDefinition {
+  definition: string;
+  example?: string;
+}
+
+interface DictionaryMeaning {
+  partOfSpeech?: string;
+  definitions?: DictionaryDefinition[];
+}
+
 interface DictionaryEntry {
   word: string;
   phonetic?: string;
   phonetics?: Array<{ text?: string; audio?: string }>;
-  meanings?: Array<{ partOfSpeech?: string; definitions?: unknown[] }>;
+  meanings?: DictionaryMeaning[];
+}
+
+export interface WordMeaning {
+  pos: string;
+  definition: string;
 }
 
 interface CachedResult {
   translation: string;
   phonetic: string;
   pos: string;
+  meanings: WordMeaning[];
 }
 
 export interface WordDictionaryResult {
   translation: string;
   phonetic: string;
   pos: string;
+  meanings: WordMeaning[];
   isLoading: boolean;
 }
 
@@ -34,15 +51,40 @@ function extractPos(entry: DictionaryEntry): string {
   return entry.meanings?.[0]?.partOfSpeech || '';
 }
 
-async function fetchDictionary(word: string): Promise<{ phonetic: string; pos: string }> {
+interface RawMeaning {
+  pos: string;
+  definitions: string[];
+}
+
+function extractRawMeanings(entry: DictionaryEntry): RawMeaning[] {
+  if (!entry.meanings) return [];
+  return entry.meanings
+    .filter((m) => m.partOfSpeech && m.definitions?.length)
+    .map((m) => ({
+      pos: m.partOfSpeech!,
+      definitions: m.definitions!.slice(0, 2).map((d) => d.definition),
+    }));
+}
+
+interface DictionaryResult {
+  phonetic: string;
+  pos: string;
+  rawMeanings: RawMeaning[];
+}
+
+async function fetchDictionary(word: string): Promise<DictionaryResult> {
   try {
     const res = await fetch(`https://api.dictionaryapi.dev/api/v2/entries/en/${encodeURIComponent(word)}`);
-    if (!res.ok) return { phonetic: '', pos: '' };
+    if (!res.ok) return { phonetic: '', pos: '', rawMeanings: [] };
     const data = (await res.json()) as DictionaryEntry[];
-    if (!Array.isArray(data) || data.length === 0) return { phonetic: '', pos: '' };
-    return { phonetic: extractPhonetic(data[0]), pos: extractPos(data[0]) };
+    if (!Array.isArray(data) || data.length === 0) return { phonetic: '', pos: '', rawMeanings: [] };
+    return {
+      phonetic: extractPhonetic(data[0]),
+      pos: extractPos(data[0]),
+      rawMeanings: extractRawMeanings(data[0]),
+    };
   } catch {
-    return { phonetic: '', pos: '' };
+    return { phonetic: '', pos: '', rawMeanings: [] };
   }
 }
 
@@ -61,14 +103,50 @@ async function fetchTranslation(text: string, targetLang: string): Promise<strin
   }
 }
 
+async function fetchBatchTranslations(sentences: string[], targetLang: string): Promise<string[]> {
+  try {
+    const res = await fetch('/api/translate/free', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sentences, targetLang }),
+    });
+    if (!res.ok) return sentences.map(() => '');
+    const data = (await res.json()) as { translations?: string[] };
+    return data.translations || sentences.map(() => '');
+  } catch {
+    return sentences.map(() => '');
+  }
+}
+
+async function translateMeanings(rawMeanings: RawMeaning[], targetLang: string): Promise<WordMeaning[]> {
+  if (rawMeanings.length === 0) return [];
+
+  const allDefs = rawMeanings.flatMap((m) => m.definitions);
+  const translations = await fetchBatchTranslations(allDefs, targetLang);
+
+  let idx = 0;
+  return rawMeanings.map((m) => {
+    const translatedDefs = m.definitions.map(() => translations[idx++] || '');
+    return {
+      pos: m.pos,
+      definition: translatedDefs.filter(Boolean).join('；'),
+    };
+  });
+}
+
 export function useWordDictionary(word: string, targetLang: string, enabled: boolean): WordDictionaryResult {
-  const [result, setResult] = useState<CachedResult>({ translation: '', phonetic: '', pos: '' });
+  const [result, setResult] = useState<CachedResult>({
+    translation: '',
+    phonetic: '',
+    pos: '',
+    meanings: [],
+  });
   const [isLoading, setIsLoading] = useState(false);
   const cacheRef = useRef<Map<string, CachedResult>>(new Map());
 
   useEffect(() => {
     if (!enabled) {
-      setResult({ translation: '', phonetic: '', pos: '' });
+      setResult({ translation: '', phonetic: '', pos: '', meanings: [] });
       return;
     }
 
@@ -88,6 +166,7 @@ export function useWordDictionary(word: string, targetLang: string, enabled: boo
       let phonetic = '';
       let pos = '';
       let translation = '';
+      let meanings: WordMeaning[] = [];
 
       if (isSingleWord(word)) {
         const [dictResult, transResult] = await Promise.all([
@@ -97,13 +176,17 @@ export function useWordDictionary(word: string, targetLang: string, enabled: boo
         phonetic = dictResult.phonetic;
         pos = dictResult.pos;
         translation = transResult;
+
+        if (dictResult.rawMeanings.length > 0) {
+          meanings = await translateMeanings(dictResult.rawMeanings, targetLang);
+        }
       } else {
         translation = await fetchTranslation(word, targetLang);
       }
 
       if (cancelled) return;
 
-      const entry = { translation, phonetic, pos };
+      const entry = { translation, phonetic, pos, meanings };
       cacheRef.current.set(key, entry);
       setResult(entry);
       setIsLoading(false);

--- a/src/lib/daily-plan-links.ts
+++ b/src/lib/daily-plan-links.ts
@@ -11,7 +11,10 @@ export function getTaskHref(task: PlanTask): string {
     const limit = task.limit ?? (task.type === 'new-words' ? Number(task.title.match(/\d+/)?.[0]) || 0 : 0);
     return limit > 0 ? `${base}?limit=${limit}` : base;
   }
-  if (task.contentId) return `/${task.module}/${task.contentId}`;
+  if (task.contentId) {
+    const mod = task.module === 'speak' ? 'read' : task.module;
+    return `/${mod}/${task.contentId}`;
+  }
   return `/${task.module}`;
 }
 
@@ -21,7 +24,8 @@ export function getReviewItemHref(item: { module: PlanTask['module']; contentId?
   }
 
   if (item.contentId) {
-    return `/${item.module}/${item.contentId}`;
+    const mod = item.module === 'speak' ? 'read' : item.module;
+    return `/${mod}/${item.contentId}`;
   }
 
   if (item.bookId) {

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -9,6 +9,13 @@ export interface TranslationCacheEntry {
   createdAt: number;
 }
 
+export interface MediaBlobEntry {
+  contentId: string;
+  blob: Blob;
+  mimeType: string;
+  createdAt: number;
+}
+
 class EchoTypeDB extends Dexie {
   contents!: Table<ContentItem>;
   records!: Table<LearningRecord>;
@@ -19,6 +26,7 @@ class EchoTypeDB extends Dexie {
   favoriteFolders!: Table<FavoriteFolder>;
   lookupHistory!: Table<LookupEntry>;
   translationCache!: Table<TranslationCacheEntry>;
+  mediaBlobs!: Table<MediaBlobEntry>;
 
   constructor() {
     super('echotype');
@@ -130,6 +138,21 @@ class EchoTypeDB extends Dexie {
       favoriteFolders: 'id, sortOrder, createdAt',
       lookupHistory: 'text, count, lastLookedUp',
       translationCache: 'key, createdAt',
+    });
+
+    // Version 11: add mediaBlobs table for persistent local audio storage
+    this.version(11).stores({
+      contents: 'id, type, category, source, difficulty, createdAt, updatedAt, *tags',
+      records: 'id, contentId, module, lastPracticed, nextReview, updatedAt',
+      sessions: 'id, contentId, module, startTime, completed',
+      books: 'id, title, source, createdAt',
+      conversations: 'id, updatedAt, createdAt',
+      favorites:
+        'id, normalizedText, type, folderId, sourceContentId, targetLang, nextReview, autoCollected, createdAt, updatedAt',
+      favoriteFolders: 'id, sortOrder, createdAt',
+      lookupHistory: 'text, count, lastLookedUp',
+      translationCache: 'key, createdAt',
+      mediaBlobs: 'contentId, createdAt',
     });
 
     // Dexie hooks: auto-set updatedAt on create/update for contents and records

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -3,6 +3,12 @@ import type { Conversation } from '@/types/chat';
 import type { BookItem, ContentItem, LearningRecord, TypingSession } from '@/types/content';
 import type { FavoriteFolder, FavoriteItem, LookupEntry } from '@/types/favorite';
 
+export interface TranslationCacheEntry {
+  key: string;
+  translations: { original: string; translation: string }[];
+  createdAt: number;
+}
+
 class EchoTypeDB extends Dexie {
   contents!: Table<ContentItem>;
   records!: Table<LearningRecord>;
@@ -12,6 +18,7 @@ class EchoTypeDB extends Dexie {
   favorites!: Table<FavoriteItem>;
   favoriteFolders!: Table<FavoriteFolder>;
   lookupHistory!: Table<LookupEntry>;
+  translationCache!: Table<TranslationCacheEntry>;
 
   constructor() {
     super('echotype');
@@ -109,6 +116,20 @@ class EchoTypeDB extends Dexie {
         'id, normalizedText, type, folderId, sourceContentId, targetLang, nextReview, autoCollected, createdAt, updatedAt',
       favoriteFolders: 'id, sortOrder, createdAt',
       lookupHistory: 'text, count, lastLookedUp',
+    });
+
+    // Version 10: add translationCache table for persistent translation caching
+    this.version(10).stores({
+      contents: 'id, type, category, source, difficulty, createdAt, updatedAt, *tags',
+      records: 'id, contentId, module, lastPracticed, nextReview, updatedAt',
+      sessions: 'id, contentId, module, startTime, completed',
+      books: 'id, title, source, createdAt',
+      conversations: 'id, updatedAt, createdAt',
+      favorites:
+        'id, normalizedText, type, folderId, sourceContentId, targetLang, nextReview, autoCollected, createdAt, updatedAt',
+      favoriteFolders: 'id, sortOrder, createdAt',
+      lookupHistory: 'text, count, lastLookedUp',
+      translationCache: 'key, createdAt',
     });
 
     // Dexie hooks: auto-set updatedAt on create/update for contents and records

--- a/src/lib/i18n/dictionary.ts
+++ b/src/lib/i18n/dictionary.ts
@@ -5,8 +5,11 @@ import { commonMessages } from './messages/common';
 import { dashboardMessages } from './messages/dashboard';
 import { libraryMessages } from './messages/library';
 import { ollamaWarningMessages } from './messages/ollama-warning';
+import { practiceFeaturesMessages } from './messages/practice-features';
 import { settingsMessages } from './messages/settings';
+import { shadowReadingMessages } from './messages/shadow-reading';
 import { sidebarMessages } from './messages/sidebar';
+import { speakMessages } from './messages/speak';
 import { tagManagementMessages } from './messages/tag-management';
 import { wordbooksMessages } from './messages/wordbooks';
 
@@ -17,9 +20,12 @@ export const messages = {
   sidebar: sidebarMessages,
   dashboard: dashboardMessages,
   settings: settingsMessages,
+  speak: speakMessages,
   library: libraryMessages,
   tagManagement: tagManagementMessages,
   ollamaWarning: ollamaWarningMessages,
+  practiceFeatures: practiceFeaturesMessages,
+  shadowReading: shadowReadingMessages,
   wordbooks: wordbooksMessages,
 } as const;
 

--- a/src/lib/i18n/messages/dashboard/en.json
+++ b/src/lib/i18n/messages/dashboard/en.json
@@ -5,6 +5,7 @@
     "analytics": "View Analytics"
   },
   "stats": {
+    "streak": "Streak",
     "content": "Content",
     "sessions": "Sessions",
     "words": "Words",

--- a/src/lib/i18n/messages/dashboard/en.json
+++ b/src/lib/i18n/messages/dashboard/en.json
@@ -59,6 +59,19 @@
     "reminderTitle": "Time to re-assess your level!",
     "reminderDescription": "You've completed 50+ sessions since your last assessment ({{level}}). Ready to check your progress?"
   },
+  "miniAnalytics": {
+    "activity": "Activity",
+    "reviewForecast": "Review Forecast",
+    "practiceBreakdown": "Practice Breakdown",
+    "details": "Details",
+    "review": "Review",
+    "noActivity": "No activity yet",
+    "noSessions": "No sessions yet",
+    "noUpcomingReviews": "No upcoming reviews",
+    "dueToday": "due today",
+    "thisWeek": "this week",
+    "sessions": "sessions"
+  },
   "sections": {
     "startLearning": "Start Learning",
     "recentActivity": "Recent Activity"

--- a/src/lib/i18n/messages/dashboard/zh.json
+++ b/src/lib/i18n/messages/dashboard/zh.json
@@ -5,6 +5,7 @@
     "analytics": "查看分析"
   },
   "stats": {
+    "streak": "连续学习",
     "content": "内容",
     "sessions": "练习次数",
     "words": "单词",

--- a/src/lib/i18n/messages/dashboard/zh.json
+++ b/src/lib/i18n/messages/dashboard/zh.json
@@ -59,6 +59,19 @@
     "reminderTitle": "该重新评估你的水平了！",
     "reminderDescription": "自上次评估以来你已经完成了 50+ 次练习（{{level}}）。准备好检查你的进步了吗？"
   },
+  "miniAnalytics": {
+    "activity": "活动记录",
+    "reviewForecast": "复习预报",
+    "practiceBreakdown": "练习分布",
+    "details": "详情",
+    "review": "复习",
+    "noActivity": "暂无活动记录",
+    "noSessions": "暂无练习记录",
+    "noUpcomingReviews": "暂无待复习内容",
+    "dueToday": "今日待复习",
+    "thisWeek": "本周",
+    "sessions": "次练习"
+  },
   "sections": {
     "startLearning": "开始学习",
     "recentActivity": "最近活动"

--- a/src/lib/i18n/messages/practice-features.ts
+++ b/src/lib/i18n/messages/practice-features.ts
@@ -1,0 +1,7 @@
+import en from './practice-features/en.json';
+import zh from './practice-features/zh.json';
+
+export const practiceFeaturesMessages = {
+  en,
+  zh,
+} as const;

--- a/src/lib/i18n/messages/practice-features/en.json
+++ b/src/lib/i18n/messages/practice-features/en.json
@@ -1,0 +1,15 @@
+{
+  "translationDisplay": {
+    "translating": "Translating...",
+    "goToSettings": "Go to Settings",
+    "retry": "Retry"
+  },
+  "recommendations": {
+    "title": "Recommendations",
+    "generating": "Generating recommendations...",
+    "empty": "No recommendations available.",
+    "tryAgain": "Try again",
+    "goToSettings": "Go to Settings",
+    "retry": "Retry"
+  }
+}

--- a/src/lib/i18n/messages/practice-features/zh.json
+++ b/src/lib/i18n/messages/practice-features/zh.json
@@ -1,0 +1,15 @@
+{
+  "translationDisplay": {
+    "translating": "翻译中...",
+    "goToSettings": "前往设置",
+    "retry": "重试"
+  },
+  "recommendations": {
+    "title": "推荐内容",
+    "generating": "正在生成推荐内容...",
+    "empty": "暂无推荐内容。",
+    "tryAgain": "再试一次",
+    "goToSettings": "前往设置",
+    "retry": "重试"
+  }
+}

--- a/src/lib/i18n/messages/settings/en.json
+++ b/src/lib/i18n/messages/settings/en.json
@@ -204,8 +204,11 @@
       "pt": "Português (Portuguese)",
       "ru": "Русский (Russian)"
     },
-    "defaultOn": "Default On",
-    "defaultOff": "Default Off",
+    "defaultOn": "Starts On",
+    "defaultOff": "Starts Off",
+    "currentOn": "Enabled",
+    "currentOff": "Disabled",
+    "defaultHint": "First use: {{state}}",
     "listenLabel": "Listen",
     "listenDescription": "Show translations while listening to content and sentence highlights.",
     "readLabel": "Read",
@@ -214,8 +217,9 @@
     "speakDescription": "Show translations while practicing speech recognition feedback.",
     "writeLabel": "Write",
     "writeDescription": "Show translations while typing practice content and checking answers.",
-    "footer": "Listen and Read start on by default. Speak and Write start off by default. Each module keeps its own visibility state.",
-    "visibilityLabel": "{{module}} translation visibility"
+    "footer": "Listen, Read, and Write start with translation on. Speak starts with translation off. Each module keeps its own current visibility state.",
+    "visibilityLabel": "{{module}} translation visibility",
+    "resetToDefaults": "Reset to Defaults"
   },
   "smartCollection": {
     "selectionTitle": "Enable selection translation",

--- a/src/lib/i18n/messages/settings/en.json
+++ b/src/lib/i18n/messages/settings/en.json
@@ -50,6 +50,8 @@
     "exportLibraryDescription": "Download all content items as JSON",
     "exportLearningData": "Export Learning Data",
     "exportLearningDataDescription": "Download records and sessions as JSON",
+    "exportFullBackup": "Full Backup",
+    "exportFullBackupDescription": "Download all data including favorites, conversations, books, and settings",
     "importFromBackup": "Import from Backup",
     "mode": "Mode:",
     "merge": "Merge",
@@ -59,8 +61,10 @@
     "invalidJson": "Failed to parse file. Ensure it is valid JSON.",
     "exportedItems": "Exported {{count}} items",
     "exportedRecordsSessions": "Exported {{records}} records, {{sessions}} sessions",
+    "exportedFullBackup": "Full backup exported ({{tables}} tables, {{total}} items)",
     "importedItems": "Imported {{count}} content items ({{mode}})",
-    "importedRecordsSessions": "Imported {{records}} records, {{sessions}} sessions ({{mode}})"
+    "importedRecordsSessions": "Imported {{records}} records, {{sessions}} sessions ({{mode}})",
+    "importedFullBackup": "Full backup restored ({{tables}} tables, {{total}} items, {{mode}})"
   },
   "dashboardChild": {
     "todaysReview": "Today's Review",
@@ -204,11 +208,8 @@
       "pt": "Português (Portuguese)",
       "ru": "Русский (Russian)"
     },
-    "defaultOn": "Starts On",
-    "defaultOff": "Starts Off",
-    "currentOn": "Enabled",
-    "currentOff": "Disabled",
-    "defaultHint": "First use: {{state}}",
+    "currentOn": "On Now",
+    "currentOff": "Off Now",
     "listenLabel": "Listen",
     "listenDescription": "Show translations while listening to content and sentence highlights.",
     "readLabel": "Read",
@@ -217,9 +218,9 @@
     "speakDescription": "Show translations while practicing speech recognition feedback.",
     "writeLabel": "Write",
     "writeDescription": "Show translations while typing practice content and checking answers.",
+    "resetToDefault": "Reset to Default",
     "footer": "Listen, Read, and Write start with translation on. Speak starts with translation off. Each module keeps its own current visibility state.",
-    "visibilityLabel": "{{module}} translation visibility",
-    "resetToDefaults": "Reset to Defaults"
+    "visibilityLabel": "{{module}} translation visibility"
   },
   "smartCollection": {
     "selectionTitle": "Enable selection translation",

--- a/src/lib/i18n/messages/settings/en.json
+++ b/src/lib/i18n/messages/settings/en.json
@@ -11,7 +11,8 @@
     "recommendations": "Recommendations",
     "shadowReading": "Shadow Reading",
     "pronunciation": "Pronunciation",
-    "tagManagement": "Tag Management"
+    "tagManagement": "Tag Management",
+    "aiOutput": "AI Output"
   },
   "page": {
     "title": "Settings",
@@ -122,6 +123,9 @@
     "retry": "Retry",
     "useAsDefault": "Use {{provider}} / {{model}} as default",
     "currentlyUsingDefault": "Currently using {{model}} as default model",
+    "maxTokensLabel": "Max Output Tokens",
+    "maxTokensOverride": "Override global setting for this provider",
+    "maxTokensGlobalFallback": "Using global setting ({{value}} tokens)",
     "signInWith": "Sign in with {{provider}}",
     "reconnectTo": "Reconnect {{provider}}",
     "connectTo": "Connect to {{provider}}",
@@ -257,5 +261,10 @@
     "callsPerMonth": "calls/month (free tier: 1,000)",
     "getApiKeys": "Get SpeechSuper API keys",
     "summary": "Pronunciation assessment runs after each speech input in the Speak module. SpeechSuper gives you phoneme-level IPA analysis, while the AI fallback provides estimated scores and tips based on text comparison."
+  },
+  "aiOutput": {
+    "maxTokensLabel": "Max Output Tokens",
+    "maxTokensDescription": "Limits the maximum number of tokens the AI can generate per response. Lower values save costs and speed up responses. Higher values allow longer, more detailed answers.",
+    "maxTokensValue": "tokens"
   }
 }

--- a/src/lib/i18n/messages/settings/zh.json
+++ b/src/lib/i18n/messages/settings/zh.json
@@ -11,7 +11,8 @@
     "recommendations": "推荐",
     "shadowReading": "影子跟读",
     "pronunciation": "发音评估",
-    "tagManagement": "标签管理"
+    "tagManagement": "标签管理",
+    "aiOutput": "AI 输出"
   },
   "page": {
     "title": "设置",
@@ -122,6 +123,9 @@
     "retry": "重试",
     "useAsDefault": "将 {{provider}} / {{model}} 设为默认",
     "currentlyUsingDefault": "当前默认模型：{{model}}",
+    "maxTokensLabel": "最大输出 Token 数",
+    "maxTokensOverride": "为此 Provider 覆盖全局设置",
+    "maxTokensGlobalFallback": "使用全局设置（{{value}} tokens）",
     "signInWith": "使用 {{provider}} 登录",
     "reconnectTo": "重新连接 {{provider}}",
     "connectTo": "连接 {{provider}}",
@@ -257,5 +261,10 @@
     "callsPerMonth": "次/月（免费额度：1,000）",
     "getApiKeys": "获取 SpeechSuper API 密钥",
     "summary": "发音评估会在口语模块每次语音输入后运行。使用 SpeechSuper 时可获得音素级 IPA 分析；AI 回退则会基于文本比对提供估算分数与建议。"
+  },
+  "aiOutput": {
+    "maxTokensLabel": "最大输出 Token 数",
+    "maxTokensDescription": "限制 AI 每次回复可生成的最大 Token 数。较低的值可节省费用并加快响应速度，较高的值允许更长、更详细的回答。",
+    "maxTokensValue": "tokens"
   }
 }

--- a/src/lib/i18n/messages/settings/zh.json
+++ b/src/lib/i18n/messages/settings/zh.json
@@ -50,6 +50,8 @@
     "exportLibraryDescription": "将所有内容项下载为 JSON",
     "exportLearningData": "导出学习数据",
     "exportLearningDataDescription": "将记录和练习会话下载为 JSON",
+    "exportFullBackup": "完整备份",
+    "exportFullBackupDescription": "下载所有数据，包括收藏、对话、词书和设置",
     "importFromBackup": "从备份导入",
     "mode": "模式：",
     "merge": "合并",
@@ -59,8 +61,10 @@
     "invalidJson": "解析文件失败，请确认它是有效的 JSON。",
     "exportedItems": "已导出 {{count}} 条内容",
     "exportedRecordsSessions": "已导出 {{records}} 条记录、{{sessions}} 条会话",
+    "exportedFullBackup": "完整备份已导出（{{tables}} 张表、{{total}} 条数据）",
     "importedItems": "已导入 {{count}} 条内容（{{mode}}）",
-    "importedRecordsSessions": "已导入 {{records}} 条记录、{{sessions}} 条会话（{{mode}}）"
+    "importedRecordsSessions": "已导入 {{records}} 条记录、{{sessions}} 条会话（{{mode}}）",
+    "importedFullBackup": "完整备份已恢复（{{tables}} 张表、{{total}} 条数据、{{mode}}）"
   },
   "dashboardChild": {
     "todaysReview": "今日复习",
@@ -204,11 +208,8 @@
       "pt": "Português（Portuguese）",
       "ru": "Русский（Russian）"
     },
-    "defaultOn": "首次默认开启",
-    "defaultOff": "首次默认关闭",
-    "currentOn": "已开启",
-    "currentOff": "已关闭",
-    "defaultHint": "首次使用时：{{state}}",
+    "currentOn": "当前开启",
+    "currentOff": "当前关闭",
     "listenLabel": "听力",
     "listenDescription": "在收听内容和句子高亮时显示翻译。",
     "readLabel": "阅读",
@@ -217,9 +218,9 @@
     "speakDescription": "在口语练习和识别反馈时显示翻译。",
     "writeLabel": "写作",
     "writeDescription": "在打字练习和对答案时显示翻译。",
+    "resetToDefault": "恢复默认",
     "footer": "听力、阅读和写作首次默认开启翻译，口语首次默认关闭。每个模块都会保留自己当前的显示状态。",
-    "visibilityLabel": "{{module}} 翻译显示",
-    "resetToDefaults": "恢复默认"
+    "visibilityLabel": "{{module}} 翻译显示"
   },
   "smartCollection": {
     "selectionTitle": "启用划词翻译",

--- a/src/lib/i18n/messages/settings/zh.json
+++ b/src/lib/i18n/messages/settings/zh.json
@@ -204,8 +204,11 @@
       "pt": "Português（Portuguese）",
       "ru": "Русский（Russian）"
     },
-    "defaultOn": "默认开启",
-    "defaultOff": "默认关闭",
+    "defaultOn": "首次默认开启",
+    "defaultOff": "首次默认关闭",
+    "currentOn": "已开启",
+    "currentOff": "已关闭",
+    "defaultHint": "首次使用时：{{state}}",
     "listenLabel": "听力",
     "listenDescription": "在收听内容和句子高亮时显示翻译。",
     "readLabel": "阅读",
@@ -214,8 +217,9 @@
     "speakDescription": "在口语练习和识别反馈时显示翻译。",
     "writeLabel": "写作",
     "writeDescription": "在打字练习和对答案时显示翻译。",
-    "footer": "听力和阅读默认开启翻译，口语和写作默认关闭。每个模块会保留自己的显示状态。",
-    "visibilityLabel": "{{module}} 翻译显示"
+    "footer": "听力、阅读和写作首次默认开启翻译，口语首次默认关闭。每个模块都会保留自己当前的显示状态。",
+    "visibilityLabel": "{{module}} 翻译显示",
+    "resetToDefaults": "恢复默认"
   },
   "smartCollection": {
     "selectionTitle": "启用划词翻译",

--- a/src/lib/i18n/messages/shadow-reading.ts
+++ b/src/lib/i18n/messages/shadow-reading.ts
@@ -1,0 +1,7 @@
+import en from './shadow-reading/en.json';
+import zh from './shadow-reading/zh.json';
+
+export const shadowReadingMessages = {
+  en,
+  zh,
+} as const;

--- a/src/lib/i18n/messages/shadow-reading/en.json
+++ b/src/lib/i18n/messages/shadow-reading/en.json
@@ -1,0 +1,52 @@
+{
+  "progressBar": {
+    "listen": "Listen",
+    "read": "Read",
+    "write": "Write",
+    "speakOptional": "Speak",
+    "optional": "optional",
+    "pending": "Not started",
+    "inProgress": "In progress",
+    "completed": "Done",
+    "practiceIn": "Practice in {{module}}",
+    "moduleCompleted": "{{module}} completed!",
+    "continueToNext": "Continue to {{module}}"
+  },
+  "statusBar": {
+    "title": "Shadow Reading",
+    "progress": "{{completed}}/3 completed",
+    "nextModule": "Next: {{module}}",
+    "endSession": "End Session",
+    "endSessionConfirmTitle": "End Shadow Reading?",
+    "endSessionConfirmDesc": "Your progress in completed modules is saved. Incomplete modules won't be recorded.",
+    "endSessionConfirmAction": "End Session",
+    "endSessionCancel": "Cancel",
+    "switchSessionTitle": "Switch Content?",
+    "switchSessionDesc": "You have an active session for \"{{current}}\". Starting a new session will discard current progress.",
+    "switchSessionConfirm": "Switch",
+    "switchSessionCancel": "Keep Current"
+  },
+  "completion": {
+    "title": "Shadow Reading Complete!",
+    "subtitle": "You've practiced this content across all three modules.",
+    "contentLabel": "Content:",
+    "timeSpent": "Time spent: {{duration}}",
+    "startAnother": "Start Another",
+    "backToLibrary": "Back to Library",
+    "repeatPractice": "Practice Again",
+    "trySpeaking": "Try Speaking",
+    "moduleSummary": "Module Summary",
+    "listenDone": "Listened",
+    "readDone": "Read Aloud",
+    "writeDone": "Typed",
+    "durationSeconds": "{{count}}s",
+    "durationMinsSecs": "{{mins}}m {{secs}}s",
+    "durationMins": "{{mins}}m",
+    "durationHoursMins": "{{hours}}h {{mins}}m",
+    "durationHours": "{{hours}}h"
+  },
+  "contentList": {
+    "practicing": "Practicing",
+    "progressBadge": "{{completed}}/3"
+  }
+}

--- a/src/lib/i18n/messages/shadow-reading/zh.json
+++ b/src/lib/i18n/messages/shadow-reading/zh.json
@@ -1,0 +1,52 @@
+{
+  "progressBar": {
+    "listen": "听力",
+    "read": "阅读",
+    "write": "写作",
+    "speakOptional": "口语",
+    "optional": "可选",
+    "pending": "未开始",
+    "inProgress": "进行中",
+    "completed": "已完成",
+    "practiceIn": "在{{module}}中练习",
+    "moduleCompleted": "{{module}}已完成！",
+    "continueToNext": "继续{{module}}"
+  },
+  "statusBar": {
+    "title": "影子跟读",
+    "progress": "{{completed}}/3 已完成",
+    "nextModule": "下一步：{{module}}",
+    "endSession": "结束练习",
+    "endSessionConfirmTitle": "结束影子跟读？",
+    "endSessionConfirmDesc": "已完成模块的进度将被保存，未完成的模块不会被记录。",
+    "endSessionConfirmAction": "确认结束",
+    "endSessionCancel": "取消",
+    "switchSessionTitle": "切换内容？",
+    "switchSessionDesc": "你正在练习「{{current}}」。切换到新内容将丢弃当前进度。",
+    "switchSessionConfirm": "切换",
+    "switchSessionCancel": "保留当前"
+  },
+  "completion": {
+    "title": "影子跟读完成！",
+    "subtitle": "你已经在所有三个模块中练习了这篇内容。",
+    "contentLabel": "内容：",
+    "timeSpent": "用时：{{duration}}",
+    "startAnother": "再来一篇",
+    "backToLibrary": "返回资料库",
+    "repeatPractice": "再练一次",
+    "trySpeaking": "去口语练习",
+    "moduleSummary": "模块完成情况",
+    "listenDone": "已听力",
+    "readDone": "已朗读",
+    "writeDone": "已打字",
+    "durationSeconds": "{{count}}秒",
+    "durationMinsSecs": "{{mins}}分{{secs}}秒",
+    "durationMins": "{{mins}}分钟",
+    "durationHoursMins": "{{hours}}小时{{mins}}分",
+    "durationHours": "{{hours}}小时"
+  },
+  "contentList": {
+    "practicing": "练习中",
+    "progressBadge": "{{completed}}/3"
+  }
+}

--- a/src/lib/i18n/messages/shortcuts/en.json
+++ b/src/lib/i18n/messages/shortcuts/en.json
@@ -96,6 +96,14 @@
     "read:listen": { "label": "Listen to Text", "description": "Play reference text with TTS" },
     "read:reset": { "label": "Reset", "description": "Clear transcript and results" },
     "write:toggle-translation": { "label": "Toggle Translation", "description": "Show or hide translation" },
-    "write:reset": { "label": "Reset", "description": "Restart the typing practice" }
+    "write:reset": { "label": "Reset", "description": "Restart the typing practice" },
+    "global:shadow-next-module": {
+      "label": "Shadow: Next Module",
+      "description": "Jump to the next incomplete shadow reading module"
+    },
+    "global:shadow-end-session": {
+      "label": "Shadow: End Session",
+      "description": "End the current shadow reading session"
+    }
   }
 }

--- a/src/lib/i18n/messages/shortcuts/zh.json
+++ b/src/lib/i18n/messages/shortcuts/zh.json
@@ -87,6 +87,8 @@
     "read:listen": { "label": "朗读文本", "description": "使用 TTS 播放参考文本" },
     "read:reset": { "label": "重置", "description": "清空转写结果和评分" },
     "write:toggle-translation": { "label": "切换翻译", "description": "显示或隐藏翻译" },
-    "write:reset": { "label": "重置", "description": "重新开始打字练习" }
+    "write:reset": { "label": "重置", "description": "重新开始打字练习" },
+    "global:shadow-next-module": { "label": "影子跟读：下一模块", "description": "跳转到影子跟读的下一个未完成模块" },
+    "global:shadow-end-session": { "label": "影子跟读：结束练习", "description": "结束当前影子跟读练习" }
   }
 }

--- a/src/lib/i18n/messages/sidebar/en.json
+++ b/src/lib/i18n/messages/sidebar/en.json
@@ -14,6 +14,7 @@
     "library": "Library",
     "wordBooks": "Word Books",
     "favorites": "Favorites",
+    "todayReview": "Today's Review",
     "settings": "Settings"
   },
   "logo": {

--- a/src/lib/i18n/messages/sidebar/zh.json
+++ b/src/lib/i18n/messages/sidebar/zh.json
@@ -14,6 +14,7 @@
     "library": "资料库",
     "wordBooks": "词书",
     "favorites": "收藏",
+    "todayReview": "今日复习",
     "settings": "设置"
   },
   "logo": {

--- a/src/lib/i18n/messages/speak.ts
+++ b/src/lib/i18n/messages/speak.ts
@@ -1,0 +1,7 @@
+import en from './speak/en.json';
+import zh from './speak/zh.json';
+
+export const speakMessages = {
+  en,
+  zh,
+} as const;

--- a/src/lib/i18n/messages/speak/en.json
+++ b/src/lib/i18n/messages/speak/en.json
@@ -1,0 +1,81 @@
+{
+  "page": {
+    "title": "Speak",
+    "subtitle": "Practice English through conversation with AI"
+  },
+  "freeConversation": {
+    "title": "Start Free Conversation",
+    "description": "Chat with AI about anything — daily life, hobbies, news, or whatever you like. No topic restrictions.",
+    "pageTitle": "Free Conversation",
+    "pageSubtitle": "Chat about anything you like",
+    "suggestedTopics": "Suggested Topics"
+  },
+  "scenarios": {
+    "sectionTitle": "Or pick a scenario",
+    "sectionSubtitle": "for guided practice",
+    "notFound": "Scenario not found",
+    "backToScenarios": "Back to Scenarios",
+    "conversationGoals": "Conversation Goals",
+    "recommended": "Recommended",
+    "noScenariosInCategory": "No scenarios in this category yet.",
+    "categories": {
+      "all": "All",
+      "daily": "Daily",
+      "work": "Work",
+      "travel": "Travel",
+      "social": "Social"
+    },
+    "difficulty": {
+      "beginner": "Beginner",
+      "intermediate": "Intermediate",
+      "advanced": "Advanced"
+    }
+  },
+  "conversation": {
+    "readyToStart": "Ready to practice?",
+    "tapMicrophone": "Tap the microphone to start speaking",
+    "thinking": "Thinking...",
+    "listening": "Listening...",
+    "processing": "Processing your speech...",
+    "translating": "Translating...",
+    "stopVoice": "Stop voice",
+    "playVoice": "Play voice",
+    "toggleTranslation": "Toggle translation",
+    "typePlaceholder": "Type your message...",
+    "typeResponsePlaceholder": "Or type your response..."
+  },
+  "voiceInput": {
+    "tapToStop": "Tap to stop",
+    "aiResponding": "AI is responding...",
+    "tapToSpeak": "Tap to speak"
+  },
+  "stats": {
+    "correct": "Correct",
+    "close": "Close",
+    "wrong": "Wrong",
+    "missed": "Missed",
+    "extra": "Extra",
+    "wordsTotal": "words total",
+    "extraWordsDetected": "extra words detected",
+    "excellentPronunciation": "Excellent pronunciation!",
+    "goodJob": "Good job! Keep practicing.",
+    "gettingThere": "Getting there! Focus on the highlighted words.",
+    "keepTrying": "Keep trying! Listen to each word and try again."
+  },
+  "pronunciation": {
+    "feedback": "Pronunciation Feedback",
+    "analyzingPronunciation": "Analyzing pronunciation...",
+    "phonemeAnalysis": "Phoneme Analysis",
+    "phonemeLegend": {
+      "good": "Good",
+      "fair": "Fair",
+      "needsWork": "Needs work"
+    },
+    "tips": "Pronunciation Tips",
+    "showDetails": "Show",
+    "hideDetails": "Hide",
+    "detailedFeedback": "detailed feedback",
+    "issues": "issues",
+    "youSaid": "You said:"
+  }
+}

--- a/src/lib/i18n/messages/speak/zh.json
+++ b/src/lib/i18n/messages/speak/zh.json
@@ -1,0 +1,81 @@
+{
+  "page": {
+    "title": "口语",
+    "subtitle": "通过 AI 对话练习英语口语"
+  },
+  "freeConversation": {
+    "title": "开始自由对话",
+    "description": "与 AI 聊任何话题——日常生活、兴趣爱好、新闻时事，想聊什么都可以，没有话题限制。",
+    "pageTitle": "自由对话",
+    "pageSubtitle": "聊聊你想聊的任何话题",
+    "suggestedTopics": "推荐话题"
+  },
+  "scenarios": {
+    "sectionTitle": "或选择一个场景",
+    "sectionSubtitle": "进行引导式练习",
+    "notFound": "未找到该场景",
+    "backToScenarios": "返回场景列表",
+    "conversationGoals": "对话目标",
+    "recommended": "推荐",
+    "noScenariosInCategory": "该分类暂无场景。",
+    "categories": {
+      "all": "全部",
+      "daily": "日常",
+      "work": "工作",
+      "travel": "旅行",
+      "social": "社交"
+    },
+    "difficulty": {
+      "beginner": "初级",
+      "intermediate": "中级",
+      "advanced": "高级"
+    }
+  },
+  "conversation": {
+    "readyToStart": "准备好开始练习了吗？",
+    "tapMicrophone": "点击麦克风开始说话",
+    "thinking": "思考中...",
+    "listening": "听取中...",
+    "processing": "正在处理你的语音...",
+    "translating": "翻译中...",
+    "stopVoice": "停止播放",
+    "playVoice": "播放语音",
+    "toggleTranslation": "切换翻译",
+    "typePlaceholder": "输入消息...",
+    "typeResponsePlaceholder": "或者输入你的回复..."
+  },
+  "voiceInput": {
+    "tapToStop": "点击停止",
+    "aiResponding": "AI 回复中...",
+    "tapToSpeak": "点击说话"
+  },
+  "stats": {
+    "correct": "正确",
+    "close": "接近",
+    "wrong": "错误",
+    "missed": "遗漏",
+    "extra": "多余",
+    "wordsTotal": "个单词",
+    "extraWordsDetected": "个多余单词",
+    "excellentPronunciation": "发音优秀！",
+    "goodJob": "做得不错！继续练习。",
+    "gettingThere": "有进步！注意高亮显示的单词。",
+    "keepTrying": "继续加油！听清每个单词再试一次。"
+  },
+  "pronunciation": {
+    "feedback": "发音反馈",
+    "analyzingPronunciation": "正在分析发音...",
+    "phonemeAnalysis": "音素分析",
+    "phonemeLegend": {
+      "good": "良好",
+      "fair": "一般",
+      "needsWork": "需改进"
+    },
+    "tips": "发音提示",
+    "showDetails": "展开",
+    "hideDetails": "收起",
+    "detailedFeedback": "详细反馈",
+    "issues": "个问题",
+    "youSaid": "你说的："
+  }
+}

--- a/src/lib/media-storage.ts
+++ b/src/lib/media-storage.ts
@@ -1,0 +1,49 @@
+import { db, type MediaBlobEntry } from './db';
+
+const blobUrlCache = new Map<string, string>();
+
+export async function saveMediaBlob(contentId: string, file: File | Blob): Promise<void> {
+  const entry: MediaBlobEntry = {
+    contentId,
+    blob: file instanceof File ? new Blob([file], { type: file.type }) : file,
+    mimeType: file.type || 'audio/mpeg',
+    createdAt: Date.now(),
+  };
+  await db.mediaBlobs.put(entry);
+}
+
+export async function getMediaBlobUrl(contentId: string): Promise<string | null> {
+  const cached = blobUrlCache.get(contentId);
+  if (cached) {
+    try {
+      const response = await fetch(cached);
+      if (response.ok) return cached;
+    } catch {
+      blobUrlCache.delete(contentId);
+    }
+  }
+
+  try {
+    const entry = await db.mediaBlobs.get(contentId);
+    if (!entry) return null;
+    const url = URL.createObjectURL(entry.blob);
+    blobUrlCache.set(contentId, url);
+    return url;
+  } catch {
+    return null;
+  }
+}
+
+export async function deleteMediaBlob(contentId: string): Promise<void> {
+  const cached = blobUrlCache.get(contentId);
+  if (cached) {
+    URL.revokeObjectURL(cached);
+    blobUrlCache.delete(contentId);
+  }
+  await db.mediaBlobs.delete(contentId);
+}
+
+export async function hasMediaBlob(contentId: string): Promise<boolean> {
+  const count = await db.mediaBlobs.where('contentId').equals(contentId).count();
+  return count > 0;
+}

--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -102,6 +102,8 @@ export interface ProviderConfig {
   modelRecommendationKey?: string;
   /** Skip dynamic model fetching, use static list only */
   noModelApi?: boolean;
+  /** Per-provider max output tokens override (falls back to global setting) */
+  maxTokens?: number;
 }
 
 const PROVIDER_UI_MESSAGES = {

--- a/src/lib/shortcut-definitions.ts
+++ b/src/lib/shortcut-definitions.ts
@@ -111,6 +111,8 @@ const SHORTCUT_BASE_DEFINITIONS: ShortcutDefinitionBase[] = [
   { id: 'read:reset', scope: 'read', defaultKey: 'r', requiresMod: false },
   { id: 'write:toggle-translation', scope: 'write', defaultKey: 'mod+alt+t', requiresMod: true },
   { id: 'write:reset', scope: 'write', defaultKey: 'mod+alt+r', requiresMod: true },
+  { id: 'global:shadow-next-module', scope: 'global', defaultKey: 'mod+]', requiresMod: true },
+  { id: 'global:shadow-end-session', scope: 'global', defaultKey: 'mod+shift+x', requiresMod: true },
 ];
 
 export function getShortcutLocaleMessages(locale: ShortcutLocale): ShortcutLocaleMessages {

--- a/src/lib/sounds.ts
+++ b/src/lib/sounds.ts
@@ -1,0 +1,58 @@
+let audioCtx: AudioContext | null = null;
+
+function getAudioContext(): AudioContext | null {
+  if (typeof window === 'undefined') return null;
+  if (!audioCtx) {
+    audioCtx = new AudioContext();
+  }
+  return audioCtx;
+}
+
+/**
+ * Short rising chime for module completion (e.g. shadow reading step done).
+ * Uses Web Audio API — no external files needed.
+ */
+export function playModuleCompleteSound() {
+  const ctx = getAudioContext();
+  if (!ctx) return;
+
+  const now = ctx.currentTime;
+  const gain = ctx.createGain();
+  gain.connect(ctx.destination);
+  gain.gain.setValueAtTime(0.15, now);
+  gain.gain.exponentialRampToValueAtTime(0.001, now + 0.6);
+
+  const notes = [523.25, 659.25, 783.99]; // C5, E5, G5 — major triad
+  for (let i = 0; i < notes.length; i++) {
+    const osc = ctx.createOscillator();
+    osc.type = 'sine';
+    osc.frequency.setValueAtTime(notes[i], now + i * 0.1);
+    osc.connect(gain);
+    osc.start(now + i * 0.1);
+    osc.stop(now + 0.5 + i * 0.1);
+  }
+}
+
+/**
+ * Grand celebration sound for full session completion.
+ */
+export function playSessionCompleteSound() {
+  const ctx = getAudioContext();
+  if (!ctx) return;
+
+  const now = ctx.currentTime;
+  const gain = ctx.createGain();
+  gain.connect(ctx.destination);
+  gain.gain.setValueAtTime(0.12, now);
+  gain.gain.exponentialRampToValueAtTime(0.001, now + 1.2);
+
+  const notes = [523.25, 659.25, 783.99, 1046.5]; // C5, E5, G5, C6
+  for (let i = 0; i < notes.length; i++) {
+    const osc = ctx.createOscillator();
+    osc.type = 'sine';
+    osc.frequency.setValueAtTime(notes[i], now + i * 0.15);
+    osc.connect(gain);
+    osc.start(now + i * 0.15);
+    osc.stop(now + 0.8 + i * 0.15);
+  }
+}

--- a/src/stores/__tests__/practice-translation-store.test.ts
+++ b/src/stores/__tests__/practice-translation-store.test.ts
@@ -36,7 +36,7 @@ describe('practice-translation-store', () => {
     expect(usePracticeTranslationStore.getState().isVisible('listen')).toBe(true);
     expect(usePracticeTranslationStore.getState().isVisible('read')).toBe(true);
     expect(usePracticeTranslationStore.getState().isVisible('speak')).toBe(false);
-    expect(usePracticeTranslationStore.getState().isVisible('write')).toBe(false);
+    expect(usePracticeTranslationStore.getState().isVisible('write')).toBe(true);
   });
 
   it('initializes from persisted visibility without waiting for hydrate', async () => {
@@ -122,7 +122,7 @@ describe('practice-translation-store', () => {
     expect(usePracticeTranslationStore.getState().isVisible('listen')).toBe(true);
     expect(usePracticeTranslationStore.getState().isVisible('read')).toBe(true);
     expect(usePracticeTranslationStore.getState().isVisible('speak')).toBe(false);
-    expect(usePracticeTranslationStore.getState().isVisible('write')).toBe(false);
+    expect(usePracticeTranslationStore.getState().isVisible('write')).toBe(true);
 
     vi.stubGlobal('localStorage', localStorageMock);
   });
@@ -136,7 +136,7 @@ describe('practice-translation-store', () => {
     expect(store.isVisible('speak')).toBe(true);
     expect(store.isVisible('listen')).toBe(true);
     expect(store.isVisible('read')).toBe(true);
-    expect(store.isVisible('write')).toBe(false);
+    expect(store.isVisible('write')).toBe(true);
   });
 
   it('hydrates persisted module visibility from localStorage', async () => {

--- a/src/stores/__tests__/shadow-reading-store.test.ts
+++ b/src/stores/__tests__/shadow-reading-store.test.ts
@@ -1,0 +1,221 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const storage = new Map<string, string>();
+
+const localStorageMock: Storage = {
+  getItem: (key: string) => storage.get(key) ?? null,
+  setItem: (key: string, value: string) => {
+    storage.set(key, value);
+  },
+  removeItem: (key: string) => {
+    storage.delete(key);
+  },
+  clear: () => storage.clear(),
+  get length() {
+    return storage.size;
+  },
+  key: (index: number) => [...storage.keys()][index] ?? null,
+};
+
+vi.stubGlobal('localStorage', localStorageMock);
+vi.stubGlobal('window', globalThis);
+
+const { useShadowReadingStore } = await import('@/stores/shadow-reading-store');
+
+describe('shadow-reading-store', () => {
+  beforeEach(() => {
+    storage.clear();
+    useShadowReadingStore.getState().resetForTests();
+  });
+
+  it('starts disabled with no session', () => {
+    const state = useShadowReadingStore.getState();
+    expect(state.enabled).toBe(false);
+    expect(state.session).toBeNull();
+    expect(state.showCompletionModal).toBe(false);
+  });
+
+  it('enables and disables', () => {
+    useShadowReadingStore.getState().setEnabled(true);
+    expect(useShadowReadingStore.getState().enabled).toBe(true);
+
+    useShadowReadingStore.getState().setEnabled(false);
+    expect(useShadowReadingStore.getState().enabled).toBe(false);
+  });
+
+  it('clears session when disabled', () => {
+    const store = useShadowReadingStore.getState();
+    store.setEnabled(true);
+    store.startSession('content-1', 'Test Content');
+    expect(useShadowReadingStore.getState().session).not.toBeNull();
+
+    store.setEnabled(false);
+    expect(useShadowReadingStore.getState().session).toBeNull();
+  });
+
+  it('starts a session with all modules pending', () => {
+    const store = useShadowReadingStore.getState();
+    store.setEnabled(true);
+    store.startSession('content-1', 'My Article');
+
+    const session = useShadowReadingStore.getState().session;
+    expect(session).not.toBeNull();
+    expect(session!.contentId).toBe('content-1');
+    expect(session!.contentTitle).toBe('My Article');
+    expect(session!.moduleProgress.listen).toBe('pending');
+    expect(session!.moduleProgress.read).toBe('pending');
+    expect(session!.moduleProgress.write).toBe('pending');
+    expect(session!.completedAt).toBeNull();
+  });
+
+  it('marks module progress', () => {
+    const store = useShadowReadingStore.getState();
+    store.setEnabled(true);
+    store.startSession('content-1', 'Test');
+
+    store.markModuleProgress('listen', 'in_progress');
+    expect(useShadowReadingStore.getState().session!.moduleProgress.listen).toBe('in_progress');
+
+    store.markModuleProgress('listen', 'completed');
+    expect(useShadowReadingStore.getState().session!.moduleProgress.listen).toBe('completed');
+  });
+
+  it('shows completion modal when all modules completed', () => {
+    const store = useShadowReadingStore.getState();
+    store.setEnabled(true);
+    store.startSession('content-1', 'Test');
+
+    store.markModuleProgress('listen', 'completed');
+    expect(useShadowReadingStore.getState().showCompletionModal).toBe(false);
+
+    store.markModuleProgress('read', 'completed');
+    expect(useShadowReadingStore.getState().showCompletionModal).toBe(false);
+
+    store.markModuleProgress('write', 'completed');
+    expect(useShadowReadingStore.getState().showCompletionModal).toBe(true);
+    expect(useShadowReadingStore.getState().session!.completedAt).not.toBeNull();
+  });
+
+  it('dismisses completion and clears session', () => {
+    const store = useShadowReadingStore.getState();
+    store.setEnabled(true);
+    store.startSession('content-1', 'Test');
+    store.markModuleProgress('listen', 'completed');
+    store.markModuleProgress('read', 'completed');
+    store.markModuleProgress('write', 'completed');
+
+    expect(useShadowReadingStore.getState().showCompletionModal).toBe(true);
+
+    store.dismissCompletion();
+    expect(useShadowReadingStore.getState().showCompletionModal).toBe(false);
+    expect(useShadowReadingStore.getState().session).toBeNull();
+  });
+
+  it('persists to localStorage', () => {
+    const store = useShadowReadingStore.getState();
+    store.setEnabled(true);
+    store.startSession('content-1', 'Persisted');
+
+    const saved = JSON.parse(storage.get('echotype_shadow_reading') ?? '{}');
+    expect(saved.enabled).toBe(true);
+    expect(saved.session.contentId).toBe('content-1');
+  });
+
+  it('hydrates from localStorage', () => {
+    storage.set(
+      'echotype_shadow_reading',
+      JSON.stringify({
+        enabled: true,
+        session: {
+          contentId: 'hydrated-1',
+          contentTitle: 'Hydrated',
+          moduleProgress: { listen: 'completed', read: 'in_progress', write: 'pending' },
+          startedAt: 1000,
+          completedAt: null,
+        },
+      }),
+    );
+
+    useShadowReadingStore.getState().hydrate();
+
+    const state = useShadowReadingStore.getState();
+    expect(state.enabled).toBe(true);
+    expect(state.session!.contentId).toBe('hydrated-1');
+    expect(state.session!.moduleProgress.listen).toBe('completed');
+    expect(state.session!.moduleProgress.read).toBe('in_progress');
+    expect(state.session!.moduleProgress.write).toBe('pending');
+  });
+
+  it('returns correct completed count', () => {
+    const store = useShadowReadingStore.getState();
+    store.setEnabled(true);
+    store.startSession('content-1', 'Test');
+
+    expect(store.getCompletedCount()).toBe(0);
+
+    store.markModuleProgress('listen', 'completed');
+    expect(useShadowReadingStore.getState().getCompletedCount()).toBe(1);
+
+    store.markModuleProgress('read', 'completed');
+    expect(useShadowReadingStore.getState().getCompletedCount()).toBe(2);
+  });
+
+  it('returns next incomplete module in order', () => {
+    const store = useShadowReadingStore.getState();
+    store.setEnabled(true);
+    store.startSession('content-1', 'Test');
+
+    expect(store.getNextIncompleteModule()).toBe('listen');
+
+    store.markModuleProgress('listen', 'completed');
+    expect(useShadowReadingStore.getState().getNextIncompleteModule()).toBe('read');
+
+    store.markModuleProgress('read', 'completed');
+    expect(useShadowReadingStore.getState().getNextIncompleteModule()).toBe('write');
+
+    store.markModuleProgress('write', 'completed');
+    expect(useShadowReadingStore.getState().getNextIncompleteModule()).toBeNull();
+  });
+
+  it('checks session for content correctly', () => {
+    const store = useShadowReadingStore.getState();
+    store.setEnabled(true);
+    store.startSession('content-1', 'Test');
+
+    expect(useShadowReadingStore.getState().isSessionForContent('content-1')).toBe(true);
+    expect(useShadowReadingStore.getState().isSessionForContent('content-2')).toBe(false);
+  });
+
+  it('does not mark progress without a session', () => {
+    const store = useShadowReadingStore.getState();
+    store.markModuleProgress('listen', 'completed');
+    expect(useShadowReadingStore.getState().session).toBeNull();
+  });
+
+  it('clears session explicitly', () => {
+    const store = useShadowReadingStore.getState();
+    store.setEnabled(true);
+    store.startSession('content-1', 'Test');
+
+    store.clearSession();
+    expect(useShadowReadingStore.getState().session).toBeNull();
+
+    const saved = JSON.parse(storage.get('echotype_shadow_reading') ?? '{}');
+    expect(saved.session).toBeNull();
+  });
+
+  it('handles hydration from empty localStorage gracefully', () => {
+    useShadowReadingStore.getState().hydrate();
+    const state = useShadowReadingStore.getState();
+    expect(state.enabled).toBe(false);
+    expect(state.session).toBeNull();
+  });
+
+  it('handles hydration from invalid JSON gracefully', () => {
+    storage.set('echotype_shadow_reading', 'not-json');
+    useShadowReadingStore.getState().hydrate();
+    const state = useShadowReadingStore.getState();
+    expect(state.enabled).toBe(false);
+    expect(state.session).toBeNull();
+  });
+});

--- a/src/stores/practice-translation-store.ts
+++ b/src/stores/practice-translation-store.ts
@@ -3,16 +3,11 @@ import { create } from 'zustand';
 import { PRACTICE_TRANSLATION_POLICY, type PracticeModule } from '@/types/translation';
 
 const STORAGE_KEY = 'echotype_practice_translation';
-const LEGACY_TTS_STORAGE_KEY = 'echotype_tts_settings';
 
 type VisibilityState = Record<PracticeModule, boolean>;
 
 type PersistedPracticeTranslationState = {
   visibility?: Partial<VisibilityState>;
-};
-
-type LegacyTTSSettings = {
-  showTranslation?: unknown;
 };
 
 interface PracticeTranslationStore {
@@ -21,6 +16,7 @@ interface PracticeTranslationStore {
   isVisible: (module: PracticeModule) => boolean;
   setVisible: (module: PracticeModule, visible: boolean) => void;
   toggle: (module: PracticeModule) => void;
+  resetToDefaults: () => void;
   resetForTests: () => void;
 }
 
@@ -51,24 +47,6 @@ function loadFromStorage(): PersistedPracticeTranslationState | null {
   }
 }
 
-function loadLegacyVisibility(): VisibilityState | null {
-  if (typeof window === 'undefined') return null;
-  try {
-    const legacy = parseStoredJson<LegacyTTSSettings>(localStorage.getItem(LEGACY_TTS_STORAGE_KEY));
-    if (typeof legacy?.showTranslation !== 'boolean') return null;
-
-    const visibility = legacy.showTranslation;
-    return {
-      listen: visibility,
-      read: visibility,
-      speak: visibility,
-      write: visibility,
-    };
-  } catch {
-    return null;
-  }
-}
-
 function saveToStorage(visibility: VisibilityState) {
   if (typeof window === 'undefined') return;
   try {
@@ -83,13 +61,6 @@ function resolveInitialVisibility(): VisibilityState {
   if (saved?.visibility) {
     return mergeVisibility(saved.visibility);
   }
-
-  const legacy = loadLegacyVisibility();
-  if (legacy) {
-    saveToStorage(legacy);
-    return legacy;
-  }
-
   return getDefaultVisibility();
 }
 
@@ -112,12 +83,7 @@ export const usePracticeTranslationStore = create<PracticeTranslationStore>((set
         set({ visibility: mergeVisibility(saved.visibility) });
         return;
       }
-
-      const legacy = loadLegacyVisibility();
-      if (legacy) {
-        set({ visibility: legacy });
-        saveToStorage(legacy);
-      }
+      set({ visibility: getDefaultVisibility() });
     },
 
     isVisible: (module) => get().visibility[module],
@@ -137,6 +103,12 @@ export const usePracticeTranslationStore = create<PracticeTranslationStore>((set
         ...get().visibility,
         [module]: !get().visibility[module],
       };
+      set({ visibility });
+      saveToStorage(visibility);
+    },
+
+    resetToDefaults: () => {
+      const visibility = getDefaultVisibility();
       set({ visibility });
       saveToStorage(visibility);
     },

--- a/src/stores/practice-translation-store.ts
+++ b/src/stores/practice-translation-store.ts
@@ -3,11 +3,16 @@ import { create } from 'zustand';
 import { PRACTICE_TRANSLATION_POLICY, type PracticeModule } from '@/types/translation';
 
 const STORAGE_KEY = 'echotype_practice_translation';
+const LEGACY_TTS_STORAGE_KEY = 'echotype_tts_settings';
 
 type VisibilityState = Record<PracticeModule, boolean>;
 
 type PersistedPracticeTranslationState = {
   visibility?: Partial<VisibilityState>;
+};
+
+type LegacyTTSSettings = {
+  showTranslation?: unknown;
 };
 
 interface PracticeTranslationStore {
@@ -16,7 +21,7 @@ interface PracticeTranslationStore {
   isVisible: (module: PracticeModule) => boolean;
   setVisible: (module: PracticeModule, visible: boolean) => void;
   toggle: (module: PracticeModule) => void;
-  resetToDefaults: () => void;
+  reset: () => void;
   resetForTests: () => void;
 }
 
@@ -47,6 +52,24 @@ function loadFromStorage(): PersistedPracticeTranslationState | null {
   }
 }
 
+function loadLegacyVisibility(): VisibilityState | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const legacy = parseStoredJson<LegacyTTSSettings>(localStorage.getItem(LEGACY_TTS_STORAGE_KEY));
+    if (typeof legacy?.showTranslation !== 'boolean') return null;
+
+    const visibility = legacy.showTranslation;
+    return {
+      listen: visibility,
+      read: visibility,
+      speak: visibility,
+      write: visibility,
+    };
+  } catch {
+    return null;
+  }
+}
+
 function saveToStorage(visibility: VisibilityState) {
   if (typeof window === 'undefined') return;
   try {
@@ -61,6 +84,13 @@ function resolveInitialVisibility(): VisibilityState {
   if (saved?.visibility) {
     return mergeVisibility(saved.visibility);
   }
+
+  const legacy = loadLegacyVisibility();
+  if (legacy) {
+    saveToStorage(legacy);
+    return legacy;
+  }
+
   return getDefaultVisibility();
 }
 
@@ -83,7 +113,12 @@ export const usePracticeTranslationStore = create<PracticeTranslationStore>((set
         set({ visibility: mergeVisibility(saved.visibility) });
         return;
       }
-      set({ visibility: getDefaultVisibility() });
+
+      const legacy = loadLegacyVisibility();
+      if (legacy) {
+        set({ visibility: legacy });
+        saveToStorage(legacy);
+      }
     },
 
     isVisible: (module) => get().visibility[module],
@@ -107,7 +142,7 @@ export const usePracticeTranslationStore = create<PracticeTranslationStore>((set
       saveToStorage(visibility);
     },
 
-    resetToDefaults: () => {
+    reset: () => {
       const visibility = getDefaultVisibility();
       set({ visibility });
       saveToStorage(visibility);

--- a/src/stores/pronunciation-store.ts
+++ b/src/stores/pronunciation-store.ts
@@ -51,7 +51,7 @@ export const usePronunciationStore = create<PronunciationStore>((set, get) => ({
   speechSuperAppKey: '',
   speechSuperSecretKey: '',
   monthlyLimit: 1000,
-  provider: 'auto',
+  provider: 'ai',
 
   setSpeechSuperAppKey: (key) => {
     set({ speechSuperAppKey: key });

--- a/src/stores/pronunciation-store.ts
+++ b/src/stores/pronunciation-store.ts
@@ -51,7 +51,7 @@ export const usePronunciationStore = create<PronunciationStore>((set, get) => ({
   speechSuperAppKey: '',
   speechSuperSecretKey: '',
   monthlyLimit: 1000,
-  provider: 'ai',
+  provider: 'auto',
 
   setSpeechSuperAppKey: (key) => {
     set({ speechSuperAppKey: key });

--- a/src/stores/provider-store.ts
+++ b/src/stores/provider-store.ts
@@ -16,9 +16,14 @@ const STORAGE_KEY = 'echotype_provider_config';
 
 export type OllamaStatus = 'idle' | 'preloading' | 'ready' | 'generating' | 'error';
 
+export const DEFAULT_MAX_TOKENS = 4096;
+export const MIN_MAX_TOKENS = 256;
+export const MAX_MAX_TOKENS = 16384;
+
 interface ProviderStore {
   providers: Record<ProviderId, ProviderConfig>;
   activeProviderId: ProviderId;
+  globalMaxTokens: number;
   ollamaModelStatus: OllamaStatus;
   ollamaFirstUse: boolean;
 
@@ -36,6 +41,8 @@ interface ProviderStore {
   setBaseUrl: (providerId: ProviderId, baseUrl: string) => void;
   setApiPath: (providerId: ProviderId, apiPath: string) => void;
   setNoModelApi: (providerId: ProviderId, value: boolean) => void;
+  setProviderMaxTokens: (providerId: ProviderId, value: number | undefined) => void;
+  setGlobalMaxTokens: (value: number) => void;
   setOllamaStatus: (status: OllamaStatus) => void;
   setOllamaFirstUse: (isFirstUse: boolean) => void;
   isConnected: (providerId: ProviderId) => boolean;
@@ -60,7 +67,7 @@ function buildDefaults(): Record<ProviderId, ProviderConfig> {
 // ─── Encrypted storage ──────────────────────────────────────────────────────
 
 async function loadFromStorage(): Promise<
-  Partial<{ providers: Record<ProviderId, ProviderConfig>; activeProviderId: ProviderId }>
+  Partial<{ providers: Record<ProviderId, ProviderConfig>; activeProviderId: ProviderId; globalMaxTokens: number }>
 > {
   if (typeof window === 'undefined') return {};
   try {
@@ -87,13 +94,17 @@ async function loadFromStorage(): Promise<
 /** Hydration guard — prevents saving default (empty) state before hydration completes */
 let _hydrated = false;
 
-function saveToStorage(providers: Record<ProviderId, ProviderConfig>, activeProviderId: ProviderId) {
+function saveToStorage(
+  providers: Record<ProviderId, ProviderConfig>,
+  activeProviderId: ProviderId,
+  globalMaxTokens: number,
+) {
   if (typeof window === 'undefined') return;
   if (!_hydrated) {
     console.warn('[Provider Store] Blocked save before hydration — preventing data loss');
     return;
   }
-  const json = JSON.stringify({ providers, activeProviderId });
+  const json = JSON.stringify({ providers, activeProviderId, globalMaxTokens });
   void encrypt(json).then((encrypted) => {
     try {
       localStorage.setItem(STORAGE_KEY, encrypted);
@@ -103,16 +114,25 @@ function saveToStorage(providers: Record<ProviderId, ProviderConfig>, activeProv
   });
 }
 
+function save(state: {
+  providers: Record<ProviderId, ProviderConfig>;
+  activeProviderId: ProviderId;
+  globalMaxTokens: number;
+}) {
+  saveToStorage(state.providers, state.activeProviderId, state.globalMaxTokens);
+}
+
 export const useProviderStore = create<ProviderStore>((set, get) => ({
   providers: buildDefaults(),
   activeProviderId: 'groq',
+  globalMaxTokens: DEFAULT_MAX_TOKENS,
   ollamaModelStatus: 'idle',
   ollamaFirstUse: true,
 
   setActiveProvider: (id) => {
     if (!PROVIDER_REGISTRY[id]) return;
     set({ activeProviderId: id });
-    saveToStorage(get().providers, id);
+    save(get());
   },
 
   setSelectedModel: (providerId, modelId) => {
@@ -123,7 +143,7 @@ export const useProviderStore = create<ProviderStore>((set, get) => ({
         [providerId]: { ...state.providers[providerId], selectedModelId: modelId },
       },
     }));
-    saveToStorage(get().providers, get().activeProviderId);
+    save(get());
   },
 
   setModelOverride: (providerId, capability, modelId) => {
@@ -140,7 +160,7 @@ export const useProviderStore = create<ProviderStore>((set, get) => ({
         },
       },
     }));
-    saveToStorage(get().providers, get().activeProviderId);
+    save(get());
   },
 
   setAuth: (providerId, auth) => {
@@ -150,7 +170,7 @@ export const useProviderStore = create<ProviderStore>((set, get) => ({
         [providerId]: { ...state.providers[providerId], auth },
       },
     }));
-    saveToStorage(get().providers, get().activeProviderId);
+    save(get());
   },
 
   clearAuth: (providerId) => {
@@ -166,7 +186,7 @@ export const useProviderStore = create<ProviderStore>((set, get) => ({
         },
       },
     }));
-    saveToStorage(get().providers, get().activeProviderId);
+    save(get());
   },
 
   setDynamicModels: (providerId, models) => {
@@ -176,7 +196,7 @@ export const useProviderStore = create<ProviderStore>((set, get) => ({
         [providerId]: { ...state.providers[providerId], dynamicModels: models },
       },
     }));
-    saveToStorage(get().providers, get().activeProviderId);
+    save(get());
   },
 
   setModelRecommendations: (providerId, recommendations, modelRecommendationKey) => {
@@ -190,7 +210,7 @@ export const useProviderStore = create<ProviderStore>((set, get) => ({
         },
       },
     }));
-    saveToStorage(get().providers, get().activeProviderId);
+    save(get());
   },
 
   setBaseUrl: (providerId, baseUrl) => {
@@ -200,7 +220,7 @@ export const useProviderStore = create<ProviderStore>((set, get) => ({
         [providerId]: { ...state.providers[providerId], baseUrl },
       },
     }));
-    saveToStorage(get().providers, get().activeProviderId);
+    save(get());
   },
 
   setApiPath: (providerId, apiPath) => {
@@ -210,7 +230,7 @@ export const useProviderStore = create<ProviderStore>((set, get) => ({
         [providerId]: { ...state.providers[providerId], apiPath },
       },
     }));
-    saveToStorage(get().providers, get().activeProviderId);
+    save(get());
   },
 
   setNoModelApi: (providerId, value) => {
@@ -220,7 +240,25 @@ export const useProviderStore = create<ProviderStore>((set, get) => ({
         [providerId]: { ...state.providers[providerId], noModelApi: value },
       },
     }));
-    saveToStorage(get().providers, get().activeProviderId);
+    save(get());
+  },
+
+  setProviderMaxTokens: (providerId, value) => {
+    if (!PROVIDER_REGISTRY[providerId]) return;
+    const clamped = value != null ? Math.max(MIN_MAX_TOKENS, Math.min(MAX_MAX_TOKENS, value)) : undefined;
+    set((state) => ({
+      providers: {
+        ...state.providers,
+        [providerId]: { ...state.providers[providerId], maxTokens: clamped },
+      },
+    }));
+    save(get());
+  },
+
+  setGlobalMaxTokens: (value) => {
+    const clamped = Math.max(MIN_MAX_TOKENS, Math.min(MAX_MAX_TOKENS, value));
+    set({ globalMaxTokens: clamped });
+    save(get());
   },
 
   setOllamaStatus: (status) => {
@@ -282,6 +320,7 @@ export const useProviderStore = create<ProviderStore>((set, get) => ({
       set({
         providers: merged,
         activeProviderId: saved.activeProviderId ?? 'groq',
+        globalMaxTokens: saved.globalMaxTokens ?? DEFAULT_MAX_TOKENS,
       });
 
       console.log('[Provider Store] Hydration complete. Active provider:', saved.activeProviderId ?? 'groq');

--- a/src/stores/shadow-reading-store.ts
+++ b/src/stores/shadow-reading-store.ts
@@ -1,0 +1,197 @@
+import { create } from 'zustand';
+
+const STORAGE_KEY = 'echotype_shadow_reading';
+
+export type ShadowModule = 'listen' | 'read' | 'write';
+export type ModuleStatus = 'pending' | 'in_progress' | 'completed';
+
+export const SHADOW_MODULES: ShadowModule[] = ['listen', 'read', 'write'];
+
+export interface ShadowReadingSession {
+  contentId: string;
+  contentTitle: string;
+  moduleProgress: Record<ShadowModule, ModuleStatus>;
+  startedAt: number;
+  completedAt: number | null;
+}
+
+interface PersistedState {
+  enabled: boolean;
+  session: ShadowReadingSession | null;
+}
+
+export interface PendingSessionSwitch {
+  contentId: string;
+  contentTitle: string;
+}
+
+interface ShadowReadingStore {
+  enabled: boolean;
+  session: ShadowReadingSession | null;
+  showCompletionModal: boolean;
+  showEndConfirm: boolean;
+  pendingSwitch: PendingSessionSwitch | null;
+  setEnabled: (v: boolean) => void;
+  startSession: (contentId: string, title: string) => void;
+  startOrSwitchSession: (contentId: string, title: string) => void;
+  confirmSwitch: () => void;
+  cancelSwitch: () => void;
+  markModuleProgress: (module: ShadowModule, status: ModuleStatus) => void;
+  clearSession: () => void;
+  dismissCompletion: () => void;
+  requestEndSession: () => void;
+  cancelEndSession: () => void;
+  hydrate: () => void;
+  getCompletedCount: () => number;
+  getNextIncompleteModule: () => ShadowModule | null;
+  isSessionForContent: (contentId: string) => boolean;
+  resetForTests: () => void;
+}
+
+function loadFromStorage(): PersistedState | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    return JSON.parse(raw) as PersistedState;
+  } catch {
+    return null;
+  }
+}
+
+function saveToStorage(state: PersistedState) {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    /* ignore */
+  }
+}
+
+function getDefaultModuleProgress(): Record<ShadowModule, ModuleStatus> {
+  return { listen: 'pending', read: 'pending', write: 'pending' };
+}
+
+function countCompleted(progress: Record<ShadowModule, ModuleStatus>): number {
+  return SHADOW_MODULES.filter((m) => progress[m] === 'completed').length;
+}
+
+function findNextIncomplete(progress: Record<ShadowModule, ModuleStatus>): ShadowModule | null {
+  return SHADOW_MODULES.find((m) => progress[m] !== 'completed') ?? null;
+}
+
+export const useShadowReadingStore = create<ShadowReadingStore>((set, get) => ({
+  enabled: false,
+  session: null,
+  showCompletionModal: false,
+  showEndConfirm: false,
+  pendingSwitch: null,
+
+  setEnabled: (enabled) => {
+    set({ enabled });
+    if (!enabled) {
+      set({ session: null, showCompletionModal: false });
+    }
+    saveToStorage({ enabled, session: enabled ? get().session : null });
+  },
+
+  startSession: (contentId, contentTitle) => {
+    const session: ShadowReadingSession = {
+      contentId,
+      contentTitle,
+      moduleProgress: getDefaultModuleProgress(),
+      startedAt: Date.now(),
+      completedAt: null,
+    };
+    set({ session, showCompletionModal: false, pendingSwitch: null });
+    saveToStorage({ enabled: get().enabled, session });
+  },
+
+  startOrSwitchSession: (contentId, contentTitle) => {
+    const { session } = get();
+    if (session && session.contentId !== contentId && countCompleted(session.moduleProgress) > 0) {
+      set({ pendingSwitch: { contentId, contentTitle } });
+      return;
+    }
+    get().startSession(contentId, contentTitle);
+  },
+
+  confirmSwitch: () => {
+    const { pendingSwitch } = get();
+    if (pendingSwitch) {
+      get().startSession(pendingSwitch.contentId, pendingSwitch.contentTitle);
+    }
+  },
+
+  cancelSwitch: () => {
+    set({ pendingSwitch: null });
+  },
+
+  markModuleProgress: (module, status) => {
+    const { session, enabled } = get();
+    if (!session) return;
+
+    const moduleProgress = { ...session.moduleProgress, [module]: status };
+    const allDone = countCompleted(moduleProgress) === SHADOW_MODULES.length;
+    const completedAt = allDone ? Date.now() : session.completedAt;
+    const updatedSession = { ...session, moduleProgress, completedAt };
+
+    set({
+      session: updatedSession,
+      showCompletionModal: allDone,
+    });
+    saveToStorage({ enabled, session: updatedSession });
+  },
+
+  clearSession: () => {
+    set({ session: null, showCompletionModal: false, showEndConfirm: false });
+    saveToStorage({ enabled: get().enabled, session: null });
+  },
+
+  dismissCompletion: () => {
+    set({ showCompletionModal: false, session: null });
+    saveToStorage({ enabled: get().enabled, session: null });
+  },
+
+  requestEndSession: () => {
+    if (get().session) set({ showEndConfirm: true });
+  },
+
+  cancelEndSession: () => {
+    set({ showEndConfirm: false });
+  },
+
+  hydrate: () => {
+    const saved = loadFromStorage();
+    if (!saved) return;
+    set({ enabled: saved.enabled, session: saved.session });
+  },
+
+  getCompletedCount: () => {
+    const { session } = get();
+    if (!session) return 0;
+    return countCompleted(session.moduleProgress);
+  },
+
+  getNextIncompleteModule: () => {
+    const { session } = get();
+    if (!session) return null;
+    return findNextIncomplete(session.moduleProgress);
+  },
+
+  isSessionForContent: (contentId) => {
+    const { session, enabled } = get();
+    return enabled && session?.contentId === contentId;
+  },
+
+  resetForTests: () => {
+    set({ enabled: false, session: null, showCompletionModal: false, showEndConfirm: false, pendingSwitch: null });
+    if (typeof window !== 'undefined') {
+      try {
+        localStorage.removeItem(STORAGE_KEY);
+      } catch {
+        /* ignore */
+      }
+    }
+  },
+}));

--- a/src/stores/tts-store.ts
+++ b/src/stores/tts-store.ts
@@ -25,7 +25,6 @@ export interface TTSSettings {
   openaiKey: string;
   anthropicKey: string;
   deepseekKey: string;
-  shadowReadingEnabled: boolean;
 }
 
 interface TTSStore extends TTSSettings {
@@ -46,7 +45,6 @@ interface TTSStore extends TTSSettings {
   setOpenaiKey: (key: string) => void;
   setAnthropicKey: (key: string) => void;
   setDeepseekKey: (key: string) => void;
-  setShadowReadingEnabled: (enabled: boolean) => void;
   hydrate: () => void;
 }
 
@@ -90,7 +88,6 @@ const defaults: TTSSettings = {
   openaiKey: '',
   anthropicKey: '',
   deepseekKey: '',
-  shadowReadingEnabled: false,
 };
 
 export const useTTSStore = create<TTSStore>((set, get) => ({
@@ -179,11 +176,6 @@ export const useTTSStore = create<TTSStore>((set, get) => ({
   setDeepseekKey: (deepseekKey) => {
     set({ deepseekKey });
     saveToStorage({ ...get(), deepseekKey });
-  },
-
-  setShadowReadingEnabled: (shadowReadingEnabled) => {
-    set({ shadowReadingEnabled });
-    saveToStorage({ ...get(), shadowReadingEnabled });
   },
 
   hydrate: () => {

--- a/src/stores/updater-store.ts
+++ b/src/stores/updater-store.ts
@@ -27,7 +27,7 @@ interface UpdaterActions {
 type UpdaterStore = UpdaterState & UpdaterActions;
 
 // Hold the Update object at module level (not serializable for Zustand)
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// biome-ignore lint/suspicious/noExplicitAny: Tauri Update type from dynamic import is not statically available
 let pendingUpdate: any = null;
 let periodicCheckInterval: ReturnType<typeof setInterval> | null = null;
 

--- a/src/types/translation.ts
+++ b/src/types/translation.ts
@@ -9,5 +9,5 @@ export const PRACTICE_TRANSLATION_POLICY: Record<PracticeModule, PracticeTransla
   listen: { defaultVisible: true, allowToggle: true },
   read: { defaultVisible: true, allowToggle: true },
   speak: { defaultVisible: false, allowToggle: true },
-  write: { defaultVisible: false, allowToggle: true },
+  write: { defaultVisible: true, allowToggle: true },
 };


### PR DESCRIPTION
… dictionary

Previously only the first part of speech was shown. Now extracts all meanings
from the dictionary API, batch-translates their definitions, and displays each
POS on its own line with abbreviated labels (n./v./adj. etc.).

Made-with: Cursor