### PR TITLE
Align mobile More pages more strictly with web parity

### DIFF
--- a/docs/superpowers/specs/2026-04-24-mobile-more-pages-parity-design.md
+++ b/docs/superpowers/specs/2026-04-24-mobile-more-pages-parity-design.md
@@ -1,0 +1,290 @@
+# Mobile More Pages Parity Design
+
+Date: 2026-04-24
+Branch: `feat/mobile-more-parity`
+Status: Draft approved for spec review
+
+## Goal
+
+Align the mobile pages reachable from the `More` tab with the web app's functionality, information hierarchy, and key interaction order.
+
+In scope:
+- `Analytics`
+- `Library`
+- `Favorites`
+- `Wordbooks`
+- `AI Tutor`
+- `Review`
+- `Settings`
+
+Out of scope:
+- Rebuilding the `More` tab information architecture
+- Introducing a new shared page framework or global secondary-page skeleton
+- Reorganizing mobile routing to mirror web route hierarchy
+- Broad unrelated refactors outside parity work
+
+## Fixed Constraints
+
+The implementation must follow these constraints:
+
+1. Keep the current mobile page shells and route structure.
+2. Do not invent a new shared page framework for this project.
+3. Focus on parity of:
+   - functionality
+   - information hierarchy
+   - key interaction order
+4. Mobile may adapt touch targets and layout for phone usage, but may not silently remove web capabilities that matter to page behavior.
+5. Shared extraction is allowed only when it reduces duplication during implementation and lowers delivery risk; it is not a project goal by itself.
+
+## Parity Standard
+
+Each target page should match the web app at this level:
+
+- Core features are present and usable.
+- Primary sections appear in roughly the same priority order as web.
+- Main CTA semantics and state transitions are preserved.
+- Loading, empty, error, and retry states are explicit where web has meaningful states.
+- Mobile-specific layout adaptation is allowed, but not feature simplification by default.
+
+The project does not require route-level or IA-level cloning of web. For example:
+- `AI Tutor` may remain a full-screen page on mobile even though web uses a global chat panel.
+- `Wordbooks` may remain a dedicated mobile page even though web nests it under `Library`.
+
+## Current Assessment
+
+### More Entry Page
+
+`mobile/app/(tabs)/more.tsx` is already a valid mobile entry surface. It exposes the right destination pages and does not need structural redesign for this parity project.
+
+The parity work therefore starts at the seven destination pages, not the `More` page itself.
+
+### Destination Page Status Summary
+
+- `Analytics`: partially aligned; mobile has useful stats and some forecast logic, but not the full web analytics structure.
+- `Library`: functionally strong, but still behind web in grouping depth, filtering breadth, and management actions.
+- `Favorites`: mobile already has a real page, but needs clearer parity with web list/review semantics and information order.
+- `Wordbooks`: largest gap; mobile currently presents a simplified catalog rather than a web-equivalent wordbook experience.
+- `AI Tutor`: mobile has working full-screen chat, but still needs parity with web chat panel capability and guidance patterns.
+- `Review`: mobile is already capable, but needs closer alignment with web's today-review framing and top-level summary.
+- `Settings`: mobile has many core sections already, but still needs a parity pass against web section order and critical advanced controls.
+
+## Page-by-Page Design
+
+### 1. Analytics
+
+Mobile currently includes summary cards and several analytics elements, but it does not yet map cleanly to the web analytics page.
+
+Target parity:
+- Match the web analytics page's primary structure:
+  - top summary stats
+  - activity heatmap
+  - accuracy trend
+  - WPM trend
+  - daily sessions
+  - module breakdown
+  - vocabulary growth
+  - review forecast
+- Keep mobile-friendly chart sizing and stacking.
+- Add explicit loading, error, and empty handling where data is missing or incomplete.
+
+Implementation intent:
+- Reorder or extend the current analytics screen rather than creating a new analytics architecture.
+- Prefer reusing existing data derivations where possible before introducing new ones.
+
+### 2. Library
+
+Mobile library is already one of the stronger pages, but it still trails web in management depth.
+
+Target parity:
+- Preserve the current mobile library page.
+- Bring its filtering and organization closer to web, including:
+  - stronger tab/group coverage
+  - clearer wordbook-related grouping
+  - media-only or source-aware views where web exposes them
+  - richer batch/select mode
+  - stronger tag editing and content actions
+- Keep search and import entry points first-class.
+
+Implementation intent:
+- Extend existing view tabs, filters, sections, and card actions.
+- Avoid turning the page into a dense desktop clone; use progressive disclosure on mobile.
+
+### 3. Favorites
+
+Mobile already has an actual favorites page with folders, search, expansion, and grading. The remaining work is mostly parity refinement rather than first-time implementation.
+
+Target parity:
+- Align the page with web's `favorites list + favorites review` relationship.
+- Strengthen the top-of-page summary and review CTA semantics.
+- Keep folder chips, search, and expandable detail, but ensure the order mirrors web priorities:
+  - page summary
+  - review entry point
+  - filtering/search
+  - item list
+  - empty states
+- Keep review scheduling and grade interactions visible and understandable.
+
+Implementation intent:
+- Improve parity at the page-structure level first.
+- Reuse the existing review route rather than inventing a second review path.
+
+### 4. Wordbooks
+
+This is the clearest gap versus web.
+
+Target parity:
+- Expand the current mobile wordbooks page to better match web:
+  - vocabulary/scenario distinction
+  - clearer filter model
+  - import/remove state
+  - stronger relationship to library inventory
+  - detail drill-in parity
+- Make the page feel like a real acquisition and management surface, not just a browse list.
+
+Implementation intent:
+- Keep the current dedicated mobile page.
+- Add the missing product semantics from the web wordbooks flow rather than relocating the feature under library routing.
+
+### 5. AI Tutor
+
+Mobile chat already supports conversations, starters, streaming, and tool status updates. The gap is in capability parity and guidance parity relative to the web chat panel.
+
+Target parity:
+- Preserve full-screen mobile chat.
+- Align with web on:
+  - provider/setup notices
+  - contextual assistant behavior
+  - tool-driven responses
+  - conversation management
+  - clearer state/error handling
+  - stronger relation to library/content context where web already supports it
+
+Implementation intent:
+- Improve the existing list/detail chat screens.
+- Keep the mobile-first full-screen form factor, but make the capability surface closer to the web chat panel.
+
+### 6. Review
+
+Mobile review already has a unified queue and filters, which is directionally strong. The gap is mostly parity with the web's framing and hierarchy around daily review.
+
+Target parity:
+- Align with web's `today review` semantics:
+  - top summary and plan framing
+  - progress sense
+  - queue emphasis
+  - completion state
+  - next-step CTAs
+- Preserve the useful mobile filters (`today / all / favorites / content`) unless they directly conflict with parity.
+
+Implementation intent:
+- Keep the current review engine and queue model.
+- Adjust the surrounding page structure and copy hierarchy to feel closer to the web experience.
+
+### 7. Settings
+
+Mobile settings has advanced significantly and already includes AI, language, translation, TTS, sync, reminders, and data management. It still needs a parity audit against the web settings surface.
+
+Target parity:
+- Reconcile section order and grouping with web where practical.
+- Verify parity for critical areas:
+  - AI provider configuration
+  - model selection and guidance
+  - language preferences
+  - translation preferences
+  - TTS configuration
+  - sync/account state
+  - reminders
+  - data management
+- Add missing status/help/error affordances where web already provides them.
+
+Implementation intent:
+- Treat this as a parity completion pass, not a rewrite.
+- Only add advanced settings that materially affect real functionality or user control.
+
+## Shared Interaction Rules
+
+These rules apply across all seven pages:
+
+1. Keep the existing mobile page shells.
+2. Preserve current mobile navigation patterns unless they block parity.
+3. Make stateful sections explicit:
+   - loading
+   - empty
+   - error
+   - retry
+4. Align button copy and CTA meaning with web wherever possible.
+5. Preserve mobile touch usability when adapting web interactions.
+6. Do not remove currently working mobile capability unless it conflicts with parity and there is a clear replacement.
+
+## Delivery Sequence
+
+Implementation should proceed in this order:
+
+1. `Wordbooks`
+2. `Analytics`
+3. `Library`
+4. `Favorites`
+5. `AI Tutor`
+6. `Settings`
+7. `Review`
+
+Rationale:
+- `Wordbooks`, `Analytics`, and `Library` have the largest parity gaps or the most structural difference from web.
+- `Favorites`, `AI Tutor`, `Settings`, and `Review` already have stronger foundations and can be completed in a second wave.
+
+## Verification Strategy
+
+Verification must cover both page entry and page behavior.
+
+Required checks:
+- Each `More` menu destination opens correctly.
+- Each page's top-level sections appear in the intended order.
+- Missing web capabilities added by this project are actually interactive, not just rendered.
+- Loading, empty, error, and retry states are exercised where applicable.
+- Page-specific functional checks are performed after implementation:
+  - `Analytics`: chart/data presence and empty/error handling
+  - `Library`: search/filter/sort/sectioning/batch flow
+  - `Favorites`: review CTA, folder filter, expand/detail, due state
+  - `Wordbooks`: filters, import/remove, detail drill-in, library relation
+  - `AI Tutor`: conversation creation, provider notice, streaming/tool state, error handling
+  - `Review`: queue filters, completion state, today framing
+  - `Settings`: provider/model/language/translation/TTS/sync/data management flows
+
+## Risks
+
+### Scope risk
+
+This is a seven-page parity project. The main risk is turning it into an architecture rewrite. The design avoids that by explicitly forbidding a new shared page framework.
+
+### Hidden capability gaps
+
+Some pages look more complete than they are. `Settings` and `AI Tutor` in particular need implementation-time audit against the web surface, not just visual comparison.
+
+### Over-cloning web
+
+Blindly copying web density would hurt mobile usability. This design therefore targets capability parity and interaction parity, not literal desktop layout parity.
+
+## Implementation Boundaries
+
+Allowed:
+- Reordering sections inside existing pages
+- Adding missing functionality
+- Adding missing state handling
+- Refining CTA copy and interaction flow
+- Extracting small shared helpers/components only where implementation duplication makes it worthwhile
+
+Not allowed:
+- New global page shell project
+- `More` IA redesign
+- Route-system overhaul to mimic web hierarchy
+- Large unrelated refactors
+
+## Success Criteria
+
+This project is successful when:
+
+1. The `More` tab still works as the mobile secondary entry point.
+2. All seven destination pages are audited and updated against their web counterparts.
+3. The largest feature gaps are closed without rewriting the mobile app structure.
+4. Mobile preserves usability while reaching functional parity and comparable interaction order.
+5. The result is implementable as one parity project without further decomposition.

--- a/mobile/app/(tabs)/library.tsx
+++ b/mobile/app/(tabs)/library.tsx
@@ -28,10 +28,26 @@ import { useLibraryStore } from '@/stores/useLibraryStore';
 import { fontFamily } from '@/theme/typography';
 import type { Content, DifficultyLevel } from '@/types/content';
 
-type ViewTab = 'all' | 'wordbook' | 'phrase' | 'sentence' | 'article';
+type ViewTab = 'all' | 'wordbook' | 'book' | 'phrase' | 'sentence' | 'article' | 'scenario';
 
 function isKnownWordbook(category: string | undefined): boolean {
   return !!category && ALL_WORDBOOKS.some((b) => b.id === category);
+}
+
+function getWordbookKind(category: string | undefined): 'vocabulary' | 'scenario' | undefined {
+  if (!category) return undefined;
+  return ALL_WORDBOOKS.find((book) => book.id === category)?.kind;
+}
+
+function formatBookCategoryTitle(category: string | undefined): string {
+  if (!category) return 'Books';
+  if (!category.startsWith('book-')) return category;
+  return category
+    .replace(/^book-/, '')
+    .split(/[-_]/g)
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(' ');
 }
 
 type LibrarySectionMeta = {
@@ -97,6 +113,8 @@ export default function LibraryScreen() {
   const [selectMode, setSelectMode] = useState(false);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [showAdvancedFilters, setShowAdvancedFilters] = useState(false);
+  const [showBatchTagInput, setShowBatchTagInput] = useState(false);
+  const [batchTagInput, setBatchTagInput] = useState('');
 
   const {
     contents,
@@ -111,6 +129,7 @@ export default function LibraryScreen() {
     getAllTags,
     getStarredContents,
     toggleStarred,
+    updateContent,
     deleteContent,
     addSampleContents,
   } = useLibraryStore();
@@ -125,7 +144,11 @@ export default function LibraryScreen() {
     // Filter by view tab
     if (activeViewTab !== 'all') {
       if (activeViewTab === 'wordbook') {
-        filtered = filtered.filter((c) => Boolean(c.category && isKnownWordbook(c.category)));
+        filtered = filtered.filter((c) => getWordbookKind(c.category) === 'vocabulary');
+      } else if (activeViewTab === 'scenario') {
+        filtered = filtered.filter((c) => getWordbookKind(c.category) === 'scenario');
+      } else if (activeViewTab === 'book') {
+        filtered = filtered.filter((c) => c.type === 'article' && Boolean(c.category?.startsWith('book-')));
       } else {
         filtered = filtered.filter((c) => c.type === activeViewTab);
         if (activeViewTab === 'article') {
@@ -187,16 +210,20 @@ export default function LibraryScreen() {
   const baseSections = useMemo((): LibrarySectionMeta[] => {
     const sorted = displayedContents;
 
-    if (activeViewTab === 'wordbook') {
+    if (activeViewTab === 'wordbook' || activeViewTab === 'scenario') {
       const map = new Map<string, Content[]>();
       for (const item of sorted) {
         if (!(item.category && isKnownWordbook(item.category))) continue;
+        if (activeViewTab === 'wordbook' && getWordbookKind(item.category) !== 'vocabulary') continue;
+        if (activeViewTab === 'scenario' && getWordbookKind(item.category) !== 'scenario') continue;
         const arr = map.get(item.category) ?? [];
         arr.push(item);
         map.set(item.category, arr);
       }
       const sections: LibrarySectionMeta[] = [];
       for (const book of ALL_WORDBOOKS) {
+        if (activeViewTab === 'wordbook' && book.kind !== 'vocabulary') continue;
+        if (activeViewTab === 'scenario' && book.kind !== 'scenario') continue;
         const fd = map.get(book.id);
         if (!fd?.length) continue;
         sections.push({
@@ -207,6 +234,22 @@ export default function LibraryScreen() {
         });
       }
       return sections;
+    }
+
+    if (activeViewTab === 'book') {
+      const groups = new Map<string, Content[]>();
+      for (const item of sorted) {
+        const key = item.category ?? 'book:uncategorized';
+        const list = groups.get(key) ?? [];
+        list.push(item);
+        groups.set(key, list);
+      }
+      return Array.from(groups.entries()).map(([key, fullData]) => ({
+        key: `book:${key}`,
+        title: formatBookCategoryTitle(key),
+        fullData,
+        practiceEntryContentId: fullData[0]?.id,
+      }));
     }
 
     if (activeViewTab === 'phrase') {
@@ -313,12 +356,16 @@ export default function LibraryScreen() {
         return 'All';
       case 'wordbook':
         return 'Wordbook';
+      case 'book':
+        return 'Book';
       case 'phrase':
         return 'Phrase';
       case 'sentence':
         return 'Sentence';
       case 'article':
         return 'Article';
+      case 'scenario':
+        return 'Scenario';
       default:
         return tab;
     }
@@ -339,6 +386,25 @@ export default function LibraryScreen() {
   const handleEdit = (contentId: string) => {
     setEditingContentId(contentId);
     setEditModalVisible(true);
+  };
+
+  const handleBatchTag = async () => {
+    const nextTags = batchTagInput
+      .split(',')
+      .map((tag) => tag.trim())
+      .filter(Boolean);
+    if (nextTags.length === 0) return;
+
+    for (const id of selectedIds) {
+      const content = contents.find((item) => item.id === id);
+      if (!content) continue;
+      const merged = Array.from(new Set([...content.tags, ...nextTags]));
+      await updateContent(id, { tags: merged });
+    }
+
+    setBatchTagInput('');
+    setShowBatchTagInput(false);
+    void haptics.success();
   };
 
   const editingContent = editingContentId ? contents.find((c) => c.id === editingContentId) : null;
@@ -449,7 +515,7 @@ export default function LibraryScreen() {
         <View style={styles.compactFiltersRow}>
           <ScrollView horizontal showsHorizontalScrollIndicator={false} style={styles.filtersScroll}>
             {/* View Tabs */}
-            {(['all', 'wordbook', 'phrase', 'sentence', 'article'] as ViewTab[]).map((tab) => (
+            {(['all', 'wordbook', 'book', 'phrase', 'sentence', 'article', 'scenario'] as ViewTab[]).map((tab) => (
               <Chip
                 key={tab}
                 mode={activeViewTab === tab ? 'flat' : 'outlined'}
@@ -600,6 +666,8 @@ export default function LibraryScreen() {
                     await deleteContent(id);
                   }
                   setSelectedIds(new Set());
+                  setShowBatchTagInput(false);
+                  setBatchTagInput('');
                 }}
                 icon="delete"
                 compact
@@ -607,6 +675,56 @@ export default function LibraryScreen() {
                 style={styles.batchActionButton}
               >
                 Delete
+              </Button>
+              <Button
+                mode="outlined"
+                onPress={() => {
+                  void haptics.light();
+                  setShowBatchTagInput((value) => !value);
+                }}
+                icon="tag"
+                compact
+                textColor={colors.onPrimary}
+                style={[styles.batchActionButton, { borderColor: `${colors.onPrimary}55` }]}
+              >
+                Tag
+              </Button>
+            </View>
+          </View>
+        )}
+
+        {selectMode && selectedIds.size > 0 && showBatchTagInput && (
+          <View style={[styles.batchTagPanel, { backgroundColor: colors.surface }]}>
+            <Text variant="labelMedium" style={{ color: colors.onSurface, marginBottom: 8 }}>
+              Add tags to selected items
+            </Text>
+            <TextInput
+              style={[
+                styles.batchTagInput,
+                {
+                  color: colors.onSurface,
+                  borderColor: colors.borderLight,
+                  backgroundColor: colors.background,
+                },
+              ]}
+              value={batchTagInput}
+              onChangeText={setBatchTagInput}
+              placeholder="tag1, tag2, tag3"
+              placeholderTextColor={colors.onSurfaceVariant}
+            />
+            <View style={styles.batchTagActions}>
+              <Button
+                mode="text"
+                compact
+                onPress={() => {
+                  setShowBatchTagInput(false);
+                  setBatchTagInput('');
+                }}
+              >
+                Cancel
+              </Button>
+              <Button mode="contained" compact onPress={() => void handleBatchTag()}>
+                Apply
               </Button>
             </View>
           </View>
@@ -661,6 +779,9 @@ export default function LibraryScreen() {
                   onEdit={handleEdit}
                   onDelete={async (id) => {
                     await deleteContent(id);
+                  }}
+                  onUpdateTags={async (id, tags) => {
+                    await updateContent(id, { tags });
                   }}
                   selectable={selectMode}
                   selected={selectedIds.has(item.id)}
@@ -860,6 +981,26 @@ const styles = StyleSheet.create({
   },
   batchActionButton: {
     margin: 0,
+  },
+  batchTagPanel: {
+    marginHorizontal: 16,
+    marginBottom: 10,
+    padding: 14,
+    borderRadius: 14,
+    borderCurve: 'continuous',
+  },
+  batchTagInput: {
+    borderWidth: 1,
+    borderRadius: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    fontSize: 14,
+  },
+  batchTagActions: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    gap: 8,
+    marginTop: 10,
   },
   list: {
     paddingTop: 4,

--- a/mobile/app/(tabs)/settings.tsx
+++ b/mobile/app/(tabs)/settings.tsx
@@ -256,7 +256,6 @@ export default function SettingsScreen() {
   }));
 
   const initials = user?.email?.split('@')[0]?.slice(0, 2).toUpperCase() ?? 'U';
-
   const handlePreviewCurrentVoice = async () => {
     try {
       await previewTTS({

--- a/mobile/app/(tabs)/vocabulary.tsx
+++ b/mobile/app/(tabs)/vocabulary.tsx
@@ -81,7 +81,7 @@ export default function FavoritesScreen() {
   };
 
   const handleReview = () => {
-    router.push('/review');
+    router.push({ pathname: '/review', params: { filter: 'favorites' } });
   };
 
   const confirmAddFolder = () => {
@@ -255,60 +255,31 @@ export default function FavoritesScreen() {
     <Screen padding={0}>
       <View style={[styles.container, { backgroundColor: colors.background }]}>
         <View style={styles.header}>
-          <Text
-            variant="displaySmall"
-            style={[styles.title, { color: colors.onSurface, fontFamily: fontFamily.headingBold }]}
-          >
-            Favorites
-          </Text>
+          <View style={styles.headerRow}>
+            <View style={styles.headerCopy}>
+              <Text
+                variant="displaySmall"
+                style={[styles.title, { color: colors.onSurface, fontFamily: fontFamily.headingBold }]}
+              >
+                Favorites
+              </Text>
+              <Text variant="bodyMedium" style={[styles.subtitle, { color: colors.onSurfaceVariant }]}>
+                {stats.total} saved items{stats.due > 0 ? ` · ${stats.due} due for review` : ''}
+              </Text>
+            </View>
+            {stats.due > 0 ? (
+              <Button
+                mode="contained"
+                onPress={handleReview}
+                style={[styles.headerReviewButton, { backgroundColor: vocabularyColors.primary }]}
+                contentStyle={styles.headerReviewButtonContent}
+                labelStyle={[styles.headerReviewButtonLabel, { fontFamily: fontFamily.heading }]}
+              >
+                Review
+              </Button>
+            ) : null}
+          </View>
         </View>
-
-        <Animated.View entering={FadeInDown.delay(80)} style={styles.statsContainer}>
-          <View style={[styles.statCard, { backgroundColor: colors.surface }]}>
-            <MaterialCommunityIcons name="bookmark-multiple-outline" size={24} color={vocabularyColors.primary} />
-            <Text variant="headlineSmall" style={[styles.statNumber, { color: colors.onSurface }]}>
-              {stats.total}
-            </Text>
-            <Text variant="bodySmall" style={[styles.statLabel, { color: colors.onSurfaceVariant }]}>
-              Total
-            </Text>
-          </View>
-          <View style={[styles.statCard, { backgroundColor: colors.surface }]}>
-            <MaterialCommunityIcons name="clock-alert-outline" size={24} color={colors.error} />
-            <Text variant="headlineSmall" style={[styles.statNumber, { color: colors.error }]}>
-              {stats.due}
-            </Text>
-            <Text variant="bodySmall" style={[styles.statLabel, { color: colors.onSurfaceVariant }]}>
-              Due Today
-            </Text>
-          </View>
-          <View style={[styles.statCard, { backgroundColor: colors.surface }]}>
-            <MaterialCommunityIcons name="star-outline" size={24} color={colors.success} />
-            <Text variant="headlineSmall" style={[styles.statNumber, { color: colors.onSurface }]}>
-              {stats.new}
-            </Text>
-            <Text variant="bodySmall" style={[styles.statLabel, { color: colors.onSurfaceVariant }]}>
-              New
-            </Text>
-          </View>
-        </Animated.View>
-
-        {stats.due > 0 && (
-          <Animated.View entering={FadeInDown.delay(160)} style={styles.reviewButtonContainer}>
-            <Button
-              mode="contained"
-              onPress={handleReview}
-              style={[styles.reviewButton, { backgroundColor: vocabularyColors.primary }]}
-              contentStyle={styles.reviewButtonContent}
-              labelStyle={[styles.reviewButtonLabel, { fontFamily: fontFamily.heading }]}
-              accessibilityLabel={`Review ${stats.due} card${stats.due > 1 ? 's' : ''}`}
-              accessibilityHint="Double tap to start reviewing due cards"
-              accessibilityRole="button"
-            >
-              Review {stats.due} card{stats.due > 1 ? 's' : ''}
-            </Button>
-          </Animated.View>
-        )}
 
         <Animated.View entering={FadeInDown.delay(200)} style={styles.chipsScrollWrap}>
           <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.chipsRow}>
@@ -449,57 +420,33 @@ const styles = StyleSheet.create({
     paddingTop: 16,
     paddingBottom: 8,
   },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    justifyContent: 'space-between',
+    gap: 12,
+  },
+  headerCopy: {
+    flex: 1,
+  },
   title: {
     fontWeight: '700',
     fontSize: 34,
     letterSpacing: 0.4,
   },
-  statsContainer: {
-    flexDirection: 'row',
-    paddingHorizontal: 16,
-    gap: 12,
-    marginBottom: 12,
+  subtitle: {
+    marginTop: 6,
   },
-  statCard: {
-    flex: 1,
-    padding: 16,
-    borderRadius: 16,
-    borderCurve: 'continuous',
-    alignItems: 'center',
-    // Shadow colors remain fixed for consistent elevation across themes
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.05,
-    shadowRadius: 8,
-    elevation: 2,
-  },
-  statNumber: {
-    fontWeight: '700',
-    marginTop: 8,
-    marginBottom: 4,
-  },
-  statLabel: {
-    fontSize: 12,
-  },
-  reviewButtonContainer: {
-    paddingHorizontal: 16,
-    marginBottom: 12,
-  },
-  reviewButton: {
+  headerReviewButton: {
     borderRadius: 14,
     borderCurve: 'continuous',
-    // Shadow color matches primary for glow effect
-    shadowColor: '#6366F1',
-    shadowOffset: { width: 0, height: 4 },
-    shadowOpacity: 0.2,
-    shadowRadius: 8,
-    elevation: 4,
   },
-  reviewButtonContent: {
-    paddingVertical: 8,
+  headerReviewButtonContent: {
+    paddingHorizontal: 4,
+    paddingVertical: 4,
   },
-  reviewButtonLabel: {
-    fontSize: 16,
+  headerReviewButtonLabel: {
+    fontSize: 14,
     fontWeight: '600',
   },
   chipsScrollWrap: {

--- a/mobile/app/analytics/index.tsx
+++ b/mobile/app/analytics/index.tsx
@@ -229,6 +229,146 @@ function SectionCard({
   );
 }
 
+function HeatmapGrid({
+  days,
+  colors,
+}: {
+  days: Array<{ date: string; count: number }>;
+  colors: ReturnType<typeof useAppTheme>['colors'];
+}) {
+  const columns = useMemo(() => {
+    const out: Array<Array<{ date: string; count: number }>> = [];
+    for (let i = 0; i < days.length; i += 7) out.push(days.slice(i, i + 7));
+    return out;
+  }, [days]);
+
+  const totalSessions = useMemo(() => days.reduce((sum, day) => sum + day.count, 0), [days]);
+  const activeDays = useMemo(() => days.filter((day) => day.count > 0).length, [days]);
+
+  const getCellColor = (count: number) => {
+    if (count <= 0) return colors.surfaceVariant;
+    if (count === 1) return `${colors.primary}45`;
+    if (count <= 3) return `${colors.primary}75`;
+    if (count <= 5) return colors.primary;
+    return colors.secondary;
+  };
+
+  return (
+    <View>
+      <Text variant="bodySmall" style={{ color: colors.onSurfaceSecondary, marginBottom: 12 }}>
+        {totalSessions} sessions across {activeDays} active days
+      </Text>
+      <View style={styles.heatmapWrap}>
+        {columns.map((column, columnIndex) => (
+          <View key={`col-${columnIndex}`} style={styles.heatmapColumn}>
+            {column.map((day) => (
+              <View key={day.date} style={[styles.heatmapCell, { backgroundColor: getCellColor(day.count) }]} />
+            ))}
+          </View>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+function StackedSessionBars({
+  rows,
+  colors,
+}: {
+  rows: Array<{ date: string; listen: number; speak: number; read: number; write: number }>;
+  colors: ReturnType<typeof useAppTheme>['colors'];
+}) {
+  const maxTotal = useMemo(
+    () => Math.max(1, ...rows.map((row) => row.listen + row.speak + row.read + row.write)),
+    [rows],
+  );
+  const hasData = rows.some((row) => row.listen + row.speak + row.read + row.write > 0);
+
+  if (!hasData) {
+    return (
+      <Text variant="bodySmall" style={{ color: colors.onSurfaceSecondary }}>
+        Complete practice sessions to populate the daily sessions chart.
+      </Text>
+    );
+  }
+
+  return (
+    <View style={styles.dailyRow}>
+      {rows.map((row) => {
+        const total = row.listen + row.speak + row.read + row.write;
+        const day = new Date(`${row.date}T12:00:00.000Z`).toLocaleDateString(undefined, {
+          weekday: 'narrow',
+          timeZone: 'UTC',
+        });
+        const stackHeight = 16 + Math.round((total / maxTotal) * 84);
+        const values = [
+          { key: 'listen', value: row.listen, color: MODULE_BAR.listen },
+          { key: 'speak', value: row.speak, color: MODULE_BAR.speak },
+          { key: 'read', value: row.read, color: MODULE_BAR.read },
+          { key: 'write', value: row.write, color: MODULE_BAR.write },
+        ].filter((segment) => segment.value > 0);
+
+        return (
+          <View key={row.date} style={styles.dailyCol}>
+            <Text variant="labelSmall" style={{ color: colors.onSurface, fontWeight: '700' }}>
+              {total}
+            </Text>
+            <View style={[styles.stackedBarTrack, { backgroundColor: colors.surfaceVariant, height: stackHeight }]}>
+              {values.map((segment) => {
+                const height = `${(segment.value / total) * 100}%` as `${number}%`;
+                return (
+                  <View key={segment.key} style={[styles.stackedBarFill, { height, backgroundColor: segment.color }]} />
+                );
+              })}
+            </View>
+            <Text variant="labelSmall" style={{ color: colors.onSurfaceSecondary, marginTop: 6 }}>
+              {day}
+            </Text>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+function ForecastBars({
+  rows,
+  colors,
+}: {
+  rows: Array<{ label: string; count: number }>;
+  colors: ReturnType<typeof useAppTheme>['colors'];
+}) {
+  const maxCount = useMemo(() => Math.max(1, ...rows.map((row) => row.count)), [rows]);
+  const total = useMemo(() => rows.reduce((sum, row) => sum + row.count, 0), [rows]);
+
+  if (total === 0) {
+    return (
+      <Text variant="bodySmall" style={{ color: colors.onSurfaceSecondary }}>
+        No upcoming reviews scheduled for the next 7 days.
+      </Text>
+    );
+  }
+
+  return (
+    <View style={styles.dailyRow}>
+      {rows.map((row) => {
+        const height = 12 + Math.round((row.count / maxCount) * 76);
+        return (
+          <View key={row.label} style={styles.dailyCol}>
+            <Text variant="labelSmall" style={{ color: colors.onSurface, fontWeight: '700' }}>
+              {row.count}
+            </Text>
+            <View style={[styles.dailyBar, { height, backgroundColor: colors.primary }]} />
+            <Text variant="labelSmall" style={{ color: colors.onSurfaceSecondary, marginTop: 6 }}>
+              {row.label}
+            </Text>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
 export default function AnalyticsScreen() {
   const { colors } = useAppTheme();
   const insets = useSafeAreaInsets();
@@ -306,6 +446,12 @@ export default function AnalyticsScreen() {
     return { dates, counts, max };
   }, [activities]);
 
+  const heatmapDays = useMemo(() => {
+    const dates = lastNDatesUTC(56);
+    const counts = new Map(activities.map((activity) => [activity.date, activity.count] as const));
+    return dates.map((date) => ({ date, count: counts.get(date) ?? 0 }));
+  }, [activities]);
+
   const accuracyTrend = useMemo(() => {
     type Row = { at: number; acc: number };
     const rows: Row[] = [
@@ -339,6 +485,66 @@ export default function AnalyticsScreen() {
     return computeReviewForecastCounts(dueTs);
   }, [libraryContents]);
 
+  const dailySessionsRows = useMemo(() => {
+    const dates = lastNDatesUTC(7);
+    const seed = new Map(dates.map((date) => [date, { date, listen: 0, speak: 0, read: 0, write: 0 }]));
+
+    for (const session of listenSessions) {
+      const date = utcDayISO(new Date(session.completedAt));
+      const row = seed.get(date);
+      if (row) row.listen += 1;
+    }
+    for (const session of speakSessions) {
+      const date = utcDayISO(new Date(session.completedAt));
+      const row = seed.get(date);
+      if (row) row.speak += 1;
+    }
+    for (const session of readSessions) {
+      const date = utcDayISO(new Date(session.completedAt));
+      const row = seed.get(date);
+      if (row) row.read += 1;
+    }
+    for (const session of writeSessions) {
+      const date = utcDayISO(new Date(session.completedAt));
+      const row = seed.get(date);
+      if (row) row.write += 1;
+    }
+
+    return dates.map((date) => seed.get(date)!);
+  }, [listenSessions, readSessions, speakSessions, writeSessions]);
+
+  const vocabularyGrowth = useMemo(() => {
+    if (libraryContents.length === 0) return [] as number[];
+    const buckets = new Map<string, number>();
+    for (const item of libraryContents) {
+      const date = utcDayISO(new Date(item.createdAt));
+      buckets.set(date, (buckets.get(date) ?? 0) + 1);
+    }
+    let running = 0;
+    return Array.from(buckets.entries())
+      .sort((a, b) => a[0].localeCompare(b[0]))
+      .map(([, count]) => {
+        running += count;
+        return running;
+      });
+  }, [libraryContents]);
+
+  const reviewForecastRows = useMemo(() => {
+    const today = new Date();
+    const dueTs = [
+      ...libraryContents.map((item) => item.fsrsCard?.due).filter((due): due is number => typeof due === 'number'),
+      ...favoriteItems.map((item) => item.fsrsCard?.due).filter((due): due is number => typeof due === 'number'),
+    ];
+
+    return Array.from({ length: 7 }, (_, index) => {
+      const date = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate() + index));
+      const iso = utcDayISO(date);
+      const count = dueTs.filter((due) => utcDayISO(new Date(due)) === iso).length;
+      const label = index === 0 ? 'T' : date.toLocaleDateString(undefined, { weekday: 'narrow', timeZone: 'UTC' });
+      return { label, count };
+    });
+  }, [favoriteItems, libraryContents]);
+
   const maxTypeCount = useMemo(() => Math.max(1, ...contentByType.map((x) => x.count)), [contentByType]);
 
   const totalWordsPracticed = useMemo(() => {
@@ -349,6 +555,8 @@ export default function AnalyticsScreen() {
     }, 0);
     return fromRead + fromWrite;
   }, [readSessions, writeSessions]);
+
+  const isEmptyState = totalSessions === 0 && libraryContents.length === 0 && favoriteItems.length === 0;
 
   return (
     <View style={[styles.root, { backgroundColor: colors.background, paddingTop: insets.top }]}>
@@ -426,7 +634,31 @@ export default function AnalyticsScreen() {
           </View>
         </Animated.View>
 
-        <SectionCard title="Time by module" subtitle="Share of total practice time" delay={260} colors={colors}>
+        {isEmptyState ? (
+          <SectionCard title="Analytics" subtitle="No learning data yet" delay={260} colors={colors}>
+            <Text variant="bodyMedium" style={{ color: colors.onSurfaceSecondary, lineHeight: 20 }}>
+              Complete a few Listen, Read, Speak, or Write sessions to populate charts and review forecasts.
+            </Text>
+          </SectionCard>
+        ) : null}
+
+        <SectionCard title="Activity heatmap" subtitle="Last 56 days of activity" delay={260} colors={colors}>
+          <HeatmapGrid days={heatmapDays} colors={colors} />
+        </SectionCard>
+
+        <SectionCard title="Accuracy trend" subtitle="Last 10 speak and write sessions" delay={320} colors={colors}>
+          <Sparkline values={accuracyTrend} lineColor={colors.primary} dotColor={colors.accent} height={110} />
+        </SectionCard>
+
+        <SectionCard title="WPM trend" subtitle="Last 10 write sessions" delay={380} colors={colors}>
+          <Sparkline values={wpmTrend} lineColor={MODULE_BAR.write} dotColor={colors.primary} height={110} />
+        </SectionCard>
+
+        <SectionCard title="Daily sessions" subtitle="Practice sessions in the last 7 days" delay={440} colors={colors}>
+          <StackedSessionBars rows={dailySessionsRows} colors={colors} />
+        </SectionCard>
+
+        <SectionCard title="Module breakdown" subtitle="Share of total practice time" delay={500} colors={colors}>
           {moduleRows.map((row) => (
             <View key={row.key} style={styles.moduleRow}>
               <View style={styles.moduleLabelCol}>
@@ -442,78 +674,19 @@ export default function AnalyticsScreen() {
           ))}
         </SectionCard>
 
-        <SectionCard title="Last 7 days" subtitle="Sessions per day" delay={320} colors={colors}>
-          <View style={styles.dailyRow}>
-            {dailyLast7.counts.map((c, i) => {
-              const h = 8 + Math.round((c / dailyLast7.max) * 72);
-              const d = new Date(`${dailyLast7.dates[i]}T12:00:00.000Z`);
-              const label = d.toLocaleDateString(undefined, { weekday: 'narrow', timeZone: 'UTC' });
-              return (
-                <View key={dailyLast7.dates[i]} style={styles.dailyCol}>
-                  <Text variant="labelSmall" style={{ color: colors.onSurface, fontWeight: '700' }}>
-                    {c}
-                  </Text>
-                  <View style={[styles.dailyBar, { height: h, backgroundColor: colors.primary }]} />
-                  <Text variant="labelSmall" style={{ color: colors.onSurfaceSecondary, marginTop: 6 }}>
-                    {label}
-                  </Text>
-                </View>
-              );
-            })}
-          </View>
-        </SectionCard>
-
-        <SectionCard title="Accuracy trend" subtitle="Last 10 speak & write sessions" delay={380} colors={colors}>
-          <Sparkline values={accuracyTrend} lineColor={colors.primary} dotColor={colors.accent} height={110} />
-        </SectionCard>
-
-        <SectionCard title="WPM trend" subtitle="Last 10 write sessions" delay={440} colors={colors}>
-          <Sparkline values={wpmTrend} lineColor={MODULE_BAR.write} dotColor={colors.primary} height={110} />
-        </SectionCard>
-
         <SectionCard
-          title="Vocabulary practice"
-          subtitle="Estimated words touched in read & write sessions"
-          delay={470}
+          title="Vocabulary growth"
+          subtitle="Cumulative library items over time"
+          delay={560}
           colors={colors}
         >
-          <Text variant="headlineSmall" style={{ color: colors.onSurface, fontFamily: fontFamily.headingBold }}>
-            {totalWordsPracticed >= 1000 ? totalWordsPracticed.toLocaleString() : totalWordsPracticed}
-          </Text>
+          <Sparkline values={vocabularyGrowth} lineColor={colors.primary} dotColor={colors.secondary} height={110} />
           <Text variant="bodySmall" style={{ color: colors.onSurfaceSecondary, marginTop: 6 }}>
-            Dashboard words-learned counter: {stats.wordsLearned}
+            {libraryContents.length} library items · {totalWordsPracticed} estimated practiced words
           </Text>
         </SectionCard>
 
-        <SectionCard title="Favorites (SRS)" subtitle="Spaced repetition deck" delay={500} colors={colors}>
-          <View style={styles.favGrid}>
-            {(
-              [
-                ['Total', favCounts.total],
-                ['Due', favCounts.due],
-                ['New', favCounts.new],
-                ['Learning', favCounts.learning],
-                ['Review', favCounts.review],
-              ] as const
-            ).map(([k, v]) => (
-              <View key={k} style={[styles.favCell, { backgroundColor: colors.surfaceVariant }]}>
-                <Text variant="labelSmall" style={{ color: colors.onSurfaceSecondary }}>
-                  {k}
-                </Text>
-                <Text variant="titleLarge" style={{ color: colors.onSurface, fontWeight: '700', marginTop: 4 }}>
-                  {v}
-                </Text>
-              </View>
-            ))}
-          </View>
-        </SectionCard>
-
-        <SectionCard
-          title="Library review forecast"
-          subtitle="FSRS due dates in your library"
-          delay={540}
-          colors={colors}
-        >
+        <SectionCard title="Review forecast" subtitle="Due items in the next 7 days" delay={620} colors={colors}>
           <View style={styles.forecastRow}>
             <View style={[styles.forecastPill, { backgroundColor: colors.primaryContainer }]}>
               <Text variant="labelSmall" style={{ color: colors.onPrimaryContainer }}>
@@ -540,31 +713,32 @@ export default function AnalyticsScreen() {
               </Text>
             </View>
           </View>
+          <View style={{ marginTop: 14 }}>
+            <ForecastBars rows={reviewForecastRows} colors={colors} />
+          </View>
         </SectionCard>
 
-        <SectionCard title="Content by type" subtitle="Items in your library" delay={600} colors={colors}>
-          {contentByType.length === 0 ? (
-            <Text variant="bodySmall" style={{ color: colors.onSurfaceSecondary }}>
-              No content yet.
-            </Text>
-          ) : (
-            contentByType.map(({ type, count }) => (
-              <View key={type} style={styles.typeRow}>
-                <Text style={[styles.typeLabel, { color: colors.onSurface }]}>{type}</Text>
-                <Text variant="bodySmall" style={{ color: colors.onSurfaceSecondary, width: 36, textAlign: 'right' }}>
-                  {count}
+        <SectionCard title="Favorites (SRS)" subtitle="Spaced repetition deck" delay={680} colors={colors}>
+          <View style={styles.favGrid}>
+            {(
+              [
+                ['Total', favCounts.total],
+                ['Due', favCounts.due],
+                ['New', favCounts.new],
+                ['Learning', favCounts.learning],
+                ['Review', favCounts.review],
+              ] as const
+            ).map(([k, v]) => (
+              <View key={k} style={[styles.favCell, { backgroundColor: colors.surfaceVariant }]}>
+                <Text variant="labelSmall" style={{ color: colors.onSurfaceSecondary }}>
+                  {k}
                 </Text>
-                <View style={[styles.typeBarBg, { backgroundColor: colors.surfaceVariant }]}>
-                  <View
-                    style={[
-                      styles.typeBarFill,
-                      { width: `${Math.round((count / maxTypeCount) * 100)}%`, backgroundColor: colors.secondary },
-                    ]}
-                  />
-                </View>
+                <Text variant="titleLarge" style={{ color: colors.onSurface, fontWeight: '700', marginTop: 4 }}>
+                  {v}
+                </Text>
               </View>
-            ))
-          )}
+            ))}
+          </View>
         </SectionCard>
 
         <Pressable
@@ -639,6 +813,18 @@ const styles = StyleSheet.create({
   dailyRow: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'flex-end', paddingTop: 8 },
   dailyCol: { alignItems: 'center', flex: 1 },
   dailyBar: { width: '56%', minHeight: 8, borderRadius: 6, borderCurve: 'continuous', marginTop: 6 },
+  stackedBarTrack: {
+    width: '56%',
+    minHeight: 16,
+    borderRadius: 6,
+    borderCurve: 'continuous',
+    marginTop: 6,
+    overflow: 'hidden',
+    justifyContent: 'flex-end',
+  },
+  stackedBarFill: {
+    width: '100%',
+  },
   sparkEmpty: { justifyContent: 'center', paddingHorizontal: 8 },
   sparkDot: {
     position: 'absolute',
@@ -663,5 +849,19 @@ const styles = StyleSheet.create({
   typeLabel: { width: 100, fontFamily: fontFamily.body, textTransform: 'capitalize' },
   typeBarBg: { flex: 1, height: 8, borderRadius: 6, borderCurve: 'continuous', overflow: 'hidden' },
   typeBarFill: { height: '100%', borderRadius: 6, borderCurve: 'continuous' },
+  heatmapWrap: {
+    flexDirection: 'row',
+    gap: 4,
+    flexWrap: 'nowrap',
+  },
+  heatmapColumn: {
+    gap: 4,
+  },
+  heatmapCell: {
+    width: 12,
+    height: 12,
+    borderRadius: 4,
+    borderCurve: 'continuous',
+  },
   linkOut: { flexDirection: 'row', alignItems: 'center', justifyContent: 'center', paddingVertical: 16, gap: 4 },
 });

--- a/mobile/app/chat/[id].tsx
+++ b/mobile/app/chat/[id].tsx
@@ -238,24 +238,26 @@ export default function ChatDetailScreen() {
         contentContainerStyle={styles.messageList}
         showsVerticalScrollIndicator={false}
         ListHeaderComponent={
-          noticeVisible ? (
-            <View style={styles.noticeContainer}>
-              <MvpNoticeCard
-                title="Configure AI Provider"
-                body="Go to Settings → AI Provider to add your API key. Once configured, you'll get real AI responses."
-              />
-              <Pressable
-                onPress={() => dismissNotice(conversation.id)}
-                style={[styles.dismissBanner, { backgroundColor: colors.surfaceVariant }]}
-                accessibilityRole="button"
-                accessibilityLabel="Dismiss banner"
-              >
-                <Text variant="labelMedium" style={{ color: colors.onSurfaceSecondary }}>
-                  Dismiss
-                </Text>
-              </Pressable>
-            </View>
-          ) : null
+          <View style={styles.noticeContainer}>
+            {noticeVisible ? (
+              <>
+                <MvpNoticeCard
+                  title="Configure AI Provider"
+                  body="Go to Settings → AI Provider to add your API key. Once configured, you'll get real AI responses."
+                />
+                <Pressable
+                  onPress={() => dismissNotice(conversation.id)}
+                  style={[styles.dismissBanner, { backgroundColor: colors.surfaceVariant }]}
+                  accessibilityRole="button"
+                  accessibilityLabel="Dismiss banner"
+                >
+                  <Text variant="labelMedium" style={{ color: colors.onSurfaceSecondary }}>
+                    Dismiss
+                  </Text>
+                </Pressable>
+              </>
+            ) : null}
+          </View>
         }
         ListEmptyComponent={
           <View style={styles.emptyChat}>

--- a/mobile/app/review/index.tsx
+++ b/mobile/app/review/index.tsx
@@ -1,6 +1,6 @@
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { addDays, endOfDay, startOfDay } from 'date-fns';
-import { router } from 'expo-router';
+import { router, useLocalSearchParams } from 'expo-router';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ScrollView, StyleSheet, View } from 'react-native';
 import { Appbar, Button, SegmentedButtons, Text } from 'react-native-paper';
@@ -84,6 +84,7 @@ function DailyRing({
 export default function ReviewScreen() {
   const { colors, getModuleColors } = useAppTheme();
   const { t, tInterpolate } = useI18n();
+  const params = useLocalSearchParams<{ filter?: ReviewFilter }>();
   const vocabularyColors = getModuleColors('vocabulary');
   const listenColors = getModuleColors('listen');
 
@@ -238,6 +239,13 @@ export default function ReviewScreen() {
     sessionStartRef.current = Date.now();
     celebratedRef.current = false;
   }, []);
+
+  useEffect(() => {
+    const requested = Array.isArray(params.filter) ? params.filter[0] : params.filter;
+    if (requested && ['today', 'all', 'favorites', 'content'].includes(requested) && requested !== filter) {
+      resetSessionProgress(requested as ReviewFilter);
+    }
+  }, [filter, params.filter, resetSessionProgress]);
 
   const sessionMinutes = Math.max(1, Math.round((Date.now() - sessionStartRef.current) / 60_000));
 

--- a/mobile/app/wordbook/[id].tsx
+++ b/mobile/app/wordbook/[id].tsx
@@ -1,23 +1,82 @@
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { LinearGradient } from 'expo-linear-gradient';
 import { router, useLocalSearchParams } from 'expo-router';
-import { useEffect, useState } from 'react';
-import { FlatList, Pressable, StyleSheet, View } from 'react-native';
-import { Appbar, Chip, Text } from 'react-native-paper';
+import { useEffect, useMemo, useState } from 'react';
+import { FlatList, Pressable, ScrollView, StyleSheet, View } from 'react-native';
+import { Appbar, Button, Chip, Searchbar, Text } from 'react-native-paper';
 import { useAppTheme } from '@/contexts/ThemeContext';
 import { haptics } from '@/lib/haptics';
-import { getWordBook, loadWordBookItems } from '@/lib/wordbooks';
+import { ALL_WORDBOOKS, getWordBook, loadWordBookItems } from '@/lib/wordbooks';
+import { useLibraryStore } from '@/stores/useLibraryStore';
+import { useWordbookStore } from '@/stores/useWordbookStore';
 import { fontFamily } from '@/theme/typography';
-import type { WordItem } from '@/types/wordbook';
+import { getWordBookItemCount, type WordBook, type WordItem } from '@/types/wordbook';
+
+function getRelatedBooks(book: WordBook, limit = 4): WordBook[] {
+  return ALL_WORDBOOKS.filter((candidate) => candidate.id !== book.id && candidate.kind === book.kind)
+    .map((candidate) => {
+      let score = 0;
+      if (candidate.filterTag === book.filterTag) score += 3;
+      if (candidate.difficulty === book.difficulty) score += 2;
+      score += candidate.tags.filter((tag) => book.tags.includes(tag)).length;
+      return { candidate, score };
+    })
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit)
+    .map((entry) => entry.candidate);
+}
 
 export default function WordbookDetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const { colors, getModuleColors } = useAppTheme();
   const vocabColors = getModuleColors('vocabulary');
+  const contents = useLibraryStore((state) => state.contents);
+  const { loadImportedState, importWordbook, removeWordbook, isImported } = useWordbookStore();
 
   const book = id ? getWordBook(id) : undefined;
+  const bookName = book?.nameEn ?? '';
   const [items, setItems] = useState<WordItem[]>([]);
   const [loading, setLoading] = useState(true);
+  const [actionLoading, setActionLoading] = useState(false);
+  const [search, setSearch] = useState('');
+
+  const imported = id ? isImported(id) : false;
+  const relatedBooks = useMemo(() => (book ? getRelatedBooks(book) : []), [book]);
+  const filteredItems = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    if (!query) return items;
+    return items.filter((item) => item.title.toLowerCase().includes(query) || item.text.toLowerCase().includes(query));
+  }, [items, search]);
+
+  const ensurePracticeContent = async () => {
+    if (!id) return null;
+    const existing = useLibraryStore.getState().contents.find((item) => item.category === id);
+    if (existing) return existing;
+    setActionLoading(true);
+    try {
+      await importWordbook(id);
+      return useLibraryStore.getState().contents.find((item) => item.category === id) ?? null;
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const openPractice = async (mode: 'listen' | 'speak' | 'read' | 'write') => {
+    const content = await ensurePracticeContent();
+    if (!content) return;
+    if (mode === 'speak') {
+      router.push({
+        pathname: '/practice/speak/conversation',
+        params: { contentId: content.id, topic: bookName },
+      });
+      return;
+    }
+    router.push(`/practice/${mode}/${content.id}`);
+  };
+
+  useEffect(() => {
+    void loadImportedState();
+  }, [loadImportedState]);
 
   useEffect(() => {
     if (id) {
@@ -56,9 +115,70 @@ export default function WordbookDetailScreen() {
           </Text>
           <View style={styles.headerMeta}>
             <Chip style={styles.headerChip} textStyle={[styles.headerChipText, { color: colors.onPrimary }]}>
+              {book.filterTag}
+            </Chip>
+            <Chip style={styles.headerChip} textStyle={[styles.headerChipText, { color: colors.onPrimary }]}>
               {book.difficulty}
             </Chip>
-            <Text style={[styles.headerCount, { color: colors.onPrimary }]}>{items.length} words</Text>
+            <Text style={[styles.headerCount, { color: colors.onPrimary }]}>{getWordBookItemCount(book)} items</Text>
+          </View>
+          <View style={styles.headerActionRow}>
+            <Button
+              compact
+              mode={imported ? 'outlined' : 'contained-tonal'}
+              onPress={() => {
+                if (!id || actionLoading) return;
+                setActionLoading(true);
+                const task = imported ? removeWordbook(id) : importWordbook(id);
+                void task.finally(() => setActionLoading(false));
+              }}
+              buttonColor={imported ? undefined : 'rgba(255,255,255,0.16)'}
+              textColor={colors.onPrimary}
+              style={[styles.headerButton, imported && { borderColor: 'rgba(255,255,255,0.35)' }]}
+            >
+              {actionLoading ? 'Working…' : imported ? 'Remove from Library' : 'Add to Library'}
+            </Button>
+            <Button compact mode="text" textColor={colors.onPrimary} onPress={() => router.push('/(tabs)/library')}>
+              View Library
+            </Button>
+          </View>
+          <View style={styles.practiceActions}>
+            <Button
+              compact
+              mode="contained-tonal"
+              disabled={actionLoading}
+              onPress={() => void openPractice('listen')}
+              style={styles.practiceButton}
+            >
+              Listen
+            </Button>
+            <Button
+              compact
+              mode="contained-tonal"
+              disabled={actionLoading}
+              onPress={() => void openPractice('speak')}
+              style={styles.practiceButton}
+            >
+              Speak
+            </Button>
+            <Button
+              compact
+              mode="contained-tonal"
+              disabled={actionLoading}
+              onPress={() => void openPractice('read')}
+              style={styles.practiceButton}
+            >
+              Read
+            </Button>
+            <Button
+              compact
+              mode="contained-tonal"
+              disabled={actionLoading}
+              onPress={() => void openPractice('write')}
+              style={styles.practiceButton}
+            >
+              Write
+            </Button>
           </View>
         </View>
       </LinearGradient>
@@ -71,8 +191,54 @@ export default function WordbookDetailScreen() {
         </View>
       ) : (
         <FlatList
-          data={items}
+          data={filteredItems}
           keyExtractor={(item, index) => `${item.title}-${index}`}
+          ListHeaderComponent={
+            <View style={styles.listHeader}>
+              <Searchbar
+                placeholder="Search words or phrases"
+                value={search}
+                onChangeText={setSearch}
+                style={[styles.searchbar, { backgroundColor: colors.surface }]}
+                inputStyle={{ color: colors.onSurface }}
+                iconColor={colors.onSurfaceSecondary}
+                placeholderTextColor={colors.onSurfaceSecondary}
+              />
+              <Text variant="bodySmall" style={{ color: colors.onSurfaceSecondary }}>
+                {filteredItems.length === items.length
+                  ? `${items.length} total items`
+                  : `${filteredItems.length} of ${items.length} items`}
+              </Text>
+              {relatedBooks.length > 0 ? (
+                <View style={styles.relatedSection}>
+                  <Text style={[styles.relatedTitle, { color: colors.onSurface }]}>Related wordbooks</Text>
+                  <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+                    {relatedBooks.map((related) => (
+                      <Pressable
+                        key={related.id}
+                        onPress={() => router.push(`/wordbook/${related.id}`)}
+                        style={({ pressed }) => [
+                          styles.relatedCard,
+                          { backgroundColor: colors.surface },
+                          pressed && { opacity: 0.72 },
+                        ]}
+                      >
+                        <Text style={styles.relatedEmoji}>{related.emoji}</Text>
+                        <View style={styles.relatedCopy}>
+                          <Text style={[styles.relatedName, { color: colors.onSurface }]} numberOfLines={1}>
+                            {related.nameEn}
+                          </Text>
+                          <Text style={[styles.relatedMeta, { color: colors.onSurfaceSecondary }]} numberOfLines={1}>
+                            {related.filterTag} · {getWordBookItemCount(related)} items
+                          </Text>
+                        </View>
+                      </Pressable>
+                    ))}
+                  </ScrollView>
+                </View>
+              ) : null}
+            </View>
+          }
           renderItem={({ item }) => (
             <Pressable
               style={({ pressed }) => [
@@ -88,17 +254,25 @@ export default function WordbookDetailScreen() {
                 <Text style={[styles.wordTitle, { color: colors.onSurface, fontFamily: fontFamily.heading }]}>
                   {item.title}
                 </Text>
-                {item.text !== item.title && (
+                {item.text !== item.title ? (
                   <Text style={[styles.wordExample, { color: colors.onSurfaceSecondary }]} numberOfLines={2}>
                     {item.text}
                   </Text>
-                )}
+                ) : null}
               </View>
               <MaterialCommunityIcons name="volume-high" size={20} color={vocabColors.primary} />
             </Pressable>
           )}
           contentContainerStyle={styles.list}
           showsVerticalScrollIndicator={false}
+          ListEmptyComponent={
+            <View style={styles.emptyState}>
+              <Text style={[styles.emptyTitle, { color: colors.onSurface }]}>No entries match your search</Text>
+              <Text style={[styles.emptyText, { color: colors.onSurfaceSecondary }]}>
+                Try a different keyword or clear the search field.
+              </Text>
+            </View>
+          }
         />
       )}
     </View>
@@ -149,6 +323,25 @@ const styles = StyleSheet.create({
     fontSize: 14,
     opacity: 0.92,
   },
+  headerActionRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    marginTop: 14,
+  },
+  headerButton: {
+    borderColor: 'rgba(255,255,255,0.2)',
+  },
+  practiceActions: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+    gap: 8,
+    marginTop: 14,
+  },
+  practiceButton: {
+    minWidth: 88,
+  },
   loadingContainer: {
     flex: 1,
     justifyContent: 'center',
@@ -157,6 +350,12 @@ const styles = StyleSheet.create({
   list: {
     padding: 16,
     paddingBottom: 40,
+  },
+  listHeader: {
+    marginBottom: 14,
+  },
+  searchbar: {
+    marginBottom: 10,
   },
   wordCard: {
     flexDirection: 'row',
@@ -177,5 +376,50 @@ const styles = StyleSheet.create({
     fontSize: 13,
     marginTop: 4,
     lineHeight: 18,
+  },
+  relatedSection: {
+    marginTop: 16,
+  },
+  relatedTitle: {
+    fontSize: 16,
+    fontWeight: '700',
+    marginBottom: 10,
+  },
+  relatedCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    width: 220,
+    padding: 12,
+    borderRadius: 14,
+    marginRight: 10,
+    borderCurve: 'continuous',
+  },
+  relatedEmoji: {
+    fontSize: 28,
+    marginRight: 10,
+  },
+  relatedCopy: {
+    flex: 1,
+  },
+  relatedName: {
+    fontSize: 14,
+    fontWeight: '700',
+  },
+  relatedMeta: {
+    fontSize: 12,
+    marginTop: 2,
+  },
+  emptyState: {
+    alignItems: 'center',
+    paddingVertical: 36,
+  },
+  emptyTitle: {
+    fontSize: 16,
+    fontWeight: '700',
+  },
+  emptyText: {
+    fontSize: 13,
+    marginTop: 6,
+    textAlign: 'center',
   },
 });

--- a/mobile/app/wordbooks/index.tsx
+++ b/mobile/app/wordbooks/index.tsx
@@ -1,31 +1,83 @@
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { LinearGradient } from 'expo-linear-gradient';
 import { type Href, router } from 'expo-router';
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { FlatList, Pressable, ScrollView, StyleSheet, View } from 'react-native';
-import { Chip, Text } from 'react-native-paper';
+import { Button, Chip, Text } from 'react-native-paper';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { WordbookCard } from '@/components/library/WordbookCard';
 import { useAppTheme } from '@/contexts/ThemeContext';
 import { ALL_WORDBOOKS } from '@/lib/wordbooks';
+import { useWordbookStore } from '@/stores/useWordbookStore';
 import { fontFamily } from '@/theme/typography';
 
-type DifficultyFilter = '' | 'beginner' | 'intermediate' | 'advanced';
-type KindFilter = '' | 'vocabulary' | 'scenario';
+type Tab = 'vocabulary' | 'scenarios';
+
+const VOCAB_FILTERS = [
+  'All',
+  'School',
+  'Textbook',
+  'College',
+  'Graduate',
+  'Domestic Exam',
+  'Study Abroad',
+  'Cambridge',
+  'Core Vocabulary',
+  'Professional',
+  'Tech',
+  'General',
+  'Academic',
+] as const;
+
+const SCENARIO_FILTERS = [
+  'All',
+  'Travel',
+  'Food & Drink',
+  'Daily Life',
+  'Business',
+  'Health',
+  'Social',
+  'Emergency',
+] as const;
 
 export default function WordbooksScreen() {
   const { colors, getModuleColors } = useAppTheme();
   const vocabColors = getModuleColors('vocabulary');
   const insets = useSafeAreaInsets();
+  const { importedIds, loadImportedState, importWordbook, removeWordbook, isImported } = useWordbookStore();
+  const [activeTab, setActiveTab] = useState<Tab>('vocabulary');
+  const [vocabFilter, setVocabFilter] = useState<(typeof VOCAB_FILTERS)[number]>('All');
+  const [scenarioFilter, setScenarioFilter] = useState<(typeof SCENARIO_FILTERS)[number]>('All');
+  const [actionBookId, setActionBookId] = useState<string | null>(null);
 
-  const [difficultyFilter, setDifficultyFilter] = useState<DifficultyFilter>('');
-  const [kindFilter, setKindFilter] = useState<KindFilter>('');
+  useEffect(() => {
+    void loadImportedState();
+  }, [loadImportedState]);
 
-  const filteredBooks = ALL_WORDBOOKS.filter((book) => {
-    if (difficultyFilter && book.difficulty !== difficultyFilter) return false;
-    if (kindFilter && book.kind !== kindFilter) return false;
-    return true;
-  });
+  const allVocabulary = useMemo(() => ALL_WORDBOOKS.filter((book) => book.kind === 'vocabulary'), []);
+  const allScenarios = useMemo(() => ALL_WORDBOOKS.filter((book) => book.kind === 'scenario'), []);
+
+  const displayedBooks = useMemo(() => {
+    if (activeTab === 'vocabulary') {
+      return vocabFilter === 'All' ? allVocabulary : allVocabulary.filter((book) => book.filterTag === vocabFilter);
+    }
+    return scenarioFilter === 'All' ? allScenarios : allScenarios.filter((book) => book.filterTag === scenarioFilter);
+  }, [activeTab, allScenarios, allVocabulary, scenarioFilter, vocabFilter]);
+
+  const activeFilter = activeTab === 'vocabulary' ? vocabFilter : scenarioFilter;
+
+  const handleAction = async (bookId: string) => {
+    setActionBookId(bookId);
+    try {
+      if (isImported(bookId)) {
+        await removeWordbook(bookId);
+      } else {
+        await importWordbook(bookId);
+      }
+    } finally {
+      setActionBookId(null);
+    }
+  };
 
   return (
     <View style={[styles.container, { backgroundColor: colors.background }]}>
@@ -39,49 +91,137 @@ export default function WordbooksScreen() {
               Wordbooks
             </Text>
             <Text style={[styles.headerSubtitle, { color: colors.onPrimary }]}>
-              {ALL_WORDBOOKS.length} books available
+              {ALL_WORDBOOKS.length} books available · {importedIds.size} imported
             </Text>
           </View>
         </View>
+        <View style={styles.headerActions}>
+          <Button
+            compact
+            mode="contained-tonal"
+            buttonColor="rgba(255,255,255,0.16)"
+            textColor={colors.onPrimary}
+            onPress={() => router.push('/(tabs)/library' as Href)}
+          >
+            View Library
+          </Button>
+        </View>
       </LinearGradient>
+
+      <View style={styles.tabsRow}>
+        <Pressable
+          onPress={() => setActiveTab('vocabulary')}
+          style={[
+            styles.tabPill,
+            { backgroundColor: activeTab === 'vocabulary' ? colors.surface : colors.surfaceVariant },
+          ]}
+        >
+          <MaterialCommunityIcons
+            name="book-open-page-variant"
+            size={18}
+            color={activeTab === 'vocabulary' ? vocabColors.primary : colors.onSurfaceSecondary}
+          />
+          <Text
+            style={[
+              styles.tabLabel,
+              { color: activeTab === 'vocabulary' ? colors.onSurface : colors.onSurfaceSecondary },
+            ]}
+          >
+            Vocabulary
+          </Text>
+          <Text
+            style={[
+              styles.tabCount,
+              { color: activeTab === 'vocabulary' ? vocabColors.primary : colors.onSurfaceSecondary },
+            ]}
+          >
+            {allVocabulary.length}
+          </Text>
+        </Pressable>
+        <Pressable
+          onPress={() => setActiveTab('scenarios')}
+          style={[
+            styles.tabPill,
+            { backgroundColor: activeTab === 'scenarios' ? colors.surface : colors.surfaceVariant },
+          ]}
+        >
+          <MaterialCommunityIcons
+            name="layers-outline"
+            size={18}
+            color={activeTab === 'scenarios' ? vocabColors.primary : colors.onSurfaceSecondary}
+          />
+          <Text
+            style={[
+              styles.tabLabel,
+              { color: activeTab === 'scenarios' ? colors.onSurface : colors.onSurfaceSecondary },
+            ]}
+          >
+            Scenarios
+          </Text>
+          <Text
+            style={[
+              styles.tabCount,
+              { color: activeTab === 'scenarios' ? vocabColors.primary : colors.onSurfaceSecondary },
+            ]}
+          >
+            {allScenarios.length}
+          </Text>
+        </Pressable>
+      </View>
 
       <View style={styles.filters}>
         <ScrollView horizontal showsHorizontalScrollIndicator={false}>
-          {(['', 'vocabulary', 'scenario'] as KindFilter[]).map((kind) => (
+          {(activeTab === 'vocabulary' ? VOCAB_FILTERS : SCENARIO_FILTERS).map((filter) => (
             <Chip
-              key={kind || 'all-kind'}
-              mode={kindFilter === kind ? 'flat' : 'outlined'}
-              selected={kindFilter === kind}
-              onPress={() => setKindFilter(kind)}
-              style={[styles.chip, kindFilter === kind && { backgroundColor: vocabColors.primary }]}
-              textStyle={kindFilter === kind ? { color: colors.onPrimary } : { color: colors.onSurface }}
+              key={filter}
+              mode={activeFilter === filter ? 'flat' : 'outlined'}
+              selected={activeFilter === filter}
+              onPress={() =>
+                activeTab === 'vocabulary'
+                  ? setVocabFilter(filter as (typeof VOCAB_FILTERS)[number])
+                  : setScenarioFilter(filter as (typeof SCENARIO_FILTERS)[number])
+              }
+              style={[styles.chip, activeFilter === filter && { backgroundColor: vocabColors.primary }]}
+              textStyle={activeFilter === filter ? { color: colors.onPrimary } : { color: colors.onSurface }}
             >
-              {kind ? kind.charAt(0).toUpperCase() + kind.slice(1) : 'All Types'}
-            </Chip>
-          ))}
-          {(['', 'beginner', 'intermediate', 'advanced'] as DifficultyFilter[]).map((diff) => (
-            <Chip
-              key={diff || 'all-diff'}
-              mode={difficultyFilter === diff ? 'flat' : 'outlined'}
-              selected={difficultyFilter === diff}
-              onPress={() => setDifficultyFilter(diff)}
-              style={[styles.chip, difficultyFilter === diff && { backgroundColor: vocabColors.primary }]}
-              textStyle={difficultyFilter === diff ? { color: colors.onPrimary } : { color: colors.onSurface }}
-            >
-              {diff ? diff.charAt(0).toUpperCase() + diff.slice(1) : 'All Levels'}
+              {filter}
             </Chip>
           ))}
         </ScrollView>
       </View>
 
+      <View style={styles.countRow}>
+        <Text style={[styles.countLabel, { color: colors.onSurfaceSecondary }]}>
+          {displayedBooks.length} {displayedBooks.length === 1 ? 'book' : 'books'} in “{activeFilter}”
+        </Text>
+      </View>
+
       <FlatList
-        data={filteredBooks}
+        data={displayedBooks}
         keyExtractor={(item) => item.id}
         renderItem={({ item }) => (
-          <WordbookCard book={item} onPress={() => router.push(`/wordbook/${item.id}` as Href)} />
+          <WordbookCard
+            book={item}
+            imported={isImported(item.id)}
+            secondaryLabel={item.filterTag}
+            actionLabel={isImported(item.id) ? 'Remove' : 'Add to Library'}
+            actionTone={isImported(item.id) ? 'danger' : 'primary'}
+            actionLoading={actionBookId === item.id}
+            onActionPress={() => void handleAction(item.id)}
+            onPress={() => router.push(`/wordbook/${item.id}` as Href)}
+          />
         )}
         contentContainerStyle={styles.list}
         showsVerticalScrollIndicator={false}
+        ListEmptyComponent={
+          <View style={[styles.emptyState, { backgroundColor: colors.surface }]}>
+            <MaterialCommunityIcons name="book-search-outline" size={28} color={colors.onSurfaceSecondary} />
+            <Text style={[styles.emptyTitle, { color: colors.onSurface }]}>No wordbooks match this filter</Text>
+            <Text style={[styles.emptyText, { color: colors.onSurfaceSecondary }]}>
+              Try another category or switch between Vocabulary and Scenarios.
+            </Text>
+          </View>
+        }
       />
     </View>
   );
@@ -120,11 +260,64 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingVertical: 12,
   },
+  headerActions: {
+    marginTop: 14,
+    alignItems: 'flex-start',
+  },
+  tabsRow: {
+    flexDirection: 'row',
+    gap: 10,
+    paddingHorizontal: 16,
+    paddingTop: 14,
+  },
+  tabPill: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 6,
+    paddingVertical: 12,
+    borderRadius: 14,
+    borderCurve: 'continuous',
+  },
+  tabLabel: {
+    fontSize: 14,
+    fontWeight: '700',
+  },
+  tabCount: {
+    fontSize: 12,
+    fontWeight: '700',
+  },
   chip: {
     marginRight: 8,
+  },
+  countRow: {
+    paddingHorizontal: 16,
+    paddingBottom: 10,
+  },
+  countLabel: {
+    fontSize: 12,
   },
   list: {
     paddingHorizontal: 16,
     paddingBottom: 40,
+  },
+  emptyState: {
+    alignItems: 'center',
+    borderRadius: 16,
+    paddingVertical: 28,
+    paddingHorizontal: 20,
+    marginTop: 8,
+  },
+  emptyTitle: {
+    fontSize: 16,
+    fontWeight: '700',
+    marginTop: 10,
+  },
+  emptyText: {
+    fontSize: 13,
+    lineHeight: 18,
+    marginTop: 6,
+    textAlign: 'center',
   },
 });

--- a/mobile/src/components/library/ContentCard.tsx
+++ b/mobile/src/components/library/ContentCard.tsx
@@ -18,6 +18,7 @@ interface ContentCardProps {
   onToggleStarred: () => void;
   onEdit?: (contentId: string) => void;
   onDelete?: (contentId: string) => void;
+  onUpdateTags?: (contentId: string, tags: string[]) => void;
   selectable?: boolean;
   selected?: boolean;
   onToggleSelect?: (contentId: string) => void;
@@ -68,6 +69,7 @@ export function ContentCard({
   onPress,
   onToggleStarred,
   onDelete,
+  onUpdateTags,
   selectable,
   selected,
   onToggleSelect,
@@ -132,8 +134,11 @@ export function ContentCard({
   };
 
   const handleSaveTags = () => {
-    // This would need to be passed from parent
-    // For now, just close the editor
+    const nextTags = tagInput
+      .split(',')
+      .map((tag) => tag.trim())
+      .filter(Boolean);
+    onUpdateTags?.(content.id, Array.from(new Set(nextTags)));
     setEditingTags(false);
   };
 

--- a/mobile/src/components/library/WordbookCard.tsx
+++ b/mobile/src/components/library/WordbookCard.tsx
@@ -9,9 +9,24 @@ import { getWordBookItemCount } from '@/types/wordbook';
 interface WordbookCardProps {
   book: WordBook;
   onPress: () => void;
+  imported?: boolean;
+  actionLabel?: string;
+  actionLoading?: boolean;
+  onActionPress?: () => void;
+  secondaryLabel?: string;
+  actionTone?: 'primary' | 'danger';
 }
 
-export function WordbookCard({ book, onPress }: WordbookCardProps) {
+export function WordbookCard({
+  book,
+  onPress,
+  imported = false,
+  actionLabel,
+  actionLoading = false,
+  onActionPress,
+  secondaryLabel,
+  actionTone = 'primary',
+}: WordbookCardProps) {
   const { colors } = useAppTheme();
   const difficultyAccent = {
     beginner: colors.success,
@@ -19,6 +34,8 @@ export function WordbookCard({ book, onPress }: WordbookCardProps) {
     advanced: colors.error,
   } as const;
   const count = getWordBookItemCount(book);
+  const actionColor = actionTone === 'danger' ? colors.error : colors.primary;
+  const actionBg = actionTone === 'danger' ? `${colors.error}12` : `${colors.primary}12`;
 
   return (
     <Pressable
@@ -34,18 +51,41 @@ export function WordbookCard({ book, onPress }: WordbookCardProps) {
     >
       <Text style={styles.emoji}>{book.emoji}</Text>
       <View style={styles.info}>
-        <Text style={[styles.name, { color: colors.onSurface, fontFamily: fontFamily.heading }]} numberOfLines={1}>
-          {book.name}
-        </Text>
-        <Text style={[styles.nameEn, { color: colors.onSurfaceSecondary }]} numberOfLines={1}>
-          {book.nameEn}
-        </Text>
+        <View style={styles.titleRow}>
+          <View style={styles.titleCopy}>
+            <Text style={[styles.name, { color: colors.onSurface, fontFamily: fontFamily.heading }]} numberOfLines={1}>
+              {book.nameEn}
+            </Text>
+            <Text style={[styles.nameEn, { color: colors.onSurfaceSecondary }]} numberOfLines={1}>
+              {secondaryLabel ?? book.filterTag}
+            </Text>
+          </View>
+          {imported ? <View style={[styles.importedDot, { backgroundColor: colors.primary }]} /> : null}
+        </View>
         <View style={styles.meta}>
           <View style={[styles.difficultyBadge, { backgroundColor: `${difficultyAccent[book.difficulty]}20` }]}>
             <Text style={[styles.difficultyText, { color: difficultyAccent[book.difficulty] }]}>{book.difficulty}</Text>
           </View>
           <Text style={[styles.count, { color: colors.onSurfaceSecondary }]}>{count} words</Text>
         </View>
+        {actionLabel && onActionPress ? (
+          <Pressable
+            hitSlop={8}
+            onPress={(event) => {
+              event.stopPropagation();
+              if (actionLoading) return;
+              void haptics.light();
+              onActionPress();
+            }}
+            style={({ pressed }) => [
+              styles.actionButton,
+              { backgroundColor: actionBg },
+              pressed && !actionLoading && { opacity: 0.72 },
+            ]}
+          >
+            <Text style={[styles.actionText, { color: actionColor }]}>{actionLoading ? 'Working…' : actionLabel}</Text>
+          </Pressable>
+        ) : null}
       </View>
     </Pressable>
   );
@@ -66,6 +106,19 @@ const styles = StyleSheet.create({
   },
   info: {
     flex: 1,
+  },
+  titleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  titleCopy: {
+    flex: 1,
+  },
+  importedDot: {
+    width: 10,
+    height: 10,
+    borderRadius: 999,
   },
   name: {
     fontSize: 16,
@@ -93,5 +146,16 @@ const styles = StyleSheet.create({
   },
   count: {
     fontSize: 12,
+  },
+  actionButton: {
+    alignSelf: 'flex-start',
+    marginTop: 10,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 999,
+  },
+  actionText: {
+    fontSize: 12,
+    fontWeight: '700',
   },
 });

--- a/mobile/src/stores/useWordbookStore.ts
+++ b/mobile/src/stores/useWordbookStore.ts
@@ -1,0 +1,91 @@
+import { nanoid } from 'nanoid/non-secure';
+import { create } from 'zustand';
+import { getWordBook, loadWordBookItems } from '@/lib/wordbooks';
+import { useLibraryStore } from '@/stores/useLibraryStore';
+import type { Content } from '@/types/content';
+
+interface WordbookState {
+  importedIds: Set<string>;
+  loading: boolean;
+  loadImportedState: () => Promise<void>;
+  importWordbook: (wordbookId: string) => Promise<void>;
+  removeWordbook: (wordbookId: string) => Promise<void>;
+  isImported: (wordbookId: string) => boolean;
+}
+
+function collectImportedIds(contents: Content[]): Set<string> {
+  const ids = new Set<string>();
+  for (const item of contents) {
+    if (item.category) ids.add(item.category);
+  }
+  return ids;
+}
+
+export const useWordbookStore = create<WordbookState>((set, get) => ({
+  importedIds: new Set(),
+  loading: false,
+
+  loadImportedState: async () => {
+    const contents = useLibraryStore.getState().contents;
+    set({ importedIds: collectImportedIds(contents), loading: false });
+  },
+
+  importWordbook: async (wordbookId: string) => {
+    if (get().isImported(wordbookId)) return;
+
+    const book = getWordBook(wordbookId);
+    if (!book) return;
+
+    set({ loading: true });
+
+    const now = Date.now();
+    const wordItems = await loadWordBookItems(wordbookId);
+    const nextItems: Content[] = wordItems.map((item) => ({
+      id: nanoid(),
+      title: item.title,
+      type: item.type as Content['type'],
+      content: item.text,
+      text: item.text,
+      language: 'en',
+      difficulty: item.difficulty as Content['difficulty'],
+      tags: item.tags,
+      source: item.source,
+      category: wordbookId,
+      createdAt: now,
+      updatedAt: now,
+      isStarred: false,
+      progress: 0,
+      wordCount: item.text.trim().split(/\s+/).length,
+      metadata: {
+        wordbookId,
+        wordbookName: book.nameEn,
+        wordbookKind: book.kind,
+      },
+    }));
+
+    useLibraryStore.setState((state) => ({
+      contents: [...nextItems, ...state.contents],
+    }));
+
+    set((state) => ({
+      importedIds: new Set([...state.importedIds, wordbookId]),
+      loading: false,
+    }));
+  },
+
+  removeWordbook: async (wordbookId: string) => {
+    set({ loading: true });
+
+    useLibraryStore.setState((state) => ({
+      contents: state.contents.filter((item) => item.category !== wordbookId),
+    }));
+
+    set((state) => {
+      const next = new Set(state.importedIds);
+      next.delete(wordbookId);
+      return { importedIds: next, loading: false };
+    });
+  },
+
+  isImported: (wordbookId: string) => get().importedIds.has(wordbookId),
+}));


### PR DESCRIPTION
## Summary
- align mobile More destination pages more closely with web information hierarchy and interactions
- remove mobile-only inventions in settings, favorites, and AI Tutor so the pages track web more strictly
- improve wordbooks, library, analytics, and review flows needed for parity

## Verification
- pnpm --dir mobile type-check
- pnpm --dir mobile test -- --runInBand
- simulator smoke validation for Analytics, Library, Favorites, Wordbooks, Wordbook detail, AI Tutor, Review, and Settings