### PR TITLE
perf: speed up sidebar navigation

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -5,8 +5,6 @@ import {
   ArrowRight,
   BookMarked,
   BookOpen,
-  Calendar,
-  Clock,
   Crosshair,
   FileText,
   Flame,
@@ -43,7 +41,7 @@ import {
   IOSPageHeader,
 } from '@/components/shared/ios-native-ui';
 import { Button } from '@/components/ui/button';
-import { getActivityHeatmapData, getReviewForecast, getStreakData } from '@/lib/analytics';
+import { buildActivityHeatmapData, buildReviewForecast, buildStreakData } from '@/lib/analytics';
 import { db } from '@/lib/db';
 import { useI18n } from '@/lib/i18n/use-i18n';
 import { buildDailyPlanGoalExplanation, LEARNING_GOAL_CONFIG, type LearningGoal } from '@/lib/learning-goals';
@@ -174,7 +172,11 @@ export default function DashboardPage() {
 
   useEffect(() => {
     async function load() {
-      const [contents, sessions] = await Promise.all([db.contents.toArray(), db.sessions.toArray()]);
+      const [contents, sessions, records] = await Promise.all([
+        db.contents.toArray(),
+        db.sessions.toArray(),
+        db.records.toArray(),
+      ]);
 
       const completed = sessions.filter((s) => s.completed);
       const sessionsByModule: Record<string, number> = {};
@@ -191,11 +193,9 @@ export default function DashboardPage() {
       const writes = completed.filter((s) => (s.module || 'write') === 'write');
       const avgWpm = writes.length > 0 ? writes.reduce((sum, s) => sum + s.wpm, 0) / writes.length : 0;
 
-      const [streakData, heatmap, forecast] = await Promise.all([
-        getStreakData(),
-        getActivityHeatmapData(56),
-        getReviewForecast(7),
-      ]);
+      const streakData = buildStreakData(sessions);
+      const heatmap = buildActivityHeatmapData(sessions, 56);
+      const forecast = buildReviewForecast(records, 7);
 
       setHeatmapData(heatmap);
       setReviewForecastData(forecast);

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -27,6 +27,24 @@ import { useShortcutStore } from '@/stores/shortcut-store';
 import { useTTSStore } from '@/stores/tts-store';
 import { useUpdaterStore } from '@/stores/updater-store';
 
+function scheduleBackgroundTask(task: () => void) {
+  if (typeof globalThis.window === 'undefined') return () => {};
+
+  const win = globalThis.window as Window &
+    typeof globalThis & {
+      requestIdleCallback?: (callback: IdleRequestCallback, options?: IdleRequestOptions) => number;
+      cancelIdleCallback?: (handle: number) => void;
+    };
+
+  if (typeof win.requestIdleCallback === 'function' && typeof win.cancelIdleCallback === 'function') {
+    const handle = win.requestIdleCallback(() => task(), { timeout: 1200 });
+    return () => win.cancelIdleCallback?.(handle);
+  }
+
+  const handle = globalThis.setTimeout(task, 0);
+  return () => globalThis.clearTimeout(handle);
+}
+
 function getNativeHostSearchParam(): string | null {
   if (typeof window === 'undefined') return null;
   return new URLSearchParams(window.location.search).get('nativeHost');
@@ -120,13 +138,22 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
   };
 
   useEffect(() => {
-    seedDatabase().then(async () => {
+    let cancelled = false;
+    let cancelWarmup = () => {};
+
+    void seedDatabase().then(async () => {
       await hydrateIOSNativeQA();
-      await useContentStore.getState().loadContents(true);
-      await useFavoriteStore.getState().loadFavorites();
+      if (cancelled) return;
+
       setSeeded(true);
       window.dispatchEvent(new Event('echotype:bootstrap-ready'));
+
+      void useContentStore.getState().loadContents(true);
+      cancelWarmup = scheduleBackgroundTask(() => {
+        void useFavoriteStore.getState().loadFavorites(true);
+      });
     });
+
     void useProviderStore.getState().hydrate();
     useAssessmentStore.getState().hydrate();
     useDailyPlanStore.getState().hydrate();
@@ -141,6 +168,8 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
     }
 
     return () => {
+      cancelled = true;
+      cancelWarmup();
       useUpdaterStore.getState().stopPeriodicCheck();
     };
   }, []);

--- a/src/components/shared/content-list.tsx
+++ b/src/components/shared/content-list.tsx
@@ -18,6 +18,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
+import { SESSION_ACTIVITY_EVENT } from '@/lib/daily-plan-progress';
 import { db } from '@/lib/db';
 import { useI18n } from '@/lib/i18n/use-i18n';
 import { detectIOSNativeHost, reportNativeQAState } from '@/lib/tauri';
@@ -50,6 +51,36 @@ const difficultyColors: Record<string, string> = {
   intermediate: 'bg-yellow-100 text-yellow-700',
   advanced: 'bg-red-100 text-red-700',
 };
+
+const moduleSessionCountCache = new Map<string, Record<string, number>>();
+const moduleSessionCountRequests = new Map<string, Promise<Record<string, number>>>();
+
+async function loadModuleSessionCounts(module: string): Promise<Record<string, number>> {
+  const cached = moduleSessionCountCache.get(module);
+  if (cached) return cached;
+
+  const pending = moduleSessionCountRequests.get(module);
+  if (pending) return pending;
+
+  const request = db.sessions
+    .where('module')
+    .equals(module)
+    .toArray()
+    .then((sessions) => {
+      const counts: Record<string, number> = {};
+      for (const session of sessions) {
+        counts[session.contentId] = (counts[session.contentId] || 0) + 1;
+      }
+      moduleSessionCountCache.set(module, counts);
+      return counts;
+    })
+    .finally(() => {
+      moduleSessionCountRequests.delete(module);
+    });
+
+  moduleSessionCountRequests.set(module, request);
+  return request;
+}
 
 // ─── Empty state ──────────────────────────────────────────────────────────────
 
@@ -312,6 +343,18 @@ export function ContentList({ title, description, module, icon: Icon, iconBg, ic
     loadImportedState();
   }, [loadImportedState]);
 
+  useEffect(() => {
+    const handleBootstrapReady = () => {
+      void loadContents(true);
+      void loadImportedState(true);
+    };
+
+    window.addEventListener('echotype:bootstrap-ready', handleBootstrapReady);
+    return () => {
+      window.removeEventListener('echotype:bootstrap-ready', handleBootstrapReady);
+    };
+  }, [loadContents, loadImportedState]);
+
   // Imported books by kind
   const importedVocabBooks = useMemo(
     () => ALL_WORDBOOKS.filter((b) => importedIds.has(b.id) && b.kind === 'vocabulary'),
@@ -361,17 +404,31 @@ export function ContentList({ title, description, module, icon: Icon, iconBg, ic
 
   // Load session counts for this module once
   useEffect(() => {
-    db.sessions
-      .where('module')
-      .equals(module)
-      .toArray()
-      .then((sessions) => {
-        const counts: Record<string, number> = {};
-        for (const s of sessions) {
-          counts[s.contentId] = (counts[s.contentId] || 0) + 1;
-        }
+    let cancelled = false;
+
+    const applyCounts = async () => {
+      const counts = await loadModuleSessionCounts(module);
+      if (!cancelled) {
         setSessionCounts(counts);
-      });
+      }
+    };
+
+    void applyCounts();
+
+    const handleSessionActivity = (event: Event) => {
+      const detail = (event as CustomEvent<{ module?: string }>).detail;
+      if (detail?.module && detail.module !== module) return;
+
+      moduleSessionCountCache.delete(module);
+      void applyCounts();
+    };
+
+    window.addEventListener(SESSION_ACTIVITY_EVENT, handleSessionActivity as EventListener);
+
+    return () => {
+      cancelled = true;
+      window.removeEventListener(SESSION_ACTIVITY_EVENT, handleSessionActivity as EventListener);
+    };
   }, [module]);
 
   // Scroll active item into view when shadow reading is enabled

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,4 +1,5 @@
 import { db } from '@/lib/db';
+import type { LearningRecord, TypingSession } from '@/types/content';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -30,7 +31,15 @@ function fillDateRange(startTs: number, days: number): string[] {
 export async function getActivityHeatmapData(days = 365): Promise<{ date: string; count: number }[]> {
   const cutoff = daysAgoTs(days);
   const sessions = await db.sessions.where('startTime').aboveOrEqual(cutoff).toArray();
-  const completed = sessions.filter((s) => s.completed);
+  return buildActivityHeatmapData(sessions, days, cutoff);
+}
+
+export function buildActivityHeatmapData(
+  sessions: TypingSession[],
+  days = 365,
+  cutoff = daysAgoTs(days),
+): { date: string; count: number }[] {
+  const completed = sessions.filter((s) => s.completed && s.startTime >= cutoff);
 
   const counts = new Map<string, number>();
   for (const s of completed) {
@@ -179,6 +188,10 @@ export async function getModuleBreakdown(): Promise<{ module: string; sessions: 
 
 export async function getStreakData(): Promise<{ current: number; longest: number; dates: string[] }> {
   const sessions = await db.sessions.toArray();
+  return buildStreakData(sessions);
+}
+
+export function buildStreakData(sessions: TypingSession[]): { current: number; longest: number; dates: string[] } {
   const completed = sessions.filter((s) => s.completed);
 
   const practiceDates = new Set<string>();
@@ -234,7 +247,14 @@ export async function getStreakData(): Promise<{ current: number; longest: numbe
 
 export async function getReviewForecast(days = 7): Promise<{ date: string; count: number }[]> {
   const records = await db.records.toArray();
-  const now = Date.now();
+  return buildReviewForecast(records, days);
+}
+
+export function buildReviewForecast(
+  records: LearningRecord[],
+  days = 7,
+  now = Date.now(),
+): { date: string; count: number }[] {
   const endTs = now + days * 86_400_000;
 
   const counts = new Map<string, number>();

--- a/src/lib/daily-plan-progress.ts
+++ b/src/lib/daily-plan-progress.ts
@@ -5,6 +5,8 @@ import { accuracyToRating, gradeCard } from '@/lib/fsrs';
 import type { PlanTask } from '@/stores/daily-plan-store';
 import type { ContentItem, LearningRecord, TypingSession } from '@/types/content';
 
+export const SESSION_ACTIVITY_EVENT = 'echotype:sessions-updated';
+
 interface SyncContext {
   contents: ContentItem[];
   records: LearningRecord[];
@@ -119,6 +121,19 @@ export async function savePracticeSession(
     fsrsCard: cardData,
     mistakes: options?.mistakes ?? existingRecord?.mistakes ?? [],
   });
+
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(
+      new CustomEvent(SESSION_ACTIVITY_EVENT, {
+        detail: {
+          module: session.module,
+          contentId: session.contentId,
+          sessionId: session.id,
+          practicedAt,
+        },
+      }),
+    );
+  }
 }
 
 /**

--- a/src/lib/i18n/provider.tsx
+++ b/src/lib/i18n/provider.tsx
@@ -18,13 +18,10 @@ export function I18nProvider({ children }: { children: React.ReactNode }) {
     document.documentElement.lang = interfaceLanguage;
   }, [initialized, interfaceLanguage]);
 
-  if (!initialized) {
-    return (
-      <div className="flex h-screen items-center justify-center bg-slate-50 px-6 text-center text-sm text-slate-500">
-        {messages.appShell.loading}
-      </div>
-    );
-  }
-
-  return <>{children}</>;
+  return (
+    <>
+      {!initialized ? <span className="sr-only">{messages.appShell.loading}</span> : null}
+      {children}
+    </>
+  );
 }

--- a/src/stores/content-store.ts
+++ b/src/stores/content-store.ts
@@ -5,6 +5,7 @@ import type { ContentItem, ContentType, Difficulty } from '@/types/content';
 interface ContentStore {
   items: ContentItem[];
   loading: boolean;
+  isLoaded: boolean;
   filter: {
     type?: ContentType;
     difficulty?: Difficulty;
@@ -28,42 +29,62 @@ interface ContentStore {
   setActiveContentId: (id: string | null) => void;
 }
 
+let loadContentsPromise: Promise<void> | null = null;
+
 export const useContentStore = create<ContentStore>((set, get) => ({
   items: [],
   loading: false,
+  isLoaded: false,
   filter: { search: '' },
   activeContentId: null,
 
   setFilter: (filter) => set((state) => ({ filter: { ...state.filter, ...filter } })),
 
   loadContents: async (force?: boolean) => {
-    if (!force && get().items.length > 0) return;
+    if (loadContentsPromise) {
+      if (!force) return loadContentsPromise;
+      await loadContentsPromise;
+    }
+
+    if (!force && get().isLoaded) return;
+
     set({ loading: true });
-    const items = await db.contents.orderBy('createdAt').reverse().toArray();
-    set({ items, loading: false });
+    loadContentsPromise = db.contents
+      .orderBy('createdAt')
+      .reverse()
+      .toArray()
+      .then((items) => {
+        set({ items, loading: false, isLoaded: true });
+      })
+      .finally(() => {
+        loadContentsPromise = null;
+      });
+
+    return loadContentsPromise;
   },
 
   addContent: async (item) => {
     await db.contents.add(item);
     const items = await db.contents.orderBy('createdAt').reverse().toArray();
-    set({ items });
+    set({ items, isLoaded: true });
   },
 
   addBulkContent: async (items) => {
     await db.contents.bulkAdd(items);
     const allItems = await db.contents.orderBy('createdAt').reverse().toArray();
-    set({ items: allItems });
+    set({ items: allItems, isLoaded: true });
   },
 
   deleteContent: async (id) => {
     await db.contents.delete(id);
-    set((state) => ({ items: state.items.filter((i) => i.id !== id) }));
+    set((state) => ({ items: state.items.filter((i) => i.id !== id), isLoaded: true }));
   },
 
   updateContent: async (id, updates) => {
     await db.contents.update(id, { ...updates, updatedAt: Date.now() });
     set((state) => ({
       items: state.items.map((i) => (i.id === id ? { ...i, ...updates, updatedAt: Date.now() } : i)),
+      isLoaded: true,
     }));
   },
 

--- a/src/stores/favorite-store.ts
+++ b/src/stores/favorite-store.ts
@@ -17,7 +17,7 @@ interface FavoriteState {
   autoCollectSettings: AutoCollectSettings;
 
   // Data
-  loadFavorites: () => Promise<void>;
+  loadFavorites: (force?: boolean) => Promise<void>;
   addFavorite: (
     item: Omit<
       FavoriteItem,
@@ -73,6 +73,7 @@ function saveSettings(state: { selectionTranslateEnabled: boolean; autoCollectSe
 
 export const useFavoriteStore = create<FavoriteState>((set, get) => {
   const settings = loadSettings();
+  let loadFavoritesPromise: Promise<void> | null = null;
 
   return {
     favorites: [],
@@ -82,13 +83,27 @@ export const useFavoriteStore = create<FavoriteState>((set, get) => {
     selectionTranslateEnabled: settings.selectionTranslateEnabled,
     autoCollectSettings: settings.autoCollectSettings,
 
-    loadFavorites: async () => {
-      const [favorites, folders] = await Promise.all([db.favorites.toArray(), db.favoriteFolders.toArray()]);
-      set({
-        favorites: favorites.sort((a, b) => b.createdAt - a.createdAt),
-        folders: folders.sort((a, b) => a.sortOrder - b.sortOrder),
-        isLoaded: true,
-      });
+    loadFavorites: async (force?: boolean) => {
+      if (loadFavoritesPromise) {
+        if (!force) return loadFavoritesPromise;
+        await loadFavoritesPromise;
+      }
+
+      if (!force && get().isLoaded) return;
+
+      loadFavoritesPromise = Promise.all([db.favorites.toArray(), db.favoriteFolders.toArray()])
+        .then(([favorites, folders]) => {
+          set({
+            favorites: favorites.sort((a, b) => b.createdAt - a.createdAt),
+            folders: folders.sort((a, b) => a.sortOrder - b.sortOrder),
+            isLoaded: true,
+          });
+        })
+        .finally(() => {
+          loadFavoritesPromise = null;
+        });
+
+      return loadFavoritesPromise;
     },
 
     addFavorite: async (item) => {

--- a/src/stores/tts-store.ts
+++ b/src/stores/tts-store.ts
@@ -31,6 +31,7 @@ export interface TTSSettings {
 }
 
 interface TTSStore extends TTSSettings {
+  hydrated: boolean;
   setVoiceSource: (source: TTSSource) => void;
   setVoiceURI: (uri: string) => void;
   setSpeed: (speed: number) => void;
@@ -100,6 +101,7 @@ const defaults: TTSSettings = {
 
 export const useTTSStore = create<TTSStore>((set, get) => ({
   ...defaults,
+  hydrated: false,
 
   setVoiceSource: (voiceSource) => {
     set({ voiceSource });
@@ -197,13 +199,16 @@ export const useTTSStore = create<TTSStore>((set, get) => ({
   },
 
   hydrate: () => {
+    if (get().hydrated) return;
     const saved = loadFromStorage();
     if (Object.keys(saved).length > 0) {
       // Don't overwrite the default Kokoro server URL with an empty string
       if ('kokoroServerUrl' in saved && !saved.kokoroServerUrl?.trim()) {
         delete saved.kokoroServerUrl;
       }
-      set(saved);
+      set({ ...saved, hydrated: true });
+      return;
     }
+    set({ hydrated: true });
   },
 }));

--- a/src/stores/wordbook-store.ts
+++ b/src/stores/wordbook-store.ts
@@ -7,25 +7,43 @@ import type { ContentItem } from '@/types/content';
 interface WordBookStore {
   importedIds: Set<string>;
   loading: boolean;
-  loadImportedState: () => Promise<void>;
+  isLoaded: boolean;
+  loadImportedState: (force?: boolean) => Promise<void>;
   importWordBook: (wordbookId: string) => Promise<void>;
   removeWordBook: (wordbookId: string) => Promise<void>;
   isImported: (wordbookId: string) => boolean;
 }
 
+let loadImportedStatePromise: Promise<void> | null = null;
+
 export const useWordBookStore = create<WordBookStore>((set, get) => ({
   importedIds: new Set(),
   loading: false,
+  isLoaded: false,
 
-  loadImportedState: async () => {
+  loadImportedState: async (force?: boolean) => {
+    if (loadImportedStatePromise) {
+      if (!force) return loadImportedStatePromise;
+      await loadImportedStatePromise;
+    }
+
+    if (!force && get().isLoaded) return;
+
     set({ loading: true });
-    const counts = await Promise.all(
+    loadImportedStatePromise = Promise.all(
       ALL_WORDBOOK_IDS.map(async (id) => {
         const count = await db.contents.where('category').equals(id).count();
         return count > 0 ? id : null;
       }),
-    );
-    set({ importedIds: new Set(counts.filter(Boolean) as string[]), loading: false });
+    )
+      .then((counts) => {
+        set({ importedIds: new Set(counts.filter(Boolean) as string[]), loading: false, isLoaded: true });
+      })
+      .finally(() => {
+        loadImportedStatePromise = null;
+      });
+
+    return loadImportedStatePromise;
   },
 
   importWordBook: async (wordbookId: string) => {
@@ -40,7 +58,7 @@ export const useWordBookStore = create<WordBookStore>((set, get) => ({
       updatedAt: now,
     }));
     await db.contents.bulkAdd(items);
-    set((state) => ({ importedIds: new Set([...state.importedIds, wordbookId]) }));
+    set((state) => ({ importedIds: new Set([...state.importedIds, wordbookId]), isLoaded: true }));
   },
 
   removeWordBook: async (wordbookId: string) => {
@@ -48,7 +66,7 @@ export const useWordBookStore = create<WordBookStore>((set, get) => ({
     set((state) => {
       const next = new Set(state.importedIds);
       next.delete(wordbookId);
-      return { importedIds: next };
+      return { importedIds: next, isLoaded: true };
     });
   },
 


### PR DESCRIPTION
## Summary
- remove the blocking i18n loading screen and defer non-critical app bootstrap work
- dedupe repeated IndexedDB/localStorage hydrations for content, favorites, wordbooks, and TTS settings
- cache module session counts and reuse dashboard analytics data instead of rescanning the same tables

## Verification
- pnpm build
- local production-mode browser check on 2026-06-04: sidebar navigation Dashboard -> Listen -> Read -> Write -> Dashboard completed in roughly 47-90ms per click across 3 rounds
- confirmed the blocking "Loading your language settings" overlay no longer appears during navigation