### PR TITLE
Fix read translation rendering and recommendation fallbacks

### DIFF
--- a/src/app/(app)/read/[id]/page.translation-mapping.test.ts
+++ b/src/app/(app)/read/[id]/page.translation-mapping.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+function mapSentenceTranslations(
+  sentenceTranslations: Array<{ original: string; translation: string }> | null,
+) {
+  if (!sentenceTranslations?.length) return null;
+
+  let startWordIndex = 0;
+
+  return sentenceTranslations.map((sentence) => {
+    const wordCount = sentence.original.split(/\s+/).filter(Boolean).length;
+    const entry = {
+      startWordIndex,
+      endWordIndex: startWordIndex + Math.max(wordCount - 1, 0),
+      translation: sentence.translation,
+    };
+    startWordIndex += wordCount;
+    return entry;
+  });
+}
+
+describe('Read detail translation mapping', () => {
+  it('maps sentence translations into read-aloud word ranges', () => {
+    expect(
+      mapSentenceTranslations([
+        { original: 'Hello world.', translation: '你好，世界。' },
+        { original: 'This is a test.', translation: '这是一个测试。' },
+      ]),
+    ).toEqual([
+      { startWordIndex: 0, endWordIndex: 1, translation: '你好，世界。' },
+      { startWordIndex: 2, endWordIndex: 5, translation: '这是一个测试。' },
+    ]);
+  });
+
+  it('returns null when there are no sentence translations', () => {
+    expect(mapSentenceTranslations(null)).toBeNull();
+  });
+});

--- a/src/app/(app)/read/[id]/page.tsx
+++ b/src/app/(app)/read/[id]/page.tsx
@@ -134,6 +134,23 @@ export default function ReadDetailPage() {
     return grouped;
   }, [content?.text, sentenceTranslations]);
 
+  const readAloudSentenceTranslations = useMemo(() => {
+    if (!sentenceTranslations?.length) return null;
+
+    let startWordIndex = 0;
+
+    return sentenceTranslations.map((sentence) => {
+      const wordCount = sentence.original.split(/\s+/).filter(Boolean).length;
+      const entry = {
+        startWordIndex,
+        endWordIndex: startWordIndex + Math.max(wordCount - 1, 0),
+        translation: sentence.translation,
+      };
+      startWordIndex += wordCount;
+      return entry;
+    });
+  }, [sentenceTranslations]);
+
   const referenceWords = useMemo(
     () =>
       content?.text
@@ -913,7 +930,12 @@ export default function ReadDetailPage() {
           </div>
           <div className="min-h-[18rem] max-h-[24rem] overflow-y-auto pr-2 scrollbar-thin scrollbar-thumb-indigo-200 scrollbar-track-transparent md:min-h-[22rem] md:max-h-[30rem]">
             {raIsActive ? (
-              <ReadAloudContent text={content.text} onWordClick={handleReadAloudWordClick} />
+              <ReadAloudContent
+                text={content.text}
+                onWordClick={handleReadAloudWordClick}
+                showTranslation={showTranslation}
+                sentenceTranslations={readAloudSentenceTranslations}
+              />
             ) : showTranslation && sentenceTranslations && sentenceTranslations.length > 0 ? (
               <div className="space-y-4">
                 {translatedBlocks.map(({ block, translations }) => (

--- a/src/app/api/recommendations/route.test.ts
+++ b/src/app/api/recommendations/route.test.ts
@@ -1,0 +1,143 @@
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { generateTextMock, resolveProviderForCapabilityMock } = vi.hoisted(() => ({
+  generateTextMock: vi.fn(),
+  resolveProviderForCapabilityMock: vi.fn(),
+}));
+
+vi.mock('ai', () => ({
+  generateText: generateTextMock,
+}));
+
+vi.mock('@/lib/ai-model', () => ({
+  resolveApiKey: vi.fn(() => 'test-api-key'),
+  resolveModel: vi.fn(() => ({ mocked: true })),
+}));
+
+vi.mock('@/lib/platform-provider', () => ({
+  enforcePlatformRateLimit: vi.fn(async () => ({ ok: true })),
+}));
+
+vi.mock('@/lib/provider-resolver', () => ({
+  ProviderResolutionError: class ProviderResolutionError extends Error {
+    code = 'provider_resolution_error';
+  },
+  resolveProviderForCapability: resolveProviderForCapabilityMock,
+}));
+
+resolveProviderForCapabilityMock.mockReturnValue({
+  providerId: 'groq',
+  modelId: 'mock-model',
+  credentialSource: 'platform',
+  fallbackApplied: false,
+  fallbackReason: undefined,
+  baseUrl: undefined,
+  apiPath: undefined,
+});
+
+const { POST } = await import('./route');
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest('http://localhost/api/recommendations', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/recommendations', () => {
+  beforeEach(() => {
+    generateTextMock.mockReset();
+  });
+
+  it('returns AI recommendations when the model responds with valid JSON', async () => {
+    generateTextMock.mockResolvedValue({
+      text: JSON.stringify({
+        recommendations: [
+          {
+            title: 'Digital Communication Basics',
+            text: 'Digital communication covers email, chat, and social media.',
+            type: 'sentence',
+            relation: 'related topic',
+          },
+        ],
+      }),
+    });
+
+    const response = await POST(
+      makeRequest({
+        content: 'Digital communication is part of daily life.',
+        contentType: 'article',
+        count: 1,
+        provider: 'groq',
+        providerConfigs: {},
+        userLevel: 'B1',
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      recommendations: [
+        {
+          title: 'Digital Communication Basics',
+          text: 'Digital communication covers email, chat, and social media.',
+          type: 'sentence',
+          relation: 'related topic',
+        },
+      ],
+      providerId: 'groq',
+      credentialSource: 'platform',
+    });
+  });
+
+  it('falls back to local recommendations when AI output is not parseable', async () => {
+    generateTextMock.mockResolvedValue({
+      text: 'not json at all',
+    });
+
+    const response = await POST(
+      makeRequest({
+        content:
+          'Digital communication is part of daily life. We use email, chat, and social media to share ideas.',
+        contentType: 'article',
+        count: 3,
+        provider: 'groq',
+        providerConfigs: {},
+        userLevel: 'B1',
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.localFallbackApplied).toBe(true);
+    expect(data.recommendations).toHaveLength(3);
+    expect(data.recommendations[0]).toMatchObject({
+      title: expect.any(String),
+      text: expect.any(String),
+      relation: expect.any(String),
+    });
+  });
+
+  it('retries transient failures and then falls back locally', async () => {
+    generateTextMock.mockRejectedValue(new Error('Connection timeout to upstream provider'));
+
+    const response = await POST(
+      makeRequest({
+        content: 'Practice the word resilient in a real-life sentence.',
+        contentType: 'word',
+        count: 2,
+        provider: 'groq',
+        providerConfigs: {},
+        userLevel: 'B1',
+      }),
+    );
+
+    expect(generateTextMock).toHaveBeenCalledTimes(2);
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.localFallbackApplied).toBe(true);
+    expect(data.localFallbackReason).toContain('timeout');
+    expect(data.recommendations).toHaveLength(2);
+  });
+});

--- a/src/app/api/recommendations/route.ts
+++ b/src/app/api/recommendations/route.ts
@@ -5,6 +5,188 @@ import { parseAIJson } from '@/lib/parse-ai-json';
 import { enforcePlatformRateLimit } from '@/lib/platform-provider';
 import { ProviderResolutionError, resolveProviderForCapability } from '@/lib/provider-resolver';
 import { type ProviderConfig, type ProviderId } from '@/lib/providers';
+import { splitSentences } from '@/lib/sentence-split';
+
+const RECOMMENDATION_RETRY_ATTEMPTS = 2;
+const RETRY_BASE_DELAY_MS = 350;
+
+const STOP_WORDS = new Set([
+  'about',
+  'after',
+  'also',
+  'and',
+  'been',
+  'both',
+  'from',
+  'have',
+  'into',
+  'more',
+  'that',
+  'than',
+  'their',
+  'them',
+  'they',
+  'this',
+  'through',
+  'your',
+  'with',
+  'would',
+  'could',
+  'should',
+  'while',
+  'where',
+  'when',
+  'which',
+  'what',
+  'will',
+  'just',
+  'very',
+  'each',
+  'into',
+  'over',
+  'under',
+  'part',
+  'become',
+  'becomes',
+  'becoming',
+]);
+
+interface RecommendationItem {
+  title: string;
+  text: string;
+  type: 'word' | 'phrase' | 'sentence' | 'article';
+  relation: string;
+}
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isTransientRecommendationError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
+  return [
+    'timeout',
+    'timed out',
+    'network',
+    'fetch failed',
+    'temporar',
+    'temporarily',
+    'overloaded',
+    'unavailable',
+    'rate limit',
+    'ssl',
+    'socket',
+    'connection',
+    'service unavailable',
+    'internal server error',
+  ].some((token) => message.includes(token));
+}
+
+function extractKeywords(content: string, limit: number): string[] {
+  const counts = new Map<string, number>();
+  const words = content.toLowerCase().match(/[a-z][a-z'-]+/g) ?? [];
+
+  for (const word of words) {
+    if (word.length < 4 || STOP_WORDS.has(word)) continue;
+    counts.set(word, (counts.get(word) ?? 0) + 1);
+  }
+
+  return [...counts.entries()]
+    .sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0]))
+    .slice(0, limit)
+    .map(([word]) => word);
+}
+
+function truncateTitle(text: string, maxWords = 5): string {
+  return text
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, maxWords)
+    .join(' ')
+    .replace(/[^\w\s'-]+$/g, '');
+}
+
+function createWordFallbackRecommendations(content: string, count: number): RecommendationItem[] {
+  const word = content.trim().split(/\s+/)[0] || 'word';
+  const templates: RecommendationItem[] = [
+    {
+      title: `${word} in context`,
+      text: `Practice "${word}" in a short sentence about your daily routine.`,
+      type: 'word',
+      relation: 'usage practice',
+    },
+    {
+      title: `${word} collocation`,
+      text: `Write a natural collocation with "${word}" and explain when you would use it.`,
+      type: 'phrase',
+      relation: 'collocation',
+    },
+    {
+      title: `${word} contrast`,
+      text: `Compare "${word}" with a nearby word that learners often confuse it with.`,
+      type: 'sentence',
+      relation: 'contrast practice',
+    },
+    {
+      title: `${word} memory cue`,
+      text: `Create a vivid example that helps you remember "${word}" in real communication.`,
+      type: 'sentence',
+      relation: 'memory cue',
+    },
+    {
+      title: `${word} review`,
+      text: `Use "${word}" in one formal and one casual example sentence.`,
+      type: 'sentence',
+      relation: 'register practice',
+    },
+  ];
+
+  return templates.slice(0, Math.max(1, count));
+}
+
+function buildLocalRecommendations(content: string, contentType: string, count: number): RecommendationItem[] {
+  if (contentType === 'word') {
+    return createWordFallbackRecommendations(content, count);
+  }
+
+  const normalized = content.replace(/\s+/g, ' ').trim();
+  const sentences = splitSentences(normalized);
+  const keywords = extractKeywords(normalized, count + 2);
+  const recommendations: RecommendationItem[] = [];
+
+  for (const sentence of sentences) {
+    if (recommendations.length >= count) break;
+    recommendations.push({
+      title: truncateTitle(sentence) || 'Practice sentence',
+      text: sentence,
+      type: contentType === 'article' ? 'sentence' : (contentType as RecommendationItem['type']),
+      relation: recommendations.length === 0 ? 'key idea' : 'related topic',
+    });
+  }
+
+  for (const keyword of keywords) {
+    if (recommendations.length >= count) break;
+    recommendations.push({
+      title: `${keyword} focus`,
+      text: `Describe how "${keyword}" appears in this topic and use it in your own example.`,
+      type: 'phrase',
+      relation: 'vocabulary focus',
+    });
+  }
+
+  while (recommendations.length < Math.max(1, count)) {
+    const topic = keywords[0] || truncateTitle(normalized, 3) || 'this topic';
+    const index = recommendations.length + 1;
+    recommendations.push({
+      title: `Practice prompt ${index}`,
+      text: `Write one more example sentence about ${topic} in clear everyday English.`,
+      type: 'sentence',
+      relation: 'practice prompt',
+    });
+  }
+
+  return recommendations.slice(0, Math.max(1, count));
+}
 
 export async function POST(req: NextRequest) {
   try {
@@ -67,26 +249,57 @@ export async function POST(req: NextRequest) {
       ? `Word: "${content}"\n\nReturn ${count} related vocabulary items as JSON.`
       : `Content: "${content.slice(0, 500)}"\n\nReturn ${count} related English learning items as JSON.`;
 
-    const { text } = await generateText({
-      model,
-      system: systemPrompt,
-      prompt: userPrompt,
-      maxOutputTokens: 4096,
-    });
+    let lastError: string | null = null;
 
-    const { data: parsed, error: parseError } = parseAIJson(text, 'recommendations');
+    for (let attempt = 0; attempt < RECOMMENDATION_RETRY_ATTEMPTS; attempt += 1) {
+      try {
+        const { text } = await generateText({
+          model,
+          system: systemPrompt,
+          prompt: userPrompt,
+          maxOutputTokens: 4096,
+        });
 
-    if (!parsed) {
-      console.error('Recommendations parse error:', parseError, '\nRaw:', text.substring(0, 300));
-      return NextResponse.json({ error: parseError || 'Failed to parse AI response' }, { status: 500 });
+        const { data: parsed, error: parseError } = parseAIJson<{ recommendations?: RecommendationItem[] }>(
+          text,
+          'recommendations',
+        );
+
+        if (parsed?.recommendations?.length) {
+          return NextResponse.json({
+            ...parsed,
+            providerId: resolution.providerId,
+            credentialSource: resolution.credentialSource,
+            fallbackApplied: resolution.fallbackApplied,
+            fallbackReason: resolution.fallbackReason,
+          });
+        }
+
+        lastError = parseError || 'Failed to parse AI response';
+        console.error('Recommendations parse error:', lastError, '\nRaw:', text.substring(0, 300));
+      } catch (error) {
+        lastError =
+          (error as { data?: { error?: { message?: string } } })?.data?.error?.message ||
+          (error instanceof Error ? error.message : 'Failed to generate recommendations');
+        console.error(`Recommendations attempt ${attempt + 1} failed:`, error);
+
+        if (!isTransientRecommendationError(error) || attempt === RECOMMENDATION_RETRY_ATTEMPTS - 1) {
+          break;
+        }
+
+        await sleep(RETRY_BASE_DELAY_MS * (attempt + 1));
+      }
     }
 
+    const fallbackRecommendations = buildLocalRecommendations(content, contentType, count);
     return NextResponse.json({
-      ...parsed,
+      recommendations: fallbackRecommendations,
       providerId: resolution.providerId,
       credentialSource: resolution.credentialSource,
       fallbackApplied: resolution.fallbackApplied,
       fallbackReason: resolution.fallbackReason,
+      localFallbackApplied: true,
+      localFallbackReason: lastError || 'AI recommendations were unavailable',
     });
   } catch (error) {
     console.error('Recommendations error:', error);


### PR DESCRIPTION
## Summary
- fix read detail translation rendering by wiring sentence translations into the read-aloud content view
- add regression coverage for read translation mapping and recommendation fallback behavior
- make recommendations resilient to transient AI failures and malformed AI JSON by retrying and returning local fallback suggestions

## Testing
- pnpm vitest run src/components/read-aloud/read-aloud-content.test.tsx 'src/app/(app)/read/[id]/page.translation-mapping.test.ts'
- pnpm vitest run src/app/api/recommendations/route.test.ts
- pnpm tsc --noEmit