### PR TITLE
Add resume support for practice flows and fix favorites refresh

### DIFF
--- a/src/components/dashboard/today-plan.tsx
+++ b/src/components/dashboard/today-plan.tsx
@@ -10,11 +10,13 @@ import { Card, CardContent } from '@/components/ui/card';
 import { generateDailyPlan, getDailyPlanSignature } from '@/lib/daily-plan';
 import { getTaskHref } from '@/lib/daily-plan-links';
 import { syncPlanTasksWithActivity } from '@/lib/daily-plan-progress';
+import { db } from '@/lib/db';
 import { useI18n } from '@/lib/i18n/use-i18n';
 import { buildDailyPlanGoalExplanation } from '@/lib/learning-goals';
 import { useAssessmentStore } from '@/stores/assessment-store';
 import { todayKey, useDailyPlanStore } from '@/stores/daily-plan-store';
 import { useLearningGoalStore } from '@/stores/learning-goal-store';
+import type { TypingSession } from '@/types/content';
 
 const moduleIcons: Record<string, React.ElementType> = {
   listen: Headphones,
@@ -30,14 +32,49 @@ const moduleColors: Record<string, string> = {
   write: 'bg-purple-500',
 };
 
+interface TaskSessionSummary {
+  sessionId: string;
+  accuracy: number;
+  wpm: number;
+  practicedAt: number;
+}
+
+function timeAgo(ts: number, messages: ReturnType<typeof useI18n<'common'>>['messages']): string {
+  const diff = Date.now() - ts;
+  const mins = Math.floor(diff / 60_000);
+  if (mins < 1) return messages.timeAgo.justNow;
+  if (mins < 60) return messages.timeAgo.minutesAgo.replace('{{count}}', String(mins));
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return messages.timeAgo.hoursAgo.replace('{{count}}', String(hrs));
+  return messages.timeAgo.daysAgo.replace('{{count}}', String(Math.floor(hrs / 24)));
+}
+
+function findLatestMatchingSession(
+  task: { module: string; contentId?: string; bookId?: string },
+  sessions: TypingSession[],
+) {
+  const matching = sessions
+    .filter((session) => {
+      if (!session.completed) return false;
+      if (session.module !== task.module) return false;
+      if (task.contentId) return session.contentId === task.contentId;
+      return true;
+    })
+    .sort((left, right) => (right.endTime ?? right.startTime) - (left.endTime ?? left.startTime));
+
+  return matching[0];
+}
+
 export function TodayPlan() {
   const { messages } = useI18n('dashboard');
+  const { messages: common } = useI18n('common');
   const { tasks, dateKey, dataSignature, levelKey, goal, skipTask, setTasks, updateStreak, hydrate } =
     useDailyPlanStore();
   const currentLevel = useAssessmentStore((state) => state.currentLevel);
   const currentGoal = useLearningGoalStore((state) => state.currentGoal);
   const [loading, setLoading] = useState(false);
   const [hydrated, setHydrated] = useState(false);
+  const [taskSessions, setTaskSessions] = useState<Record<string, TaskSessionSummary>>({});
 
   useEffect(() => {
     hydrate();
@@ -85,6 +122,37 @@ export function TodayPlan() {
   }, [hydrated, refreshPlan]);
 
   useEffect(() => {
+    if (!hydrated || tasks.length === 0) return;
+
+    let cancelled = false;
+
+    async function loadTaskSessions() {
+      const sessions = await db.sessions.toArray();
+      if (cancelled) return;
+
+      const next: Record<string, TaskSessionSummary> = {};
+      for (const task of tasks) {
+        if (!task.completed) continue;
+        const latest = findLatestMatchingSession(task, sessions);
+        if (!latest) continue;
+        next[task.id] = {
+          sessionId: latest.id,
+          accuracy: latest.accuracy,
+          wpm: latest.wpm,
+          practicedAt: latest.endTime ?? latest.startTime,
+        };
+      }
+      setTaskSessions(next);
+    }
+
+    void loadTaskSessions();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [hydrated, tasks]);
+
+  useEffect(() => {
     if (!hydrated) return;
 
     const handleFocus = () => {
@@ -112,6 +180,13 @@ export function TodayPlan() {
       updateStreak();
     }
   }, [completedCount, updateStreak]);
+
+  const todayPlanMessages = messages.todayPlan as typeof messages.todayPlan & {
+    reopen?: string;
+    lastPracticed?: string;
+    accuracy?: string;
+    wpm?: string;
+  };
 
   if (!hydrated) return null;
 
@@ -162,6 +237,8 @@ export function TodayPlan() {
           {tasks.map((task) => {
             const Icon = moduleIcons[task.module] ?? PenTool;
             const color = moduleColors[task.module] ?? 'bg-indigo-500';
+            const taskHref = getTaskHref(task);
+            const latestSession = taskSessions[task.id];
 
             if (task.skipped) return null;
 
@@ -189,9 +266,43 @@ export function TodayPlan() {
                     {task.title}
                   </p>
                   <p className="truncate text-xs text-indigo-400">{task.description}</p>
+                  {task.completed && latestSession && (
+                    <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-green-700/90">
+                      <span>
+                        {(todayPlanMessages.lastPracticed ?? 'Last practiced').replace(
+                          '{{time}}',
+                          timeAgo(latestSession.practicedAt, common),
+                        )}
+                      </span>
+                      {latestSession.accuracy > 0 && (
+                        <span>
+                          {(todayPlanMessages.accuracy ?? 'Accuracy {{value}}').replace(
+                            '{{value}}',
+                            `${latestSession.accuracy}%`,
+                          )}
+                        </span>
+                      )}
+                      {latestSession.wpm > 0 && (
+                        <span>
+                          {(todayPlanMessages.wpm ?? 'WPM {{value}}').replace('{{value}}', String(latestSession.wpm))}
+                        </span>
+                      )}
+                    </div>
+                  )}
                 </div>
 
-                {!task.completed && (
+                {task.completed ? (
+                  <Link href={taskHref}>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-8 shrink-0 cursor-pointer text-green-700 hover:bg-green-100 hover:text-green-800"
+                    >
+                      <Play className="mr-1 h-3.5 w-3.5" />
+                      {todayPlanMessages.reopen ?? 'Open'}
+                    </Button>
+                  </Link>
+                ) : (
                   <div className="flex shrink-0 items-center gap-1">
                     <button
                       type="button"

--- a/src/components/shared/word-book-practice.tsx
+++ b/src/components/shared/word-book-practice.tsx
@@ -86,6 +86,58 @@ const moduleIcons = {
 };
 
 const SWIPE_THRESHOLD = 50;
+const WORDBOOK_PROGRESS_STORAGE_KEY = 'echotype_wordbook_progress';
+
+interface WordBookPracticeProgress {
+  currentIndex: number;
+  completedCount: number;
+  finished: boolean;
+  updatedAt: number;
+}
+
+function buildWordBookProgressKey(module: PracticeModule, bookId: string, limit: number): string {
+  return `${module}::${bookId}::${limit || 0}`;
+}
+
+function loadWordBookProgress(progressKey: string): WordBookPracticeProgress | null {
+  if (typeof window === 'undefined') return null;
+
+  try {
+    const raw = localStorage.getItem(WORDBOOK_PROGRESS_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Record<string, WordBookPracticeProgress>;
+    return parsed[progressKey] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function saveWordBookProgress(progressKey: string, progress: WordBookPracticeProgress) {
+  if (typeof window === 'undefined') return;
+
+  try {
+    const raw = localStorage.getItem(WORDBOOK_PROGRESS_STORAGE_KEY);
+    const parsed = raw ? (JSON.parse(raw) as Record<string, WordBookPracticeProgress>) : {};
+    parsed[progressKey] = progress;
+    localStorage.setItem(WORDBOOK_PROGRESS_STORAGE_KEY, JSON.stringify(parsed));
+  } catch {
+    /* ignore storage failures */
+  }
+}
+
+function clearWordBookProgress(progressKey: string) {
+  if (typeof window === 'undefined') return;
+
+  try {
+    const raw = localStorage.getItem(WORDBOOK_PROGRESS_STORAGE_KEY);
+    if (!raw) return;
+    const parsed = JSON.parse(raw) as Record<string, WordBookPracticeProgress>;
+    delete parsed[progressKey];
+    localStorage.setItem(WORDBOOK_PROGRESS_STORAGE_KEY, JSON.stringify(parsed));
+  } catch {
+    /* ignore storage failures */
+  }
+}
 
 // ─── Translation Helper ─────────────────────────────────────────────────────
 
@@ -895,6 +947,7 @@ export function WordBookPractice({ module }: WordBookPracticeProps) {
   const searchParams = useSearchParams();
   const bookId = params.bookId as string;
   const limit = searchParams.get('limit') ? Number(searchParams.get('limit')) : 0;
+  const progressKey = buildWordBookProgressKey(module, bookId, limit);
 
   const [book, setBook] = useState<WordBook | null>(null);
   const [bookInfo, setBookInfo] = useState<BookInfo | null>(null);
@@ -955,6 +1008,31 @@ export function WordBookPractice({ module }: WordBookPracticeProps) {
     load();
   }, [bookId, limit]);
 
+  useEffect(() => {
+    if (loading || items.length === 0) return;
+
+    const saved = loadWordBookProgress(progressKey);
+    if (!saved) return;
+
+    const safeIndex = Math.min(Math.max(saved.currentIndex, 0), Math.max(items.length - 1, 0));
+    const safeCompletedCount = Math.min(Math.max(saved.completedCount, 0), items.length);
+
+    setCurrentIndex(safeIndex);
+    setCompletedCount(safeCompletedCount);
+    setFinished(saved.finished && safeCompletedCount >= items.length && items.length > 0);
+  }, [items.length, loading, progressKey]);
+
+  useEffect(() => {
+    if (loading || items.length === 0) return;
+
+    saveWordBookProgress(progressKey, {
+      currentIndex,
+      completedCount,
+      finished,
+      updatedAt: Date.now(),
+    });
+  }, [completedCount, currentIndex, finished, items.length, loading, progressKey]);
+
   const currentItem = items[currentIndex];
   const total = items.length;
 
@@ -974,7 +1052,7 @@ export function WordBookPractice({ module }: WordBookPracticeProps) {
   }, [currentIndex, total]);
 
   const handleItemCompleted = useCallback(() => {
-    setCompletedCount((c) => c + 1);
+    setCompletedCount((count) => Math.min(count + 1, total));
   }, []);
 
   const goToPrev = useCallback(() => {
@@ -1043,6 +1121,7 @@ export function WordBookPractice({ module }: WordBookPracticeProps) {
         completedCount={completedCount}
         total={total}
         onRestart={() => {
+          clearWordBookProgress(progressKey);
           setFinished(false);
           setCurrentIndex(0);
           setCompletedCount(0);

--- a/src/hooks/use-conversation.ts
+++ b/src/hooks/use-conversation.ts
@@ -13,6 +13,7 @@ import { usePracticeTranslationStore } from '@/stores/practice-translation-store
 import { useProviderStore } from '@/stores/provider-store';
 import { useSpeakStore } from '@/stores/speak-store';
 import { useTTSStore } from '@/stores/tts-store';
+import type { ConversationMessage } from '@/types/scenario';
 
 interface UseConversationOptions {
   /** Scenario info sent to API; omit for free conversation */
@@ -28,6 +29,60 @@ interface UseConversationOptions {
   topicHint?: string;
   /** Content ID to associate with the session for progress tracking */
   contentId?: string;
+}
+
+const SPEAK_CONVERSATION_STORAGE_KEY = 'echotype_speak_conversations';
+
+interface PersistedSpeakConversation {
+  contentId: string;
+  messages: ConversationMessage[];
+  sessionStart: number;
+  userTurnCount: number;
+  updatedAt: number;
+}
+
+function buildConversationKey(contentId?: string) {
+  return contentId || 'free-conversation';
+}
+
+function loadPersistedConversation(contentId?: string): PersistedSpeakConversation | null {
+  if (typeof window === 'undefined') return null;
+
+  try {
+    const raw = localStorage.getItem(SPEAK_CONVERSATION_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Record<string, PersistedSpeakConversation>;
+    return parsed[buildConversationKey(contentId)] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function savePersistedConversation(record: PersistedSpeakConversation) {
+  if (typeof window === 'undefined') return;
+
+  try {
+    const raw = localStorage.getItem(SPEAK_CONVERSATION_STORAGE_KEY);
+    const parsed = raw ? (JSON.parse(raw) as Record<string, PersistedSpeakConversation>) : {};
+    parsed[buildConversationKey(record.contentId)] = record;
+    localStorage.setItem(SPEAK_CONVERSATION_STORAGE_KEY, JSON.stringify(parsed));
+  } catch {
+    /* ignore storage failures */
+  }
+}
+
+function clearPersistedConversation(contentId?: string) {
+  if (typeof window === 'undefined') return;
+
+  try {
+    const raw = localStorage.getItem(SPEAK_CONVERSATION_STORAGE_KEY);
+    if (!raw) return;
+    const parsed = JSON.parse(raw) as Record<string, PersistedSpeakConversation>;
+    delete parsed[buildConversationKey(contentId)];
+    localStorage.setItem(SPEAK_CONVERSATION_STORAGE_KEY, JSON.stringify(parsed));
+  } catch {
+    /* ignore storage failures */
+  }
 }
 
 export function useConversation({ scenario, openingMessage, topicHint, contentId }: UseConversationOptions = {}) {
@@ -68,6 +123,7 @@ export function useConversation({ scenario, openingMessage, topicHint, contentId
 
   const abortRef = useRef<AbortController | null>(null);
   const initRef = useRef(false);
+  const hydratedRef = useRef(false);
   const sendToAIRef = useRef<(msgs: { role: string; content: string }[]) => void>(() => {});
   const getTranscriptRef = useRef<() => { transcript: string; interimTranscript: string }>(() => ({
     transcript: '',
@@ -231,6 +287,20 @@ export function useConversation({ scenario, openingMessage, topicHint, contentId
     initRef.current = true;
     resetConversation();
 
+    const persisted = loadPersistedConversation(contentId);
+    if (persisted?.messages?.length) {
+      const restoredMessages = persisted.messages.filter((message) => message.role !== 'recording');
+      useSpeakStore.setState({
+        messages: restoredMessages,
+        isStreaming: false,
+        isRecording: false,
+      });
+      sessionStartRef.current = persisted.sessionStart || 0;
+      userTurnCountRef.current = persisted.userTurnCount || 0;
+      hydratedRef.current = true;
+      return;
+    }
+
     if (openingMessage) {
       addMessage({
         id: nanoid(),
@@ -239,7 +309,27 @@ export function useConversation({ scenario, openingMessage, topicHint, contentId
         timestamp: Date.now(),
       });
     }
+
+    hydratedRef.current = true;
   }, [openingMessage, resetConversation, addMessage]);
+
+  useEffect(() => {
+    if (!hydratedRef.current) return;
+
+    const persistedMessages = messages.filter((message) => message.role !== 'recording');
+    if (persistedMessages.length === 0) {
+      clearPersistedConversation(contentId);
+      return;
+    }
+
+    savePersistedConversation({
+      contentId: buildConversationKey(contentId),
+      messages: persistedMessages,
+      sessionStart: sessionStartRef.current,
+      userTurnCount: userTurnCountRef.current,
+      updatedAt: Date.now(),
+    });
+  }, [contentId, messages]);
 
   // --- Native voice recognition (Web Speech API) ---
   const handleVoiceResult = useCallback((text: string) => {
@@ -461,6 +551,10 @@ export function useConversation({ scenario, openingMessage, topicHint, contentId
     setIsRecording(false);
     setIsFallbackTranscribing(false);
     resetConversation();
+    clearPersistedConversation(contentId);
+    sessionIdRef.current = nanoid();
+    sessionStartRef.current = 0;
+    userTurnCountRef.current = 0;
 
     if (openingMessage) {
       addMessage({

--- a/src/lib/i18n/messages/dashboard/en.json
+++ b/src/lib/i18n/messages/dashboard/en.json
@@ -104,7 +104,11 @@
     "explanationWithoutLevel": "Based on your recent practice, weak spots, and the skills you haven't practiced this week. Reviews due today appear above in Today's Review.",
     "skip": "Skip",
     "start": "Start",
-    "completed": "{{done}}/{{total}} completed"
+    "completed": "{{done}}/{{total}} completed",
+    "reopen": "Open",
+    "lastPracticed": "Last practiced {{time}}",
+    "accuracy": "Accuracy {{value}}",
+    "wpm": "WPM {{value}}"
   },
   "goalDialog": {
     "trigger": "Set Goals",

--- a/src/lib/i18n/messages/dashboard/zh.json
+++ b/src/lib/i18n/messages/dashboard/zh.json
@@ -104,7 +104,11 @@
     "explanationWithoutLevel": "根据你最近的练习、薄弱项，以及本周尚未充分练习的技能生成。今天到期的复习任务会显示在上方。",
     "skip": "跳过",
     "start": "开始",
-    "completed": "已完成 {{done}}/{{total}}"
+    "completed": "已完成 {{done}}/{{total}}",
+    "reopen": "查看",
+    "lastPracticed": "{{time}} 完成",
+    "accuracy": "准确率 {{value}}",
+    "wpm": "WPM {{value}}"
   },
   "goalDialog": {
     "trigger": "设置目标",

--- a/src/stores/__tests__/favorite-store.test.ts
+++ b/src/stores/__tests__/favorite-store.test.ts
@@ -77,6 +77,7 @@ describe('favorite-store', () => {
     expect(fav.normalizedText).toBe('hello world');
     expect(fav.autoCollected).toBe(false);
     expect(fav.fsrsCard).toBeDefined();
+    expect(useFavoriteStore.getState().isLoaded).toBe(true);
   });
 
   it('detects duplicates via isFavorited', async () => {

--- a/src/stores/favorite-store.ts
+++ b/src/stores/favorite-store.ts
@@ -107,19 +107,20 @@ export const useFavoriteStore = create<FavoriteState>((set, get) => {
         updatedAt: now,
       };
       await db.favorites.add(favorite);
-      set((state) => ({ favorites: [favorite, ...state.favorites] }));
+      set((state) => ({ favorites: [favorite, ...state.favorites], isLoaded: true }));
       return id;
     },
 
     removeFavorite: async (id) => {
       await db.favorites.delete(id);
-      set((state) => ({ favorites: state.favorites.filter((f) => f.id !== id) }));
+      set((state) => ({ favorites: state.favorites.filter((f) => f.id !== id), isLoaded: true }));
     },
 
     updateFavorite: async (id, updates) => {
       await db.favorites.update(id, { ...updates, updatedAt: Date.now() });
       set((state) => ({
         favorites: state.favorites.map((f) => (f.id === id ? { ...f, ...updates, updatedAt: Date.now() } : f)),
+        isLoaded: true,
       }));
     },
 
@@ -141,6 +142,7 @@ export const useFavoriteStore = create<FavoriteState>((set, get) => {
       await db.favoriteFolders.add(newFolder);
       set((state) => ({
         folders: [...state.folders, newFolder].sort((a, b) => a.sortOrder - b.sortOrder),
+        isLoaded: true,
       }));
       return id;
     },
@@ -151,6 +153,7 @@ export const useFavoriteStore = create<FavoriteState>((set, get) => {
         folders: state.folders
           .map((f) => (f.id === id ? { ...f, ...updates } : f))
           .sort((a, b) => a.sortOrder - b.sortOrder),
+        isLoaded: true,
       }));
     },
 
@@ -164,6 +167,7 @@ export const useFavoriteStore = create<FavoriteState>((set, get) => {
       set((state) => ({
         folders: state.folders.filter((f) => f.id !== id),
         favorites: state.favorites.map((f) => (f.folderId === id ? { ...f, folderId: 'default' } : f)),
+        isLoaded: true,
       }));
     },
 
@@ -191,6 +195,7 @@ export const useFavoriteStore = create<FavoriteState>((set, get) => {
         favorites: state.favorites.map((f) =>
           f.id === id ? { ...f, fsrsCard: cardData, nextReview, updatedAt: Date.now() } : f,
         ),
+        isLoaded: true,
       }));
     },
 


### PR DESCRIPTION
## Summary
- restore progress for shared word-book practice across listen, read, speak, and write
- restore independent speak scenario conversations and let completed daily plan tasks reopen with recent stats
- make favorites updates render immediately instead of waiting behind the loading state

## Verification
- pnpm lint
- pnpm test
- pnpm tsc --noEmit
- pnpm build *(local build is otherwise green, but can fail intermittently here when Next/Turbopack cannot fetch Google fonts from fonts.gstatic.com)*