### PR TITLE
Fix Listen highlighting speed and translation display

### DIFF
--- a/src/app/(app)/listen/[id]/page.tsx
+++ b/src/app/(app)/listen/[id]/page.tsx
@@ -28,6 +28,7 @@ import enListenDetail from '@/lib/i18n/messages/listen-detail/en.json';
 import zhListenDetail from '@/lib/i18n/messages/listen-detail/zh.json';
 import { scoreDictationAttempt } from '@/lib/listen-dictation';
 import { estimateSentenceHighlightTimings } from '@/lib/listen-highlight';
+import { getListenTranslationDisplayState } from '@/lib/listen-translation';
 import { resolveWeakSpot, upsertWeakSpot } from '@/lib/weak-spots';
 import { fetchAlignment, matchTimestampsToText, WordAlignmentPlayer } from '@/lib/word-alignment';
 import { useContentStore } from '@/stores/content-store';
@@ -102,6 +103,8 @@ export default function ListenDetailPage() {
   const currentSentenceIndex = useReadAloudStore((s) => s.currentSentenceIndex);
 
   const {
+    translation,
+    sentenceTranslations,
     isLoading: translationLoading,
     error: translationError,
     retry: retryTranslation,
@@ -223,6 +226,14 @@ export default function ListenDetailPage() {
   const activeSentence = raSentences[activeSentenceIndex] ?? null;
   const dictationTargetText = activeSentence?.text ?? content?.text ?? '';
   const transcriptVisible = listenMode === 'normal' || listenMode === 'repeat' || transcriptRevealed;
+  const translationDisplayState = getListenTranslationDisplayState({
+    showTranslation,
+    transcriptVisible,
+    translationLoading,
+    translationError,
+    translation,
+    sentenceTranslations,
+  });
 
   const updateListenMode = useCallback(
     (nextMode: ListenMode) => {
@@ -446,7 +457,6 @@ export default function ListenDetailPage() {
         kokoroShouldPersistCompletionRef.current = true;
         raSetPlaying(true);
         setTtsError(null);
-        startKokoroSentenceHighlight(speed);
         kokoroPlaybackStartedRef.current = false;
 
         void (async () => {
@@ -454,6 +464,9 @@ export default function ListenDetailPage() {
             const result = await speakWithSelectedVoice(content.text, { rate: speed });
             if (result && 'blob' in result && result.blob && result.audio) {
               const wordTimestamps = 'wordTimestamps' in result ? result.wordTimestamps : undefined;
+              if (!wordTimestamps?.length) {
+                startKokoroSentenceHighlight(speed);
+              }
               void startLazyAlignment(result.blob, result.audio, content.text, content.id, wordTimestamps);
             }
           } catch {
@@ -537,12 +550,14 @@ export default function ListenDetailPage() {
       listenStartRef.current = Date.now();
       kokoroShouldPersistCompletionRef.current = true;
       raSetPlaying(true);
-      startKokoroSentenceHighlight(speed);
 
       void (async () => {
         const result = await speakWithSelectedVoice(content.text, { rate: speed });
         if (result && 'blob' in result && result.blob && result.audio) {
           const wordTimestamps = 'wordTimestamps' in result ? result.wordTimestamps : undefined;
+          if (!wordTimestamps?.length) {
+            startKokoroSentenceHighlight(speed);
+          }
           void startLazyAlignment(result.blob, result.audio, content.text, content.id, wordTimestamps);
         }
       })();
@@ -991,12 +1006,13 @@ export default function ListenDetailPage() {
             </div>
           )}
 
-          {showTranslation && transcriptVisible && translationError && !translationLoading && (
+          {translationDisplayState && (
             <TranslationDisplay
-              translation={null}
-              isLoading={false}
+              translation={translationDisplayState.translation}
+              sentenceTranslations={translationDisplayState.sentenceTranslations}
+              isLoading={translationDisplayState.isLoading}
               show={true}
-              error={translationError}
+              error={translationDisplayState.error}
               onRetry={retryTranslation}
             />
           )}

--- a/src/app/(app)/read/[id]/page.tsx
+++ b/src/app/(app)/read/[id]/page.tsx
@@ -580,7 +580,6 @@ export default function ReadDetailPage() {
       raSetPlaying(true);
       setTtsError(null);
       cloudPlaybackStartedRef.current = false;
-      startCloudSentenceHighlight(speed);
 
       void (async () => {
         try {
@@ -601,6 +600,9 @@ export default function ReadDetailPage() {
 
           if (result && 'blob' in result && result.blob && result.audio) {
             const wordTimestamps = 'wordTimestamps' in result ? result.wordTimestamps : undefined;
+            if (!wordTimestamps?.length) {
+              startCloudSentenceHighlight(speed);
+            }
             void startLazyAlignment(result.blob, result.audio, content.text, content.id, wordTimestamps);
           }
         } catch {

--- a/src/lib/edge-tts.test.ts
+++ b/src/lib/edge-tts.test.ts
@@ -188,6 +188,15 @@ describe('edge-tts', () => {
       expect(mockEdgeTTS).toHaveBeenCalledWith('test', 'en-US-AriaNeural', { rate: '-50%' });
     });
 
+    it('scales word boundaries to the actual playback timeline for slow speech', async () => {
+      mockTTSInstance([1], [{ text: 'Hello', offset: 1_000_000, duration: 3_750_000 }]);
+
+      const { synthesizeEdgeSpeech } = await import('./edge-tts');
+      const result = await synthesizeEdgeSpeech({ text: 'Hello', voice: 'en-US-AriaNeural', speed: 0.5 });
+
+      expect(result.wordBoundaries).toEqual([{ word: 'Hello', start: 0.2, end: 0.95 }]);
+    });
+
     it('defaults speed to 1.0 (+0%)', async () => {
       mockTTSInstance([1], []);
 

--- a/src/lib/edge-tts.ts
+++ b/src/lib/edge-tts.ts
@@ -82,10 +82,11 @@ export async function synthesizeEdgeSpeech({
   const audioBuffer = Buffer.from(await result.audio.arrayBuffer());
 
   const HNS_PER_SEC = 10_000_000;
+  const timelineScale = 1 / Math.max(speed, 0.1);
   const wordBoundaries: EdgeWordBoundary[] = result.subtitle.map((wb) => ({
     word: wb.text,
-    start: wb.offset / HNS_PER_SEC,
-    end: (wb.offset + wb.duration) / HNS_PER_SEC,
+    start: (wb.offset / HNS_PER_SEC) * timelineScale,
+    end: ((wb.offset + wb.duration) / HNS_PER_SEC) * timelineScale,
   }));
 
   return {

--- a/src/lib/listen-translation.test.ts
+++ b/src/lib/listen-translation.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { getListenTranslationDisplayState } from './listen-translation';
+
+describe('listen translation display state', () => {
+  it('shows fetched sentence translations when translation is enabled', () => {
+    const state = getListenTranslationDisplayState({
+      showTranslation: true,
+      transcriptVisible: true,
+      translationLoading: false,
+      translationError: null,
+      translation: '奖励在我的手机上。',
+      sentenceTranslations: [{ original: 'Rewards on my phone.', translation: '奖励在我的手机上。' }],
+    });
+
+    expect(state).toEqual({
+      translation: '奖励在我的手机上。',
+      sentenceTranslations: [{ original: 'Rewards on my phone.', translation: '奖励在我的手机上。' }],
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  it('hides translations when the listen transcript is hidden', () => {
+    const state = getListenTranslationDisplayState({
+      showTranslation: true,
+      transcriptVisible: false,
+      translationLoading: false,
+      translationError: null,
+      translation: '奖励在我的手机上。',
+      sentenceTranslations: [{ original: 'Rewards on my phone.', translation: '奖励在我的手机上。' }],
+    });
+
+    expect(state).toBeNull();
+  });
+});

--- a/src/lib/listen-translation.ts
+++ b/src/lib/listen-translation.ts
@@ -1,0 +1,57 @@
+import type { SentenceTranslation } from '@/hooks/use-translation';
+
+export interface ListenTranslationDisplayInput {
+  showTranslation: boolean;
+  transcriptVisible: boolean;
+  translationLoading: boolean;
+  translationError: string | null;
+  translation: string | null;
+  sentenceTranslations: SentenceTranslation[] | null;
+}
+
+export interface ListenTranslationDisplayState {
+  translation: string | null;
+  sentenceTranslations: SentenceTranslation[] | null;
+  isLoading: boolean;
+  error: string | null;
+}
+
+export function getListenTranslationDisplayState({
+  showTranslation,
+  transcriptVisible,
+  translationLoading,
+  translationError,
+  translation,
+  sentenceTranslations,
+}: ListenTranslationDisplayInput): ListenTranslationDisplayState | null {
+  if (!showTranslation || !transcriptVisible) return null;
+
+  if (translationLoading) {
+    return {
+      translation: null,
+      sentenceTranslations: null,
+      isLoading: true,
+      error: null,
+    };
+  }
+
+  if (translationError) {
+    return {
+      translation: null,
+      sentenceTranslations: null,
+      isLoading: false,
+      error: translationError,
+    };
+  }
+
+  if (sentenceTranslations?.length || translation) {
+    return {
+      translation,
+      sentenceTranslations,
+      isLoading: false,
+      error: null,
+    };
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- Keep Listen/Read fallback sentence highlighting aligned with cloud audio by starting estimated timers only after audio playback begins
- Scale Edge TTS word timestamps to the selected playback speed so 0.5x highlighting does not outrun the audio
- Render fetched Listen translations instead of only rendering translation errors

## Verification
- pnpm typecheck
- pnpm lint
- pnpm test
- Browser smoke: http://localhost:3001/listen/codex-listen-speed-translation showed Listen content at 0.5x with Chinese translation visible