### PR TITLE
Fix stale speak wordbook state between prompts

### DIFF
--- a/e2e/wordbook-practice.spec.ts
+++ b/e2e/wordbook-practice.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 
 /**
  * E2E tests for WordBook practice routes:
@@ -21,6 +21,71 @@ async function mockTranslationApi(page: import('@playwright/test').Page) {
       contentType: 'application/json',
       body: JSON.stringify({ translation: MOCK_TRANSLATION }),
     });
+  });
+}
+
+async function installSpeechRecognitionMock(page: Page) {
+  await page.addInitScript(() => {
+    class FakeSpeechRecognition {
+      static activeInstance: FakeSpeechRecognition | null = null;
+      continuous = true;
+      interimResults = true;
+      lang = 'en-US';
+      onresult: ((event: SpeechRecognitionEvent) => void) | null = null;
+      onerror: ((event: SpeechRecognitionErrorEvent) => void) | null = null;
+      onend: (() => void) | null = null;
+
+      start() {
+        FakeSpeechRecognition.activeInstance = this;
+      }
+
+      stop() {
+        this.onend?.();
+      }
+
+      abort() {
+        this.onend?.();
+      }
+
+      static emit(text: string) {
+        const instance = FakeSpeechRecognition.activeInstance;
+        if (!instance?.onresult) return;
+
+        const result = {
+          0: { transcript: text, confidence: 1 },
+          isFinal: true,
+          length: 1,
+          item(index: number) {
+            return this[index as 0];
+          },
+        };
+
+        const results = {
+          0: result,
+          length: 1,
+          item(index: number) {
+            return this[index as 0];
+          },
+        };
+
+        instance.onresult({
+          resultIndex: 0,
+          results,
+        } as SpeechRecognitionEvent);
+        instance.onend?.();
+      }
+    }
+
+    const speechWindow = window as Window &
+      typeof globalThis & {
+        SpeechRecognition?: typeof FakeSpeechRecognition;
+        webkitSpeechRecognition?: typeof FakeSpeechRecognition;
+        __emitSpeechResult?: (text: string) => void;
+      };
+
+    speechWindow.SpeechRecognition = FakeSpeechRecognition;
+    speechWindow.webkitSpeechRecognition = FakeSpeechRecognition;
+    speechWindow.__emitSpeechResult = (text: string) => FakeSpeechRecognition.emit(text);
   });
 }
 
@@ -308,6 +373,39 @@ test.describe('WordBook Practice – Speak', () => {
     await waitForPracticeCard(page);
 
     await expect(page.getByTestId('wordbook-translation')).toHaveCount(0);
+  });
+
+  test('resets pronunciation feedback when moving to the next item', async ({ page }) => {
+    await installSpeechRecognitionMock(page);
+    await page.goto(`/speak/book/${BOOK_ID}?limit=2`);
+    await waitForPracticeCard(page);
+
+    const emitSpeech = (text: string) =>
+      page.evaluate((spoken) => {
+        (window as Window & { __emitSpeechResult?: (text: string) => void }).__emitSpeechResult?.(spoken);
+      }, text);
+
+    const firstText = (await page.getByTestId('listen-book-sentence').textContent())?.trim();
+    expect(firstText).toBeTruthy();
+
+    await page.getByTestId('wordbook-speech-toggle').click();
+    await emitSpeech(firstText!);
+
+    const panel = page.getByTestId('wordbook-pronunciation-panel');
+    await expect(panel).toContainText('100%');
+
+    await page.getByRole('button', { name: 'Next', exact: true }).click();
+    await expect(page.locator('text=/2 \\/ 2/')).toBeVisible();
+    await expect(panel).toHaveCount(0);
+
+    const secondText = (await page.getByTestId('listen-book-sentence').textContent())?.trim();
+    expect(secondText).toBeTruthy();
+    expect(secondText).not.toBe(firstText);
+
+    await page.getByTestId('wordbook-speech-toggle').click();
+    await emitSpeech(secondText!);
+
+    await expect(page.getByTestId('wordbook-pronunciation-panel')).toContainText('100%');
   });
 });
 

--- a/src/components/shared/word-book-practice.tsx
+++ b/src/components/shared/word-book-practice.tsx
@@ -178,7 +178,7 @@ function ListenPractice({
     window.speechSynthesis.cancel();
     setIsPlaying(false);
     startedAtRef.current = Date.now();
-  }, []);
+  }, [item.id]);
 
   const handlePlay = useCallback(() => {
     if (isPlaying) {
@@ -276,7 +276,7 @@ function WritePractice({
     setResult(null);
     startedAtRef.current = Date.now();
     setTimeout(() => inputRef.current?.focus(), 100);
-  }, []);
+  }, [item.id]);
 
   const handleSubmit = () => {
     const normalized = typedText.trim().toLowerCase();
@@ -431,6 +431,8 @@ function ReadSpeakPractice({
   const lastSavedTranscriptRef = useRef<string>('');
   const intentionalStopRef = useRef(false);
   const autoRestartCountRef = useRef(0);
+  const itemIdRef = useRef(item.id);
+  const activeRecognitionItemIdRef = useRef<string | null>(null);
   const MAX_AUTO_RESTARTS = 3;
 
   const transcript = finalTranscript || interimTranscript;
@@ -439,13 +441,16 @@ function ReadSpeakPractice({
   const fallbackSTT = useFallbackSTT({
     lang: 'en',
     onTranscript: useCallback((text: string) => {
+      if (activeRecognitionItemIdRef.current !== itemIdRef.current) return;
       setFinalTranscript(text);
       setPhase(text ? 'result' : 'idle');
     }, []),
     onInterimTranscript: useCallback((text: string) => {
+      if (activeRecognitionItemIdRef.current !== itemIdRef.current) return;
       setInterimTranscript(text);
     }, []),
     onError: useCallback((error: string) => {
+      if (activeRecognitionItemIdRef.current !== itemIdRef.current) return;
       setSttError(error);
       setPhase('idle');
     }, []),
@@ -453,6 +458,10 @@ function ReadSpeakPractice({
 
   // Reset when item changes
   useEffect(() => {
+    itemIdRef.current = item.id;
+    activeRecognitionItemIdRef.current = null;
+    recognitionRef.current?.abort();
+    fallbackSTT.stopRecording();
     setFinalTranscript('');
     setInterimTranscript('');
     setPhase('idle');
@@ -461,8 +470,7 @@ function ReadSpeakPractice({
     lastSavedTranscriptRef.current = '';
     intentionalStopRef.current = false;
     autoRestartCountRef.current = 0;
-    recognitionRef.current?.abort();
-  }, []);
+  }, [fallbackSTT.stopRecording, item.id]);
 
   // Initialize native speech recognition
   useEffect(() => {
@@ -477,6 +485,7 @@ function ReadSpeakPractice({
     rec.lang = 'en-US';
 
     rec.onresult = (event: SpeechRecognitionEvent) => {
+      if (activeRecognitionItemIdRef.current !== itemIdRef.current) return;
       let final = '';
       let interim = '';
       for (let i = 0; i < event.results.length; i++) {
@@ -492,6 +501,7 @@ function ReadSpeakPractice({
     };
 
     rec.onend = () => {
+      if (activeRecognitionItemIdRef.current !== itemIdRef.current) return;
       // Auto-restart if user didn't intentionally stop and we haven't exceeded retries
       if (!intentionalStopRef.current && autoRestartCountRef.current < MAX_AUTO_RESTARTS) {
         autoRestartCountRef.current += 1;
@@ -509,6 +519,7 @@ function ReadSpeakPractice({
     };
 
     rec.onerror = (event: SpeechRecognitionErrorEvent) => {
+      if (activeRecognitionItemIdRef.current !== itemIdRef.current) return;
       // 'no-speech' and 'aborted' are recoverable — let onend handle restart
       if (event.error === 'no-speech' || event.error === 'aborted') return;
       setPhase('result');
@@ -517,6 +528,7 @@ function ReadSpeakPractice({
     recognitionRef.current = rec;
 
     return () => {
+      activeRecognitionItemIdRef.current = null;
       rec.abort();
     };
   }, []);
@@ -526,6 +538,7 @@ function ReadSpeakPractice({
     setFinalTranscript('');
     setInterimTranscript('');
     startedAtRef.current = Date.now();
+    activeRecognitionItemIdRef.current = item.id;
 
     if (useNative.current && recognitionRef.current) {
       intentionalStopRef.current = false;
@@ -551,7 +564,7 @@ function ReadSpeakPractice({
       void fallbackSTT.startRecording();
       setPhase('listening');
     }
-  }, [fallbackSTT]);
+  }, [fallbackSTT, item.id]);
 
   const stopListening = useCallback(() => {
     if (useNative.current && recognitionRef.current) {
@@ -673,6 +686,7 @@ function ReadSpeakPractice({
             </>
           )}
           <Button
+            data-testid="wordbook-speech-toggle"
             onClick={phase === 'listening' ? stopListening : startListening}
             disabled={phase === 'transcribing'}
             className={cn(
@@ -723,7 +737,7 @@ function ReadSpeakPractice({
 
       {/* Real-time word highlighting (visible during listening AND result) */}
       {wordComparison && (
-        <div className="bg-slate-50 rounded-lg p-3 text-center space-y-2">
+        <div data-testid="wordbook-pronunciation-panel" className="bg-slate-50 rounded-lg p-3 text-center space-y-2">
           <p className="text-xs text-slate-400">
             {phase === 'listening' ? t.speak.hearingYou : t.speak.yourPronunciation}
           </p>
@@ -1124,6 +1138,7 @@ export function WordBookPractice({ module }: WordBookPracticeProps) {
                 {/* Mode-specific practice area */}
                 {module === 'listen' && (
                   <ListenPractice
+                    key={currentItem.id}
                     item={currentItem}
                     persistProgress={persistProgress}
                     onCompleted={handleItemCompleted}
@@ -1131,6 +1146,7 @@ export function WordBookPractice({ module }: WordBookPracticeProps) {
                 )}
                 {module === 'write' && (
                   <WritePractice
+                    key={currentItem.id}
                     item={currentItem}
                     onCorrect={goToNext}
                     persistProgress={persistProgress}
@@ -1139,6 +1155,7 @@ export function WordBookPractice({ module }: WordBookPracticeProps) {
                 )}
                 {(module === 'read' || module === 'speak') && (
                   <ReadSpeakPractice
+                    key={currentItem.id}
                     item={currentItem}
                     module={module}
                     persistProgress={persistProgress}

--- a/src/hooks/use-fallback-stt.ts
+++ b/src/hooks/use-fallback-stt.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useProviderStore } from '@/stores/provider-store';
 
 interface UseFallbackSTTOptions {
@@ -42,6 +42,7 @@ export function useFallbackSTT(options: UseFallbackSTTOptions = {}): UseFallback
   const onTranscriptRef = useRef(onTranscript);
   const onInterimTranscriptRef = useRef(onInterimTranscript);
   const onErrorRef = useRef(onError);
+  const disposedRef = useRef(false);
   onTranscriptRef.current = onTranscript;
   onInterimTranscriptRef.current = onInterimTranscript;
   onErrorRef.current = onError;
@@ -118,15 +119,19 @@ export function useFallbackSTT(options: UseFallbackSTTOptions = {}): UseFallback
         stream.getTracks().forEach((t) => t.stop());
         const blob = new Blob(chunksRef.current, { type: mimeType });
         if (blob.size > 100) {
+          if (disposedRef.current) return;
           setIsTranscribing(true);
           sendForTranscription(blob)
             .then((text) => {
+              if (disposedRef.current) return;
               onTranscriptRef.current?.(text ?? '');
             })
             .catch(() => {
+              if (disposedRef.current) return;
               onErrorRef.current?.('Failed to connect to speech recognition service.');
             })
             .finally(() => {
+              if (disposedRef.current) return;
               setIsTranscribing(false);
             });
         }
@@ -141,6 +146,7 @@ export function useFallbackSTT(options: UseFallbackSTTOptions = {}): UseFallback
         interimTimerRef.current = setInterval(requestInterimTranscription, interimIntervalMs);
       }
     } catch {
+      if (disposedRef.current) return;
       onErrorRef.current?.('Microphone access denied.');
     }
   }, [sendForTranscription, clearInterimTimer, requestInterimTranscription, interimIntervalMs]);
@@ -150,7 +156,25 @@ export function useFallbackSTT(options: UseFallbackSTTOptions = {}): UseFallback
     if (mediaRecorderRef.current && mediaRecorderRef.current.state !== 'inactive') {
       mediaRecorderRef.current.stop();
     }
+    streamRef.current?.getTracks().forEach((track) => track.stop());
     setIsRecording(false);
+  }, [clearInterimTimer]);
+
+  useEffect(() => {
+    disposedRef.current = false;
+    return () => {
+      disposedRef.current = true;
+      clearInterimTimer();
+      const recorder = mediaRecorderRef.current;
+      if (recorder && recorder.state !== 'inactive') {
+        recorder.onstop = null;
+        recorder.stop();
+      }
+      streamRef.current?.getTracks().forEach((track) => track.stop());
+      mediaRecorderRef.current = null;
+      streamRef.current = null;
+      chunksRef.current = [];
+    };
   }, [clearInterimTimer]);
 
   return {


### PR DESCRIPTION
## Summary
- reset wordbook practice speak/read state whenever the current item changes
- ignore late native and fallback STT callbacks from prior prompts and clean up recorder resources on unmount
- add an end-to-end regression test for advancing to the next speak prompt

## Verification
- pnpm exec tsc --noEmit
- browser-level verification on localhost:3010 for /speak/book/coffee-shop?limit=4, confirming prompt 1 can score 100%, prompt 2 starts with no leftover pronunciation panel, and prompt 2 scores against its own sentence