### PR TITLE
Fix large media import, TTS parity, and dashboard task sync

### DIFF
--- a/src/app/(app)/listen/[id]/page.tsx
+++ b/src/app/(app)/listen/[id]/page.tsx
@@ -94,7 +94,7 @@ export default function ListenDetailPage() {
     browserVoices,
     currentVoice,
     boundaryPlaybackNotice,
-    voiceSource,
+    resolvedVoiceSource,
   } = useTTS();
   const { speed, setSpeed, voiceURI, kokoroVoiceName } = useTTSStore();
   const showTranslation = usePracticeTranslationStore((s) => s.visibility.listen);
@@ -234,8 +234,10 @@ export default function ListenDetailPage() {
   const duration = content ? estimateListenDuration(content.text, speed) : 0;
 
   const browserVoice = browserVoices.find((voice) => voice.voiceURI === voiceURI);
-  const isCloudListenMode = voiceSource === 'kokoro' || voiceSource === 'fish' || voiceSource === 'edge';
-  const cloudSourceLabel = voiceSource === 'fish' ? 'Fish Audio' : voiceSource === 'edge' ? 'Edge TTS' : 'Kokoro';
+  const isCloudListenMode =
+    resolvedVoiceSource === 'kokoro' || resolvedVoiceSource === 'fish' || resolvedVoiceSource === 'edge';
+  const cloudSourceLabel =
+    resolvedVoiceSource === 'fish' ? 'Fish Audio' : resolvedVoiceSource === 'edge' ? 'Edge TTS' : 'Kokoro';
   const activeListenVoiceName = isCloudListenMode
     ? currentVoice?.name || kokoroVoiceName || cloudSourceLabel
     : browserVoice?.name;

--- a/src/components/dashboard/today-plan.tsx
+++ b/src/components/dashboard/today-plan.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useLiveQuery } from 'dexie-react-hooks';
 import { BookOpen, CheckCircle2, Circle, Headphones, Mic, PenTool, Play, SkipForward } from 'lucide-react';
 import Link from 'next/link';
 import { useCallback, useEffect, useState } from 'react';
@@ -77,6 +78,16 @@ export function TodayPlan() {
   const [hydrated, setHydrated] = useState(false);
   const [taskSessions, setTaskSessions] = useState<Record<string, TaskSessionSummary>>({});
   const isIOSNativeHost = detectIOSNativeHost();
+  const activitySignature = useLiveQuery(async () => {
+    const [latestSession, latestRecord] = await Promise.all([
+      db.sessions.orderBy('startTime').last(),
+      db.records.orderBy('lastPracticed').last(),
+    ]);
+
+    return `${latestSession?.id ?? 'none'}:${latestSession?.endTime ?? latestSession?.startTime ?? 0}:${
+      latestRecord?.id ?? 'none'
+    }:${latestRecord?.lastPracticed ?? 0}`;
+  }, []);
 
   useEffect(() => {
     hydrate();
@@ -121,7 +132,7 @@ export function TodayPlan() {
   useEffect(() => {
     if (!hydrated) return;
     void refreshPlan();
-  }, [hydrated, refreshPlan]);
+  }, [activitySignature, hydrated, refreshPlan]);
 
   useEffect(() => {
     if (!hydrated || tasks.length === 0) return;

--- a/src/components/import/local-media-upload.tsx
+++ b/src/components/import/local-media-upload.tsx
@@ -8,6 +8,11 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
+import {
+  type BrowserTranscriptionResult,
+  shouldUseDirectBrowserTranscription,
+  transcribeInBrowser,
+} from '@/lib/browser-transcription';
 import { useI18n } from '@/lib/i18n/use-i18n';
 import { saveMediaBlob } from '@/lib/media-storage';
 import { IS_IOS_NATIVE_HOST, pickNativeFiles } from '@/lib/tauri';
@@ -33,6 +38,15 @@ interface TranscriptionResult {
   providerId?: string;
   fallbackApplied?: boolean;
   fallbackReason?: string;
+}
+
+interface ServerTranscriptionPayload extends BrowserTranscriptionResult {
+  error?: string;
+  classification?: {
+    title?: string;
+    difficulty?: Difficulty;
+    tags?: string[];
+  };
 }
 
 export function LocalMediaUpload({ compact, onImported }: LocalMediaUploadProps) {
@@ -117,20 +131,30 @@ export function LocalMediaUpload({ compact, onImported }: LocalMediaUploadProps)
     setTranscribing(true);
 
     try {
-      const transcribeForm = new FormData();
-      transcribeForm.append('file', file);
-      transcribeForm.append('provider', activeProviderId);
-      transcribeForm.append('providerConfigs', JSON.stringify(providers));
+      let data: ServerTranscriptionPayload;
 
-      const response = await fetch('/api/import/transcribe', {
-        method: 'POST',
-        body: transcribeForm,
-      });
-      const data = await response.json();
+      if (shouldUseDirectBrowserTranscription(file)) {
+        data = await transcribeInBrowser({
+          file,
+          provider: activeProviderId,
+          providerConfigs: providers,
+        });
+      } else {
+        const transcribeForm = new FormData();
+        transcribeForm.append('file', file);
+        transcribeForm.append('provider', activeProviderId);
+        transcribeForm.append('providerConfigs', JSON.stringify(providers));
 
-      if (!response.ok) {
-        setError(data.error || m.transcriptionFailed);
-        return;
+        const response = await fetch('/api/import/transcribe', {
+          method: 'POST',
+          body: transcribeForm,
+        });
+        data = (await response.json()) as ServerTranscriptionPayload;
+
+        if (!response.ok) {
+          setError(data.error || m.transcriptionFailed);
+          return;
+        }
       }
 
       setResult({
@@ -149,8 +173,8 @@ export function LocalMediaUpload({ compact, onImported }: LocalMediaUploadProps)
       if (Array.isArray(data.classification?.tags)) {
         setTags(data.classification.tags.join(', '));
       }
-    } catch {
-      setError(m.networkError);
+    } catch (error) {
+      setError(error instanceof Error ? error.message : m.networkError);
     } finally {
       setTranscribing(false);
     }

--- a/src/components/selection-translation/selection-translation-popup.tsx
+++ b/src/components/selection-translation/selection-translation-popup.tsx
@@ -4,6 +4,7 @@ import { Check, Copy, Mic, MicOff, Volume2, X } from 'lucide-react';
 import { forwardRef, useCallback, useEffect, useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { Button } from '@/components/ui/button';
+import { useTTS } from '@/hooks/use-tts';
 import { IS_IOS_NATIVE_HOST, IS_TAURI } from '@/lib/tauri';
 import { normalizeText } from '@/lib/text-normalize';
 import { cn } from '@/lib/utils';
@@ -56,6 +57,7 @@ export const SelectionTranslationPopup = forwardRef<HTMLDivElement, Props>(
     const getFavoriteByText = useFavoriteStore((s) => s.getFavoriteByText);
     const folders = useFavoriteStore((s) => s.folders);
     const targetLang = useTTSStore((s) => s.targetLang);
+    const { speak: speakSelection } = useTTS();
     const [selectedFolderId, setSelectedFolderId] = useState('default');
 
     const alreadyFavorited = useMemo(() => {
@@ -108,14 +110,9 @@ export const SelectionTranslationPopup = forwardRef<HTMLDivElement, Props>(
     const handleTTS = useCallback(
       (e: React.MouseEvent) => {
         e.stopPropagation();
-        if ('speechSynthesis' in window) {
-          window.speechSynthesis.cancel();
-          const utterance = new SpeechSynthesisUtterance(selection.speechText);
-          utterance.lang = 'en-US';
-          window.speechSynthesis.speak(utterance);
-        }
+        void speakSelection(selection.speechText);
       },
-      [selection.speechText],
+      [selection.speechText, speakSelection],
     );
 
     const handleMic = useCallback(

--- a/src/lib/browser-transcription.test.ts
+++ b/src/lib/browser-transcription.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ProviderConfig, ProviderId } from '@/lib/providers';
+import {
+  DIRECT_TRANSCRIPTION_FILE_SIZE_THRESHOLD,
+  shouldUseDirectBrowserTranscription,
+  transcribeInBrowser,
+} from './browser-transcription';
+
+describe('browser transcription', () => {
+  const fetchMock = vi.fn<typeof fetch>();
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('switches large files to direct browser transcription', () => {
+    const file = new File([new Uint8Array(DIRECT_TRANSCRIPTION_FILE_SIZE_THRESHOLD + 1)], 'sample.mp3', {
+      type: 'audio/mpeg',
+    });
+
+    expect(shouldUseDirectBrowserTranscription(file)).toBe(true);
+  });
+
+  it('uses the first configured direct transcription provider', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          text: 'hello world',
+          language: 'en',
+          segments: [{ start: 0, end: 1.2, text: ' hello world ' }],
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    const file = new File(['audio'], 'sample.wav', { type: 'audio/wav' });
+    const providerConfigs = {
+      groq: {
+        providerId: 'groq',
+        auth: { type: 'api-key', apiKey: 'groq-key' },
+      },
+    } satisfies Partial<Record<ProviderId, Partial<ProviderConfig>>>;
+
+    const result = await transcribeInBrowser({
+      file,
+      language: 'en',
+      provider: 'groq',
+      providerConfigs,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.groq.com/openai/v1/audio/transcriptions',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer groq-key',
+        }),
+      }),
+    );
+    expect(result).toMatchObject({
+      text: 'hello world',
+      language: 'en',
+      duration: 1.2,
+      providerId: 'groq',
+      credentialSource: 'stored',
+      fallbackApplied: false,
+    });
+    expect(result.segments).toEqual([{ start: 0, end: 1.2, text: 'hello world' }]);
+  });
+
+  it('falls back to the next configured provider when the requested one is unavailable', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          text: 'fallback transcript',
+          language: 'en',
+          segments: [{ start: 0, end: 2, text: 'fallback transcript' }],
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    const file = new File(['audio'], 'sample.wav', { type: 'audio/wav' });
+    const providerConfigs = {
+      openai: {
+        providerId: 'openai',
+        auth: { type: 'api-key', apiKey: 'openai-key' },
+      },
+    } satisfies Partial<Record<ProviderId, Partial<ProviderConfig>>>;
+
+    const result = await transcribeInBrowser({
+      file,
+      provider: 'groq',
+      providerConfigs,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.openai.com/v1/audio/transcriptions',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer openai-key',
+        }),
+      }),
+    );
+    expect(result.providerId).toBe('openai');
+    expect(result.fallbackApplied).toBe(true);
+  });
+});

--- a/src/lib/browser-transcription.ts
+++ b/src/lib/browser-transcription.ts
@@ -1,0 +1,210 @@
+import type { ProviderAuthState, ProviderConfig, ProviderId } from '@/lib/providers';
+
+export const DIRECT_TRANSCRIPTION_FILE_SIZE_THRESHOLD = 4 * 1024 * 1024;
+const MAX_TRANSCRIPTION_FILE_SIZE = 25 * 1024 * 1024;
+const SUPPORTED_MIME_TYPES = new Set([
+  'audio/mpeg',
+  'audio/mp3',
+  'audio/wav',
+  'audio/x-wav',
+  'audio/mp4',
+  'audio/m4a',
+  'audio/x-m4a',
+  'audio/ogg',
+  'audio/flac',
+  'video/mp4',
+  'video/webm',
+  'video/x-msvideo',
+]);
+const SUPPORTED_EXTENSIONS = new Set(['.mp3', '.wav', '.m4a', '.ogg', '.flac', '.mp4', '.webm', '.avi']);
+const DIRECT_TRANSCRIPTION_PROVIDER_IDS = ['groq', 'openai'] as const;
+
+interface BrowserTranscriptionRequest {
+  file: File;
+  language?: string | null;
+  provider: ProviderId;
+  providerConfigs: Partial<Record<ProviderId, Partial<ProviderConfig>>>;
+}
+
+export interface BrowserTranscriptionResult {
+  text: string;
+  language: string;
+  duration: number;
+  segments: Array<{ start: number; end: number; text: string }>;
+  providerId: ProviderId;
+  credentialSource: 'stored';
+  fallbackApplied: boolean;
+  fallbackReason?: string;
+}
+
+function getStoredCredential(auth?: ProviderAuthState): string {
+  return auth?.apiKey || auth?.accessToken || '';
+}
+
+function getExtension(filename: string): string {
+  const dot = filename.lastIndexOf('.');
+  return dot >= 0 ? filename.slice(dot).toLowerCase() : '';
+}
+
+function validateDirectTranscriptionFile(file: File) {
+  const ext = getExtension(file.name);
+
+  if (!SUPPORTED_EXTENSIONS.has(ext)) {
+    return {
+      valid: false,
+      error: `Unsupported format "${ext}". Supported: MP3, WAV, M4A, OGG, FLAC, MP4, WebM, AVI`,
+    };
+  }
+
+  if (
+    file.type &&
+    !SUPPORTED_MIME_TYPES.has(file.type) &&
+    !file.type.startsWith('audio/') &&
+    !file.type.startsWith('video/')
+  ) {
+    return {
+      valid: false,
+      error: `Unsupported file type "${file.type}".`,
+    };
+  }
+
+  if (file.size > MAX_TRANSCRIPTION_FILE_SIZE) {
+    return {
+      valid: false,
+      error: 'File too large. Maximum 25MB. Try trimming the audio first.',
+    };
+  }
+
+  return { valid: true };
+}
+
+function getTranscriptionEndpoint(providerId: 'groq' | 'openai'): string {
+  return providerId === 'groq'
+    ? 'https://api.groq.com/openai/v1/audio/transcriptions'
+    : 'https://api.openai.com/v1/audio/transcriptions';
+}
+
+function getTranscriptionModel(providerId: 'groq' | 'openai'): string {
+  return providerId === 'groq' ? 'whisper-large-v3-turbo' : 'whisper-1';
+}
+
+function buildUpstreamTranscriptionFormData(
+  file: File,
+  providerId: 'groq' | 'openai',
+  language?: string | null,
+): FormData {
+  const upstreamForm = new FormData();
+  upstreamForm.append('file', file);
+  upstreamForm.append('model', getTranscriptionModel(providerId));
+  upstreamForm.append('response_format', 'verbose_json');
+  upstreamForm.append('timestamp_granularities[]', 'segment');
+  if (language) upstreamForm.append('language', language);
+  return upstreamForm;
+}
+
+async function parseUpstreamTranscriptionPayload(response: Response) {
+  const raw = await response.text();
+  if (!raw) return {};
+
+  try {
+    return JSON.parse(raw) as {
+      text?: string;
+      language?: string;
+      error?: { message?: string };
+      segments?: Array<{ start: number; end: number; text: string }>;
+    };
+  } catch {
+    return {
+      error: {
+        message: raw.slice(0, 500),
+      },
+    };
+  }
+}
+
+function getDirectProviderChain(requestedProviderId: ProviderId): Array<'groq' | 'openai'> {
+  const chain: Array<'groq' | 'openai'> = [];
+  for (const providerId of [requestedProviderId, ...DIRECT_TRANSCRIPTION_PROVIDER_IDS]) {
+    if ((providerId === 'groq' || providerId === 'openai') && !chain.includes(providerId)) {
+      chain.push(providerId);
+    }
+  }
+  return chain;
+}
+
+function normalizeSegments(
+  segments: Array<{ start: number; end: number; text: string }> | undefined,
+): Array<{ start: number; end: number; text: string }> {
+  return (
+    segments?.map((segment) => ({
+      start: segment.start,
+      end: segment.end,
+      text: segment.text.trim(),
+    })) ?? []
+  );
+}
+
+export function shouldUseDirectBrowserTranscription(file: File): boolean {
+  return file.size > DIRECT_TRANSCRIPTION_FILE_SIZE_THRESHOLD;
+}
+
+export async function transcribeInBrowser({
+  file,
+  language,
+  provider,
+  providerConfigs,
+}: BrowserTranscriptionRequest): Promise<BrowserTranscriptionResult> {
+  const fileValidation = validateDirectTranscriptionFile(file);
+  if (!fileValidation.valid) {
+    throw new Error(fileValidation.error);
+  }
+
+  const directCandidates = getDirectProviderChain(provider)
+    .map((providerId) => ({
+      providerId,
+      apiKey: getStoredCredential(providerConfigs[providerId]?.auth),
+    }))
+    .filter((candidate) => candidate.apiKey);
+
+  if (directCandidates.length === 0) {
+    throw new Error('Large media uploads need a configured Groq or OpenAI API key for direct browser transcription.');
+  }
+
+  const errors: string[] = [];
+
+  for (const { providerId, apiKey } of directCandidates) {
+    const response = await fetch(getTranscriptionEndpoint(providerId), {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: buildUpstreamTranscriptionFormData(file, providerId, language),
+    }).catch((error) => {
+      throw new Error(error instanceof Error ? error.message : 'Direct transcription request failed.');
+    });
+
+    const payload = await parseUpstreamTranscriptionPayload(response);
+
+    if (!response.ok) {
+      errors.push(payload.error?.message || `${providerId} transcription failed.`);
+      continue;
+    }
+
+    const segments = normalizeSegments(payload.segments);
+    const duration = segments.length > 0 ? segments[segments.length - 1].end : 0;
+
+    return {
+      text: payload.text || '',
+      language: payload.language || 'en',
+      duration,
+      segments,
+      providerId,
+      credentialSource: 'stored',
+      fallbackApplied: providerId !== provider,
+      fallbackReason:
+        providerId !== provider ? `${provider} is not configured; using configured provider ${providerId}` : undefined,
+    };
+  }
+
+  throw new Error(errors[0] || 'Direct browser transcription failed.');
+}


### PR DESCRIPTION
## Summary
- route large media transcription directly from the browser to configured Groq/OpenAI providers to avoid app upload limits
- align listen-page playback with selection-popup TTS so both use the same configured voice source
- refresh Today Plan completion state when new practice activity lands locally

## Verification
- pnpm test src/lib/browser-transcription.test.ts src/lib/transcription.test.ts src/__tests__/daily-plan-progress.test.ts
- pnpm typecheck
- pnpm lint
- pnpm build
- web verification:
  - 6.4MB audio upload on a temporary debug page bypassed /api/import/transcribe and issued direct POST requests to https://api.groq.com/openai/v1/audio/transcriptions
  - listen TTS trigger and selection popup Speak button both hit /api/tts/kokoro/speak
  - Today Plan updated from 0/4 to 1/4 immediately after inserting a matching practice session through app code