### PR TITLE
Fix scenario collection loading and chat dock

### DIFF
--- a/src/app/(app)/library/collections/[id]/page.tsx
+++ b/src/app/(app)/library/collections/[id]/page.tsx
@@ -23,7 +23,7 @@ export default function CollectionDetailPage() {
   const router = useRouter();
   const collections = useCollectionStore((s) => s.collections);
   const collectionsLoading = useCollectionStore((s) => s.loading);
-  const loadCollections = useCollectionStore((s) => s.loadCollections);
+  const ensureBuiltinCollections = useCollectionStore((s) => s.ensureBuiltinCollections);
   const getCollectionItems = useCollectionStore((s) => s.getCollectionItems);
   const setActiveContentId = useContentStore((s) => s.setActiveContentId);
   const shadowReadingEnabled = useShadowReadingStore((s) => s.enabled);
@@ -31,6 +31,7 @@ export default function CollectionDetailPage() {
 
   const [items, setItems] = useState<ContentItem[]>([]);
   const [itemsLoading, setItemsLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
 
   const id = typeof params?.id === 'string' ? params.id : '';
 
@@ -50,21 +51,45 @@ export default function CollectionDetailPage() {
 
     void (async () => {
       setItemsLoading(true);
-      await loadCollections();
-      if (cancelled || !id) return;
-      const result = await getCollectionItems(id);
-      if (!cancelled) {
-        setItems(result);
-        setItemsLoading(false);
+      setLoadError(false);
+      try {
+        await ensureBuiltinCollections();
+        if (cancelled || !id) return;
+        const result = await getCollectionItems(id);
+        if (!cancelled) {
+          setItems(result);
+        }
+      } catch {
+        if (!cancelled) {
+          setItems([]);
+          setLoadError(true);
+        }
+      } finally {
+        if (!cancelled) {
+          setItemsLoading(false);
+        }
       }
     })();
 
     return () => {
       cancelled = true;
     };
-  }, [getCollectionItems, id, loadCollections]);
+  }, [ensureBuiltinCollections, getCollectionItems, id]);
 
-  const showNotFound = !collectionsLoading && !itemsLoading && !collection;
+  const showNotFound = !loadError && !collectionsLoading && !itemsLoading && !collection;
+
+  if (loadError) {
+    return (
+      <div className="max-w-4xl mx-auto py-12 text-center">
+        <p className="text-slate-500">Unable to load this collection.</p>
+        <Link href="/library">
+          <Button variant="outline" className="mt-4">
+            Back to Library
+          </Button>
+        </Link>
+      </div>
+    );
+  }
 
   if (showNotFound) {
     return (

--- a/src/app/(app)/library/page.tsx
+++ b/src/app/(app)/library/page.tsx
@@ -40,7 +40,7 @@ import { useContentStore } from '@/stores/content-store';
 import { useShadowReadingStore } from '@/stores/shadow-reading-store';
 import { useTTSStore } from '@/stores/tts-store';
 import { useWordBookStore } from '@/stores/wordbook-store';
-import type { ContentItem, ContentType, Difficulty } from '@/types/content';
+import type { CollectionItem, ContentItem, ContentType, Difficulty } from '@/types/content';
 import type { WordBook } from '@/types/wordbook';
 
 // ─── Constants ───────────────────────────────────────────────────────────────
@@ -345,6 +345,83 @@ function ContentGroup({
   );
 }
 
+function ScenarioCollectionsGroup({ collections }: { collections: CollectionItem[] }) {
+  const { messages } = useI18n('library');
+
+  return (
+    <AccordionItem
+      value="scenario-collections"
+      className="border rounded-xl bg-white/50 backdrop-blur-sm border-indigo-100 px-4"
+    >
+      <AccordionTrigger className="hover:no-underline py-4 cursor-pointer">
+        <div className="flex items-center gap-3 min-w-0">
+          <div className="w-8 h-8 rounded-lg bg-indigo-100 flex items-center justify-center shrink-0">
+            <Layers className="w-4 h-4 text-indigo-700" />
+          </div>
+          <h2 className="font-semibold text-indigo-900 text-lg truncate">Scenario Collections</h2>
+          <Badge variant="secondary" className="bg-indigo-100 text-indigo-600 shrink-0">
+            {collections.length}
+          </Badge>
+        </div>
+      </AccordionTrigger>
+      <AccordionContent>
+        <div className="space-y-6 pb-2">
+          <div className="flex justify-end">
+            <Link href="/library/collections/generate">
+              <Button
+                size="sm"
+                variant="outline"
+                className="border-indigo-200 text-indigo-600 hover:bg-indigo-50 cursor-pointer shrink-0"
+              >
+                <Sparkles className="w-3.5 h-3.5 mr-1.5" />
+                AI Generate
+              </Button>
+            </Link>
+          </div>
+          {SCENARIO_CATEGORIES.map((cat) => {
+            const catCollections = collections.filter((c) => c.category === cat.id);
+            if (catCollections.length === 0) return null;
+            return (
+              <div key={cat.id}>
+                <h3 className="text-sm font-semibold text-slate-500 uppercase tracking-wide mb-3 flex items-center gap-2 flex-wrap">
+                  <span>{cat.icon}</span>
+                  <span>{cat.label}</span>
+                  <span className="text-slate-400 font-normal normal-case tracking-normal">
+                    ({catCollections.length})
+                  </span>
+                </h3>
+                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+                  {catCollections.map((collection) => (
+                    <Link key={collection.id} href={`/library/collections/${collection.id}`}>
+                      <Card className="bg-white/70 backdrop-blur-sm border-indigo-100 shadow-sm hover:shadow-md hover:border-indigo-200 transition-all duration-200 cursor-pointer h-full">
+                        <CardContent className="p-4">
+                          <div className="flex items-start gap-3">
+                            <span className="text-2xl shrink-0">{collection.icon}</span>
+                            <div className="min-w-0 flex-1">
+                              <h4 className="font-semibold text-indigo-900 text-sm truncate">{collection.title}</h4>
+                              <p className="text-xs text-indigo-500 truncate">{collection.titleZh}</p>
+                              <div className="flex items-center gap-1.5 mt-2 flex-wrap">
+                                <Badge className={difficultyColors[collection.difficulty]} variant="secondary">
+                                  {messages.difficulty[collection.difficulty as keyof typeof messages.difficulty] ??
+                                    collection.difficulty}
+                                </Badge>
+                                <span className="text-[11px] text-slate-400">{collection.itemIds.length} items</span>
+                              </div>
+                            </div>
+                          </div>
+                        </CardContent>
+                      </Card>
+                    </Link>
+                  ))}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </AccordionContent>
+    </AccordionItem>
+  );
+}
 // ─── Word Book Group (for wordbook/scenario sections) ────────────────────────
 
 function WordBookGroup({
@@ -528,7 +605,7 @@ export default function LibraryPage() {
     loadContents();
     loadImportedState();
     loadBooks();
-    void seedBuiltinCollections().then(() => loadCollections());
+    void seedBuiltinCollections().then(() => loadCollections(true));
   }, [loadContents, loadImportedState, loadBooks, seedBuiltinCollections, loadCollections]);
 
   // Imported books by kind
@@ -643,11 +720,12 @@ export default function LibraryPage() {
   const hasScenarios = importedScenarioBooks.some((b) => (scenarioBookItems[b.id]?.length || 0) > 0);
 
   const hasCollections = collections.length > 0;
-  const showStandaloneCollections = showCollections && hasCollections;
+  const showStandaloneCollections = false;
   const hasAnyContent =
     hasCollections || hasWordBooks || hasBooks || hasPhrases || hasSentences || hasArticles || hasScenarios;
 
   const hasAccordionSections =
+    (showCollections && hasCollections) ||
     (showWordBooks && importedVocabBooks.some((b) => (vocabBookItems[b.id]?.length ?? 0) > 0)) ||
     (showBooks && importedBooks.length > 0) ||
     (showPhrases && grouped.phrase.length > 0) ||
@@ -658,6 +736,7 @@ export default function LibraryPage() {
   // Default open accordion values
   const defaultAccordionValues = useMemo(() => {
     const vals: string[] = [];
+    if (activeViewTab === 'collection' && hasCollections) vals.push('scenario-collections');
     if (hasBooks) vals.push('imported-books');
     // Phrases, sentences, articles open by default
     if (hasPhrases) vals.push('phrase');
@@ -665,7 +744,7 @@ export default function LibraryPage() {
     if (hasArticles) vals.push('article');
     // Word books and scenarios collapsed by default (per user request)
     return vals;
-  }, [hasBooks, hasPhrases, hasSentences, hasArticles]);
+  }, [activeViewTab, hasBooks, hasCollections, hasPhrases, hasSentences, hasArticles]);
 
   const showLibraryEmpty = !showStandaloneCollections && !hasAccordionSections;
 
@@ -858,76 +937,10 @@ export default function LibraryPage() {
         </div>
       )}
 
-      {showStandaloneCollections && (
-        <div className="space-y-6">
-          <div className="flex items-center justify-between gap-3 flex-wrap">
-            <div className="flex items-center gap-3 min-w-0">
-              <div className="w-8 h-8 rounded-lg bg-indigo-100 flex items-center justify-center shrink-0">
-                <Layers className="w-4 h-4 text-indigo-700" />
-              </div>
-              <h2 className="font-semibold text-indigo-900 text-lg truncate">Scenario Collections</h2>
-              <Badge variant="secondary" className="bg-indigo-100 text-indigo-600 shrink-0">
-                {collections.length}
-              </Badge>
-            </div>
-            {activeViewTab === 'collection' && (
-              <Link href="/library/collections/generate">
-                <Button
-                  size="sm"
-                  variant="outline"
-                  className="border-indigo-200 text-indigo-600 hover:bg-indigo-50 cursor-pointer shrink-0"
-                >
-                  <Sparkles className="w-3.5 h-3.5 mr-1.5" />
-                  AI Generate
-                </Button>
-              </Link>
-            )}
-          </div>
-
-          {SCENARIO_CATEGORIES.map((cat) => {
-            const catCollections = collections.filter((c) => c.category === cat.id);
-            if (catCollections.length === 0) return null;
-            return (
-              <div key={cat.id}>
-                <h3 className="text-sm font-semibold text-slate-500 uppercase tracking-wide mb-3 flex items-center gap-2 flex-wrap">
-                  <span>{cat.icon}</span>
-                  <span>{cat.label}</span>
-                  <span className="text-slate-400 font-normal normal-case tracking-normal">
-                    ({catCollections.length})
-                  </span>
-                </h3>
-                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-                  {catCollections.map((collection) => (
-                    <Link key={collection.id} href={`/library/collections/${collection.id}`}>
-                      <Card className="bg-white/70 backdrop-blur-sm border-indigo-100 shadow-sm hover:shadow-md hover:border-indigo-200 transition-all duration-200 cursor-pointer h-full">
-                        <CardContent className="p-4">
-                          <div className="flex items-start gap-3">
-                            <span className="text-2xl shrink-0">{collection.icon}</span>
-                            <div className="min-w-0 flex-1">
-                              <h4 className="font-semibold text-indigo-900 text-sm truncate">{collection.title}</h4>
-                              <p className="text-xs text-indigo-500 truncate">{collection.titleZh}</p>
-                              <div className="flex items-center gap-1.5 mt-2 flex-wrap">
-                                <Badge className={difficultyColors[collection.difficulty]} variant="secondary">
-                                  {messages.difficulty[collection.difficulty as keyof typeof messages.difficulty] ??
-                                    collection.difficulty}
-                                </Badge>
-                                <span className="text-[11px] text-slate-400">{collection.itemIds.length} items</span>
-                              </div>
-                            </div>
-                          </div>
-                        </CardContent>
-                      </Card>
-                    </Link>
-                  ))}
-                </div>
-              </div>
-            );
-          })}
-        </div>
-      )}
-
       {hasAccordionSections ? (
-        <Accordion type="multiple" defaultValue={defaultAccordionValues} className="space-y-3">
+        <Accordion key={activeViewTab} type="multiple" defaultValue={defaultAccordionValues} className="space-y-3">
+          {showCollections && hasCollections && <ScenarioCollectionsGroup collections={collections} />}
+
           {/* Word Books section */}
           {showWordBooks &&
             importedVocabBooks.map((book) => {

--- a/src/lib/chat-dock-layout.test.ts
+++ b/src/lib/chat-dock-layout.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { getChatDockClasses, isLibraryRoute } from './chat-dock-layout';
+
+describe('chat dock layout', () => {
+  it('keeps the chat dock on the viewport right edge for library detail pages', () => {
+    expect(isLibraryRoute('/library/collections/asking-directions')).toBe(true);
+    expect(getChatDockClasses('/library/collections/asking-directions')).toEqual({
+      fab: 'right-6',
+      panel: 'right-6',
+    });
+  });
+});

--- a/src/lib/chat-dock-layout.ts
+++ b/src/lib/chat-dock-layout.ts
@@ -3,13 +3,6 @@ export function isLibraryRoute(pathname: string): boolean {
 }
 
 export function getChatDockClasses(pathname: string): { fab: string; panel: string } {
-  if (isLibraryRoute(pathname)) {
-    return {
-      fab: 'right-4 lg:right-auto lg:left-[17rem]',
-      panel: 'right-4 lg:right-auto lg:left-[17rem]',
-    };
-  }
-
   return {
     fab: 'right-6',
     panel: 'right-6',

--- a/src/stores/collection-store.test.ts
+++ b/src/stores/collection-store.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const toArrayMock = vi.fn();
+const getCollectionMock = vi.fn();
+const bulkGetCollectionsMock = vi.fn();
+const putCollectionMock = vi.fn();
+const bulkAddContentsMock = vi.fn();
+const anyOfMock = vi.fn(() => ({
+  toArray: itemsToArrayMock,
+}));
+const itemsToArrayMock = vi.fn();
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    collections: {
+      add: putCollectionMock,
+      bulkGet: bulkGetCollectionsMock,
+      get: getCollectionMock,
+      orderBy: vi.fn(() => ({
+        reverse: vi.fn(() => ({
+          toArray: toArrayMock,
+        })),
+      })),
+      put: putCollectionMock,
+    },
+    contents: {
+      bulkAdd: bulkAddContentsMock,
+      where: vi.fn(() => ({
+        anyOf: anyOfMock,
+      })),
+    },
+  },
+}));
+
+const { useCollectionStore } = await import('./collection-store');
+
+describe('useCollectionStore', () => {
+  const storage = new Map<string, string>();
+
+  beforeEach(() => {
+    storage.clear();
+    toArrayMock.mockReset();
+    getCollectionMock.mockReset();
+    bulkGetCollectionsMock.mockReset();
+    putCollectionMock.mockReset();
+    bulkAddContentsMock.mockReset();
+    itemsToArrayMock.mockReset();
+    vi.stubGlobal('window', globalThis);
+    vi.stubGlobal('localStorage', {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        storage.set(key, value);
+      },
+    });
+    useCollectionStore.setState({ collections: [], loading: false, seeded: false });
+  });
+
+  it('clears loading when collection loading fails', async () => {
+    toArrayMock.mockRejectedValue(new Error('IndexedDB unavailable'));
+
+    await expect(useCollectionStore.getState().loadCollections()).rejects.toThrow('IndexedDB unavailable');
+
+    expect(useCollectionStore.getState().loading).toBe(false);
+  });
+
+  it('loads collection items by id when the in-memory collection list is empty', async () => {
+    getCollectionMock.mockResolvedValue({
+      id: 'taking-taxi',
+      itemIds: ['second', 'first'],
+    });
+    itemsToArrayMock.mockResolvedValue([
+      { id: 'first', text: 'First item' },
+      { id: 'second', text: 'Second item' },
+    ]);
+
+    const items = await useCollectionStore.getState().getCollectionItems('taking-taxi');
+
+    expect(getCollectionMock).toHaveBeenCalledWith('taking-taxi');
+    expect(anyOfMock).toHaveBeenCalledWith(['second', 'first']);
+    expect(items.map((item) => item.id)).toEqual(['second', 'first']);
+  });
+
+  it('seeds missing builtin collections even when the old seed marker exists', async () => {
+    storage.set('echotype_collections_seeded_v1', '1');
+    bulkGetCollectionsMock.mockResolvedValue([]);
+    bulkAddContentsMock.mockResolvedValue(undefined);
+    putCollectionMock.mockResolvedValue(undefined);
+
+    await useCollectionStore.getState().seedBuiltinCollections();
+
+    expect(bulkGetCollectionsMock).toHaveBeenCalled();
+    expect(putCollectionMock).toHaveBeenCalledWith(expect.objectContaining({ id: 'asking-directions' }));
+    expect(storage.get('echotype_collections_seeded_v1')).toBe('1');
+    expect(useCollectionStore.getState().seeded).toBe(true);
+  });
+});

--- a/src/stores/collection-store.ts
+++ b/src/stores/collection-store.ts
@@ -10,6 +10,7 @@ interface CollectionStore {
   seeded: boolean;
   loadCollections: (force?: boolean) => Promise<void>;
   seedBuiltinCollections: () => Promise<void>;
+  ensureBuiltinCollections: () => Promise<void>;
   addCollection: (collection: CollectionItem) => Promise<void>;
   deleteCollection: (id: string) => Promise<void>;
   getCollectionById: (id: string) => CollectionItem | undefined;
@@ -26,27 +27,27 @@ export const useCollectionStore = create<CollectionStore>((set, get) => ({
   loadCollections: async (force?: boolean) => {
     if (!force && get().collections.length > 0) return;
     set({ loading: true });
-    const collections = await db.collections.orderBy('createdAt').reverse().toArray();
-    set({ collections, loading: false });
+    try {
+      const collections = await db.collections.orderBy('createdAt').reverse().toArray();
+      set({ collections });
+    } finally {
+      set({ loading: false });
+    }
   },
 
   seedBuiltinCollections: async () => {
     if (typeof window === 'undefined') return;
-    if (localStorage.getItem(SEED_KEY)) {
-      set({ seeded: true });
-      return;
-    }
-
-    const existing = await db.collections.where('source').equals('builtin').count();
-    if (existing > 0) {
-      localStorage.setItem(SEED_KEY, '1');
-      set({ seeded: true });
-      return;
-    }
 
     const now = Date.now();
+    const existingBuiltins = await db.collections.bulkGet(BUILTIN_COLLECTIONS.map((builtin) => builtin.id));
+    const existingIds = new Set(
+      existingBuiltins
+        .filter((collection): collection is CollectionItem => Boolean(collection))
+        .map((collection) => collection.id),
+    );
+    const missingBuiltins = BUILTIN_COLLECTIONS.filter((builtin) => !existingIds.has(builtin.id));
 
-    for (const builtin of BUILTIN_COLLECTIONS) {
+    for (const builtin of missingBuiltins) {
       const contentItems: ContentItem[] = builtin.items.map((item) => ({
         id: nanoid(),
         title: item.text,
@@ -79,11 +80,16 @@ export const useCollectionStore = create<CollectionStore>((set, get) => ({
         updatedAt: now,
       };
 
-      await db.collections.add(collection);
+      await db.collections.put(collection);
     }
 
     localStorage.setItem(SEED_KEY, '1');
     set({ seeded: true });
+  },
+
+  ensureBuiltinCollections: async () => {
+    await get().seedBuiltinCollections();
+    await get().loadCollections(true);
   },
 
   addCollection: async (collection) => {
@@ -101,7 +107,7 @@ export const useCollectionStore = create<CollectionStore>((set, get) => ({
   },
 
   getCollectionItems: async (id) => {
-    const collection = get().collections.find((c) => c.id === id);
+    const collection = get().collections.find((c) => c.id === id) ?? (await db.collections.get(id));
     if (!collection) return [];
     const items = await db.contents.where('id').anyOf(collection.itemIds).toArray();
     const orderMap = new Map(collection.itemIds.map((itemId, i) => [itemId, i]));


### PR DESCRIPTION
## Summary
- Move Scenario Collections into the library accordion so the section can collapse and expand
- Make builtin collection seeding idempotent and recover missing collection records even when the old seed flag exists
- Keep collection detail pages from hanging on loading errors and resolve collection items by id from IndexedDB
- Restore the AI chat dock to the bottom-right corner on library routes

## Verification
- pnpm exec vitest run src/stores/collection-store.test.ts src/lib/chat-dock-layout.test.ts
- pnpm exec tsc --noEmit --pretty false
- pnpm exec biome check src/app/'(app)'/library/page.tsx src/app/'(app)'/library/collections/'[id]'/page.tsx src/stores/collection-store.ts src/stores/collection-store.test.ts src/lib/chat-dock-layout.ts src/lib/chat-dock-layout.test.ts --diagnostic-level=error
- Browser checked http://127.0.0.1:3010/library/collections/asking-directions: page renders 10 items, no Loading/Unable/Not found, chat FAB is 24px from right and bottom