### PR TITLE
fix: desktop OAuth login via system browser with session handoff

### DIFF
--- a/docs/supabase-setup.md
+++ b/docs/supabase-setup.md
@@ -259,8 +259,12 @@ https://your-project.supabase.co/auth/v1/callback
 ```
 
 并在 Supabase Dashboard → **Authentication** → **URL Configuration** 中添加：
-- **Site URL:** `https://your-domain.com`
-- **Redirect URLs:** `https://your-domain.com/auth/callback`
+- **Site URL:** `https://echo-type.app`
+- **Redirect URLs:**
+  - `https://echo-type.app/auth/callback`（Web 端 OAuth 回调）
+  - `https://echo-type.app/auth/desktop-callback`（桌面端 OAuth 回调）
+  - `http://localhost:3000/auth/callback`（本地开发）
+  - `http://localhost:3000/auth/desktop-callback`（本地桌面开发）
 
 ---
 
@@ -269,7 +273,7 @@ https://your-project.supabase.co/auth/v1/callback
 | 问题 | 解决方案 |
 |------|---------|
 | 页面报 "Your project's URL and Key are required" | 检查 `.env.local` 是否正确配置并重启 dev server |
-| OAuth 登录后跳转到空白页 | 检查 Supabase Dashboard 的 Redirect URLs 是否包含 `http://localhost:3000/auth/callback` |
+| OAuth 登录后跳转到空白页 | 检查 Supabase Dashboard 的 Redirect URLs 是否包含 `http://localhost:3000/auth/callback` 和 `http://localhost:3000/auth/desktop-callback` |
 | 同步失败 "Not authenticated" | 确认已登录，检查 Supabase session 是否过期 |
 | 数据未同步 | 检查 Settings → Account 中同步是否已启用 |
 | RLS 错误 | 确认 SQL 中的 RLS policies 已正确创建 |

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@supabase/supabase-js": "^2.99.3",
     "@tauri-apps/api": "^2.10.1",
     "@tauri-apps/plugin-process": "^2.3.1",
+    "@tauri-apps/plugin-shell": "^2.3.5",
     "@tauri-apps/plugin-updater": "^2.10.0",
     "@upstash/ratelimit": "^2.0.8",
     "@upstash/redis": "^1.36.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       '@tauri-apps/plugin-process':
         specifier: ^2.3.1
         version: 2.3.1
+      '@tauri-apps/plugin-shell':
+        specifier: ^2.3.5
+        version: 2.3.5
       '@tauri-apps/plugin-updater':
         specifier: ^2.10.0
         version: 2.10.0
@@ -2218,6 +2221,9 @@ packages:
 
   '@tauri-apps/plugin-process@2.3.1':
     resolution: {integrity: sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==}
+
+  '@tauri-apps/plugin-shell@2.3.5':
+    resolution: {integrity: sha512-jewtULhiQ7lI7+owCKAjc8tYLJr92U16bPOeAa472LHJdgaibLP83NcfAF2e+wkEcA53FxKQAZ7byDzs2eeizg==}
 
   '@tauri-apps/plugin-updater@2.10.0':
     resolution: {integrity: sha512-ljN8jPlnT0aSn8ecYhuBib84alxfMx6Hc8vJSKMJyzGbTPFZAC44T2I1QNFZssgWKrAlofvJqCC6Rr472JWfkQ==}
@@ -7341,6 +7347,10 @@ snapshots:
       '@tauri-apps/cli-win32-x64-msvc': 2.10.1
 
   '@tauri-apps/plugin-process@2.3.1':
+    dependencies:
+      '@tauri-apps/api': 2.10.1
+
+  '@tauri-apps/plugin-shell@2.3.5':
     dependencies:
       '@tauri-apps/api': 2.10.1
 

--- a/src/app/(app)/login/page.tsx
+++ b/src/app/(app)/login/page.tsx
@@ -56,6 +56,8 @@ function LoginContent() {
     verifyEmailOtp,
     resetEmailAuth,
     isAuthenticated,
+    oauthLoading,
+    oauthError,
     emailAuthLoading,
     emailAuthError,
     emailOtpSent,
@@ -164,9 +166,9 @@ function LoginContent() {
         </div>
 
         <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-          {(authError || emailAuthError) && (
+          {(authError || emailAuthError || oauthError) && (
             <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
-              {getLocalizedError(emailAuthError)}
+              {getLocalizedError(emailAuthError || oauthError)}
             </div>
           )}
 
@@ -231,16 +233,18 @@ function LoginContent() {
                   variant="outline"
                   className="h-11 gap-2 text-sm font-medium cursor-pointer"
                   onClick={() => signInWithGoogle()}
+                  disabled={oauthLoading}
                 >
-                  <GoogleIcon className="h-4 w-4" />
+                  {oauthLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : <GoogleIcon className="h-4 w-4" />}
                   Google
                 </Button>
                 <Button
                   variant="outline"
                   className="h-11 gap-2 text-sm font-medium cursor-pointer"
                   onClick={() => signInWithGitHub()}
+                  disabled={oauthLoading}
                 >
-                  <GitHubIcon className="h-4 w-4" />
+                  {oauthLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : <GitHubIcon className="h-4 w-4" />}
                   GitHub
                 </Button>
               </div>

--- a/src/app/api/auth/session-exchange/route.ts
+++ b/src/app/api/auth/session-exchange/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const pendingSessions = new Map<string, { accessToken: string; refreshToken: string; expiresAt: number }>();
+
+setInterval(() => {
+  const now = Date.now();
+  for (const [key, value] of pendingSessions) {
+    if (value.expiresAt < now) pendingSessions.delete(key);
+  }
+}, 30_000);
+
+export async function POST(req: NextRequest) {
+  const { exchangeId, accessToken, refreshToken } = await req.json();
+  if (!exchangeId || !accessToken || !refreshToken) {
+    return NextResponse.json({ error: 'Missing fields' }, { status: 400 });
+  }
+
+  pendingSessions.set(exchangeId, {
+    accessToken,
+    refreshToken,
+    expiresAt: Date.now() + 120_000,
+  });
+
+  return NextResponse.json({ ok: true });
+}
+
+export async function GET(req: NextRequest) {
+  const exchangeId = req.nextUrl.searchParams.get('id');
+  if (!exchangeId) {
+    return NextResponse.json({ error: 'Missing id' }, { status: 400 });
+  }
+
+  const session = pendingSessions.get(exchangeId);
+  if (!session) {
+    return NextResponse.json({ found: false });
+  }
+
+  pendingSessions.delete(exchangeId);
+  return NextResponse.json({
+    found: true,
+    accessToken: session.accessToken,
+    refreshToken: session.refreshToken,
+  });
+}

--- a/src/app/auth/desktop-callback/page.tsx
+++ b/src/app/auth/desktop-callback/page.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export default function DesktopCallbackPage() {
+  const [status, setStatus] = useState<'processing' | 'success' | 'error'>('processing');
+  const [errorMessage, setErrorMessage] = useState('');
+
+  useEffect(() => {
+    async function handleCallback() {
+      const url = new URL(window.location.href);
+      const exchangeId = url.searchParams.get('exchange_id');
+
+      const hash = window.location.hash.substring(1);
+      const params = new URLSearchParams(hash);
+      const accessToken = params.get('access_token');
+      const refreshToken = params.get('refresh_token');
+
+      if (!accessToken || !refreshToken) {
+        setStatus('error');
+        setErrorMessage(params.get('error_description') || 'No tokens received');
+        return;
+      }
+
+      if (!exchangeId) {
+        setStatus('error');
+        setErrorMessage('Missing exchange ID');
+        return;
+      }
+
+      try {
+        const res = await fetch('/api/auth/session-exchange', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ exchangeId, accessToken, refreshToken }),
+        });
+
+        if (!res.ok) throw new Error('Failed to store session');
+
+        setStatus('success');
+      } catch {
+        setStatus('error');
+        setErrorMessage('Failed to complete sign-in');
+      }
+    }
+
+    handleCallback();
+  }, []);
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-slate-50 px-4">
+      <div className="w-full max-w-sm text-center">
+        <div className="mx-auto mb-5 flex h-14 w-14 items-center justify-center rounded-2xl bg-gradient-to-br from-indigo-500 to-violet-600 shadow-lg shadow-indigo-200/50">
+          <span className="text-2xl font-bold text-white">E</span>
+        </div>
+
+        {status === 'processing' && (
+          <>
+            <h2 className="text-xl font-semibold text-slate-900">Signing you in...</h2>
+            <p className="mt-2 text-sm text-slate-500">Please wait while we complete authentication.</p>
+          </>
+        )}
+
+        {status === 'success' && (
+          <>
+            <h2 className="text-xl font-semibold text-green-700">Login successful!</h2>
+            <p className="mt-2 text-sm text-slate-500">You can close this tab and return to EchoType.</p>
+          </>
+        )}
+
+        {status === 'error' && (
+          <>
+            <h2 className="text-xl font-semibold text-red-700">Login failed</h2>
+            <p className="mt-2 text-sm text-slate-500">{errorMessage}</p>
+            <p className="mt-4 text-xs text-slate-400">Please close this tab and try again in the app.</p>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/stores/auth-store.ts
+++ b/src/stores/auth-store.ts
@@ -1,12 +1,16 @@
 import type { AuthChangeEvent, Session, User } from '@supabase/supabase-js';
+import { createClient as createSupabaseClient } from '@supabase/supabase-js';
 import { create } from 'zustand';
 import { createClient, isSupabaseConfigured } from '@/lib/supabase/client';
+import { IS_TAURI } from '@/lib/tauri';
 
 interface AuthState {
   user: User | null;
   isLoading: boolean;
   isAuthenticated: boolean;
   isConfigured: boolean;
+  oauthLoading: boolean;
+  oauthError: string | null;
   emailAuthLoading: boolean;
   emailAuthError: string | null;
   emailOtpSent: boolean;
@@ -21,12 +25,93 @@ interface AuthState {
 }
 
 let initialized = false;
+let oauthPollingTimer: ReturnType<typeof setInterval> | null = null;
+
+async function signInWithOAuthForTauri(provider: 'google' | 'github'): Promise<string> {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  if (!supabaseUrl || !supabaseKey) throw new Error('Auth service not configured');
+
+  const exchangeId = crypto.randomUUID();
+
+  const tempClient = createSupabaseClient(supabaseUrl, supabaseKey, {
+    auth: { flowType: 'implicit' },
+  });
+
+  const { data, error } = await tempClient.auth.signInWithOAuth({
+    provider,
+    options: {
+      skipBrowserRedirect: true,
+      redirectTo: `${window.location.origin}/auth/desktop-callback?exchange_id=${exchangeId}`,
+    },
+  });
+  if (error) throw error;
+  if (!data?.url) throw new Error('No auth URL returned');
+
+  const { open } = await import('@tauri-apps/plugin-shell');
+  await open(data.url);
+
+  return exchangeId;
+}
+
+function startOAuthPolling(exchangeId: string, set: (state: Partial<AuthState>) => void) {
+  stopOAuthPolling();
+  let attempts = 0;
+  const maxAttempts = 120;
+
+  oauthPollingTimer = setInterval(async () => {
+    attempts++;
+    if (attempts > maxAttempts) {
+      stopOAuthPolling();
+      set({ oauthLoading: false, oauthError: 'Login timed out. Please try again.' });
+      return;
+    }
+
+    try {
+      const res = await fetch(`/api/auth/session-exchange?id=${exchangeId}`);
+      if (!res.ok) return;
+
+      const data = await res.json();
+      if (!data.found) return;
+
+      stopOAuthPolling();
+
+      const supabase = createClient();
+      if (!supabase) {
+        set({ oauthLoading: false, oauthError: 'Auth service not configured' });
+        return;
+      }
+
+      const { error } = await supabase.auth.setSession({
+        access_token: data.accessToken,
+        refresh_token: data.refreshToken,
+      });
+
+      if (error) {
+        set({ oauthLoading: false, oauthError: error.message });
+      } else {
+        set({ oauthLoading: false });
+      }
+    } catch {
+      // Network error, keep polling
+    }
+  }, 1000);
+}
+
+function stopOAuthPolling() {
+  if (oauthPollingTimer) {
+    clearInterval(oauthPollingTimer);
+    oauthPollingTimer = null;
+  }
+}
 
 export const useAuthStore = create<AuthState>((set) => ({
   user: null,
   isLoading: true,
   isAuthenticated: false,
   isConfigured: false,
+  oauthLoading: false,
+  oauthError: null,
   emailAuthLoading: false,
   emailAuthError: null,
   emailOtpSent: false,
@@ -70,24 +155,60 @@ export const useAuthStore = create<AuthState>((set) => ({
 
   signInWithGoogle: async () => {
     const supabase = createClient();
-    if (!supabase) return;
-    await supabase.auth.signInWithOAuth({
-      provider: 'google',
-      options: {
-        redirectTo: `${window.location.origin}/auth/callback`,
-      },
-    });
+    if (!supabase) {
+      set({ oauthError: 'Auth service not configured' });
+      return;
+    }
+    set({ oauthLoading: true, oauthError: null });
+    try {
+      if (IS_TAURI) {
+        const exchangeId = await signInWithOAuthForTauri('google');
+        startOAuthPolling(exchangeId, set);
+      } else {
+        const { data, error } = await supabase.auth.signInWithOAuth({
+          provider: 'google',
+          options: {
+            skipBrowserRedirect: true,
+            redirectTo: `${window.location.origin}/auth/callback`,
+          },
+        });
+        if (error) throw error;
+        if (data?.url) {
+          window.location.assign(data.url);
+        }
+      }
+    } catch (e) {
+      set({ oauthLoading: false, oauthError: e instanceof Error ? e.message : 'OAuth sign-in failed' });
+    }
   },
 
   signInWithGitHub: async () => {
     const supabase = createClient();
-    if (!supabase) return;
-    await supabase.auth.signInWithOAuth({
-      provider: 'github',
-      options: {
-        redirectTo: `${window.location.origin}/auth/callback`,
-      },
-    });
+    if (!supabase) {
+      set({ oauthError: 'Auth service not configured' });
+      return;
+    }
+    set({ oauthLoading: true, oauthError: null });
+    try {
+      if (IS_TAURI) {
+        const exchangeId = await signInWithOAuthForTauri('github');
+        startOAuthPolling(exchangeId, set);
+      } else {
+        const { data, error } = await supabase.auth.signInWithOAuth({
+          provider: 'github',
+          options: {
+            skipBrowserRedirect: true,
+            redirectTo: `${window.location.origin}/auth/callback`,
+          },
+        });
+        if (error) throw error;
+        if (data?.url) {
+          window.location.assign(data.url);
+        }
+      }
+    } catch (e) {
+      set({ oauthLoading: false, oauthError: e instanceof Error ? e.message : 'OAuth sign-in failed' });
+    }
   },
 
   signInWithEmail: async (email: string) => {


### PR DESCRIPTION
## Summary

- Fix OAuth login (Google/GitHub) silently failing in the Tauri desktop app
- In Tauri: open OAuth in system browser (shows saved accounts), use implicit flow + session-exchange API to relay tokens back to the webview
- In Web: use PKCE flow with explicit `skipBrowserRedirect` + `window.location.assign`
- Add `oauthLoading`/`oauthError` state with loading spinner and error display on login page

## Changes

- `src/stores/auth-store.ts` — Platform-aware OAuth: Tauri uses system browser + implicit flow + polling; Web uses PKCE flow
- `src/app/(app)/login/page.tsx` — OAuth buttons show loading spinner and disabled state; display OAuth errors
- `src/app/auth/desktop-callback/page.tsx` — **New** page for system browser to hand off tokens after OAuth
- `src/app/api/auth/session-exchange/route.ts` — **New** one-time token relay API (POST stores, GET consumes)
- `docs/supabase-setup.md` — Updated redirect URL docs with desktop-callback paths
- `package.json` — Added `@tauri-apps/plugin-shell` for opening system browser

## Test plan

- [x] Web: Google OAuth button navigates to Google login page
- [x] Web: GitHub OAuth button navigates to GitHub login page
- [x] Desktop-callback page correctly parses tokens and shows success
- [x] Session-exchange API stores and returns tokens (one-time use)
- [x] TypeScript type check passes
- [x] Biome lint passes
- [ ] Manual: Tauri desktop Google OAuth full flow
- [ ] Manual: Tauri desktop GitHub OAuth full flow


Made with [Cursor](https://cursor.com)