### PR TITLE
fix(mobile): handle GO_BACK navigation error with safe fallback

### DIFF
--- a/mobile/app/practice/listen/[id].tsx
+++ b/mobile/app/practice/listen/[id].tsx
@@ -135,7 +135,11 @@ export default function ListenPracticeScreen() {
   const handleRate = (rating: Rating) => {
     if (content) {
       gradeContent(content.id, rating);
-      router.back();
+      if (router.canGoBack()) {
+        router.back();
+      } else {
+        router.replace('/(tabs)/listen');
+      }
     }
   };
 
@@ -255,7 +259,17 @@ export default function ListenPracticeScreen() {
           <Text variant="headlineSmall" style={{ color: colors.onSurface }}>
             {t('common.contentNotFound')}
           </Text>
-          <Button mode="contained" onPress={() => router.back()} buttonColor={listenColors.primary}>
+          <Button
+            mode="contained"
+            onPress={() => {
+              if (router.canGoBack()) {
+                router.back();
+              } else {
+                router.replace('/(tabs)/listen');
+              }
+            }}
+            buttonColor={listenColors.primary}
+          >
             {t('common.goBack')}
           </Button>
         </View>
@@ -270,7 +284,16 @@ export default function ListenPracticeScreen() {
       {!focusMode && (
         <LinearGradient colors={listenColors.gradient} style={styles.headerGradient}>
           <Appbar.Header style={styles.appbar}>
-            <Appbar.BackAction onPress={() => router.back()} color="#FFFFFF" />
+            <Appbar.BackAction
+              onPress={() => {
+                if (router.canGoBack()) {
+                  router.back();
+                } else {
+                  router.replace('/(tabs)/listen');
+                }
+              }}
+              color="#FFFFFF"
+            />
             <Appbar.Content title={content.title} titleStyle={styles.headerTitle} />
           </Appbar.Header>
           <View style={styles.headerInfo}>
@@ -515,7 +538,13 @@ export default function ListenPracticeScreen() {
                     wordsCount,
                     replayCount,
                   }}
-                  onGoBack={() => router.back()}
+                  onGoBack={() => {
+                    if (router.canGoBack()) {
+                      router.back();
+                    } else {
+                      router.replace('/(tabs)/listen');
+                    }
+                  }}
                   ratingIntervals={ratingIntervals}
                   onRate={handleRate}
                 />

--- a/mobile/app/practice/read/[id].tsx
+++ b/mobile/app/practice/read/[id].tsx
@@ -496,7 +496,11 @@ export default function ReadPracticeScreen() {
     (rating: Rating) => {
       if (content) {
         gradeContent(content.id, rating);
-        router.back();
+        if (router.canGoBack()) {
+          router.back();
+        } else {
+          router.replace('/(tabs)/read');
+        }
       }
     },
     [content, gradeContent],
@@ -509,7 +513,17 @@ export default function ReadPracticeScreen() {
           <Text variant="headlineSmall" style={{ color: colors.onSurface }}>
             {t('common.contentNotFound')}
           </Text>
-          <Button mode="contained" onPress={() => router.back()} buttonColor={readColors.primary}>
+          <Button
+            mode="contained"
+            onPress={() => {
+              if (router.canGoBack()) {
+                router.back();
+              } else {
+                router.replace('/(tabs)/read');
+              }
+            }}
+            buttonColor={readColors.primary}
+          >
             {t('common.goBack')}
           </Button>
         </View>
@@ -524,7 +538,16 @@ export default function ReadPracticeScreen() {
       <View style={[styles.fullContainer, { backgroundColor: colors.background }]}>
         <LinearGradient colors={readColors.gradient} style={styles.headerGradient}>
           <Appbar.Header style={styles.appbar}>
-            <Appbar.BackAction onPress={() => router.back()} color="#FFFFFF" />
+            <Appbar.BackAction
+              onPress={() => {
+                if (router.canGoBack()) {
+                  router.back();
+                } else {
+                  router.replace('/(tabs)/read');
+                }
+              }}
+              color="#FFFFFF"
+            />
             <Appbar.Content title={content.title} titleStyle={[styles.headerTitle, styles.title]} />
           </Appbar.Header>
           <View style={styles.headerInfo}>
@@ -719,7 +742,13 @@ export default function ReadPracticeScreen() {
                   wordsCount: content.text.split(/\s+/).filter(Boolean).length,
                   pronunciationScore: pronunciationScore ?? undefined,
                 }}
-                onGoBack={() => router.back()}
+                onGoBack={() => {
+                  if (router.canGoBack()) {
+                    router.back();
+                  } else {
+                    router.replace('/(tabs)/read');
+                  }
+                }}
                 ratingIntervals={ratingIntervals}
                 onRate={handleRate}
               />

--- a/mobile/app/practice/speak/conversation.tsx
+++ b/mobile/app/practice/speak/conversation.tsx
@@ -461,7 +461,16 @@ Start with a short greeting and one question about the passage. Keep replies con
     >
       <LinearGradient colors={speakColors.gradient} style={styles.headerGradient}>
         <Appbar.Header style={styles.appbar}>
-          <Appbar.BackAction onPress={() => router.back()} color={colors.onPrimary} />
+          <Appbar.BackAction
+            onPress={() => {
+              if (router.canGoBack()) {
+                router.back();
+              } else {
+                router.replace('/(tabs)/speak');
+              }
+            }}
+            color={colors.onPrimary}
+          />
           <Appbar.Content
             title={screenTitle}
             titleStyle={[styles.headerTitle, { color: colors.onPrimary, fontFamily: fontFamily.heading }]}
@@ -498,7 +507,13 @@ Start with a short greeting and one question about the passage. Keep replies con
               duration: completedDurationSec,
               messagesCount: messages.length,
             }}
-            onGoBack={() => router.back()}
+            onGoBack={() => {
+              if (router.canGoBack()) {
+                router.back();
+              } else {
+                router.replace('/(tabs)/speak');
+              }
+            }}
           />
 
           <SpeakRecommendationSection title={t('speak.continueLearning')} cards={recommendationCards} />

--- a/mobile/app/practice/write/[id].tsx
+++ b/mobile/app/practice/write/[id].tsx
@@ -192,7 +192,11 @@ export default function WritePracticeScreen() {
   const handleRate = (rating: Rating) => {
     if (content) {
       gradeContent(content.id, rating);
-      router.back();
+      if (router.canGoBack()) {
+        router.back();
+      } else {
+        router.replace('/(tabs)/write');
+      }
     }
   };
 
@@ -201,7 +205,16 @@ export default function WritePracticeScreen() {
       <Screen>
         <View style={styles.container}>
           <Text variant="headlineSmall">{t('common.contentNotFound')}</Text>
-          <Button mode="contained" onPress={() => router.back()}>
+          <Button
+            mode="contained"
+            onPress={() => {
+              if (router.canGoBack()) {
+                router.back();
+              } else {
+                router.replace('/(tabs)/write');
+              }
+            }}
+          >
             {t('common.goBack')}
           </Button>
         </View>
@@ -214,7 +227,16 @@ export default function WritePracticeScreen() {
       <View style={{ flex: 1, backgroundColor: colors.background }}>
         <LinearGradient colors={writeColors.gradient} style={styles.headerGradient}>
           <Appbar.Header style={styles.appbar}>
-            <Appbar.BackAction onPress={() => router.back()} color="#FFFFFF" />
+            <Appbar.BackAction
+              onPress={() => {
+                if (router.canGoBack()) {
+                  router.back();
+                } else {
+                  router.replace('/(tabs)/write');
+                }
+              }}
+              color="#FFFFFF"
+            />
             <Appbar.Content title={content.title} titleStyle={[styles.headerTitle, styles.title]} />
           </Appbar.Header>
         </LinearGradient>
@@ -352,7 +374,13 @@ export default function WritePracticeScreen() {
                   errors,
                 }}
                 onTryAgain={handleTryAgain}
-                onGoBack={() => router.back()}
+                onGoBack={() => {
+                  if (router.canGoBack()) {
+                    router.back();
+                  } else {
+                    router.replace('/(tabs)/write');
+                  }
+                }}
                 ratingIntervals={ratingIntervals}
                 onRate={handleRate}
               />


### PR DESCRIPTION
## Summary

Fixes the "The action 'GO_BACK' was not handled by any navigator" error that occurs when clicking the back button in practice screens when there's no navigation history.

## Problem

When users navigate directly to a practice screen (e.g., via deep link or direct URL), clicking the back button throws an error because `router.back()` fails when there's no previous screen in the navigation stack.

## Solution

All `router.back()` calls now check `router.canGoBack()` first and fallback to `router.replace()` to the appropriate tab screen when no navigation history exists:

- Listen practice → `/(tabs)/listen`
- Read practice → `/(tabs)/read`
- Speak conversation → `/(tabs)/speak`
- Write practice → `/(tabs)/write`

## Changes

- ✅ Listen practice screen (`/practice/listen/[id]`)
- ✅ Read practice screen (`/practice/read/[id]`)
- ✅ Speak conversation screen (`/practice/speak/conversation`)
- ✅ Write practice screen (`/practice/write/[id]`)

## Test Plan

- [x] Navigate to practice screen with history → back button works
- [x] Navigate to practice screen without history → fallback to tab screen
- [x] Complete practice and rate → navigation works correctly
- [x] Click back in header → safe navigation
- [x] Content not found screen → safe navigation

🤖 Generated with Claude Opus 4.7