### PR TITLE
perf: reduce route prefetch churn and stabilize tts

### DIFF
--- a/src/__tests__/tts-store.test.ts
+++ b/src/__tests__/tts-store.test.ts
@@ -32,13 +32,16 @@ const DEFAULT_STATE = {
   fishVoiceId: '',
   fishVoiceName: '',
   fishModel: 's2-pro',
-  kokoroServerUrl: 'http://54.166.253.41:8880',
+  kokoroServerUrl: '',
   kokoroApiKey: '',
-  kokoroVoiceId: 'af_heart',
-  kokoroVoiceName: 'Heart',
+  kokoroVoiceId: '',
+  kokoroVoiceName: '',
+  edgeVoiceId: 'en-US-EmmaMultilingualNeural',
+  edgeVoiceName: 'Emma',
   targetLang: 'zh-CN',
   recommendationsEnabled: true,
   recommendationsCount: 5,
+  groqApiKey: '',
   openaiKey: '',
   anthropicKey: '',
   deepseekKey: '',
@@ -47,7 +50,7 @@ const DEFAULT_STATE = {
 describe('tts-store', () => {
   beforeEach(() => {
     storage.clear();
-    useTTSStore.setState(DEFAULT_STATE);
+    useTTSStore.setState({ ...DEFAULT_STATE, hydrated: false });
   });
 
   it('starts with Edge TTS defaults', () => {
@@ -56,8 +59,8 @@ describe('tts-store', () => {
     expect(state.voiceSource).toBe('edge');
     expect(state.fishModel).toBe('s2-pro');
     expect(state.fishVoiceId).toBe('');
-    expect(state.kokoroServerUrl).toBe('http://54.166.253.41:8880');
-    expect(state.kokoroVoiceId).toBe('af_heart');
+    expect(state.edgeVoiceId).toBe('en-US-EmmaMultilingualNeural');
+    expect(state.edgeVoiceName).toBe('Emma');
   });
 
   it('persists Fish settings to localStorage', () => {
@@ -98,23 +101,7 @@ describe('tts-store', () => {
     expect(state.fishModel).toBe('s1');
   });
 
-  it('persists Kokoro settings to localStorage', () => {
-    const store = useTTSStore.getState();
-
-    store.setVoiceSource('kokoro');
-    store.setKokoroServerUrl('http://localhost:8880');
-    store.setKokoroApiKey('kokoro-secret');
-    store.setKokoroVoice('bf_emma', 'Emma');
-
-    const saved = JSON.parse(storage.get('echotype_tts_settings') ?? '{}');
-    expect(saved.voiceSource).toBe('kokoro');
-    expect(saved.kokoroServerUrl).toBe('http://localhost:8880');
-    expect(saved.kokoroApiKey).toBe('kokoro-secret');
-    expect(saved.kokoroVoiceId).toBe('bf_emma');
-    expect(saved.kokoroVoiceName).toBe('Emma');
-  });
-
-  it('hydrates persisted Kokoro settings', () => {
+  it('migrates persisted Kokoro selection to Edge defaults', () => {
     storage.set(
       'echotype_tts_settings',
       JSON.stringify({
@@ -129,11 +116,17 @@ describe('tts-store', () => {
     useTTSStore.getState().hydrate();
 
     const state = useTTSStore.getState();
-    expect(state.voiceSource).toBe('kokoro');
+    expect(state.voiceSource).toBe('edge');
+    expect(state.edgeVoiceId).toBe('en-US-EmmaMultilingualNeural');
+    expect(state.edgeVoiceName).toBe('Emma');
     expect(state.kokoroServerUrl).toBe('http://localhost:8880');
     expect(state.kokoroApiKey).toBe('persisted-kokoro-key');
     expect(state.kokoroVoiceId).toBe('bm_daniel');
     expect(state.kokoroVoiceName).toBe('Daniel');
+
+    const saved = JSON.parse(storage.get('echotype_tts_settings') ?? '{}');
+    expect(saved.voiceSource).toBe('edge');
+    expect(saved.edgeVoiceId).toBe('en-US-EmmaMultilingualNeural');
   });
 
   it('auto-saves Fish API key on change', () => {
@@ -211,13 +204,15 @@ describe('tts-store', () => {
     expect(saved.voiceSource).toBe('edge');
   });
 
-  it('switches voice source to kokoro and persists it', () => {
-    useTTSStore.getState().setVoiceSource('kokoro');
+  it('persists selected Edge voice metadata', () => {
+    useTTSStore.getState().setEdgeVoice('en-US-AvaNeural', 'Ava');
 
-    expect(useTTSStore.getState().voiceSource).toBe('kokoro');
-
+    const state = useTTSStore.getState();
     const saved = JSON.parse(storage.get('echotype_tts_settings') ?? '{}');
-    expect(saved.voiceSource).toBe('kokoro');
+    expect(state.edgeVoiceId).toBe('en-US-AvaNeural');
+    expect(state.edgeVoiceName).toBe('Ava');
+    expect(saved.edgeVoiceId).toBe('en-US-AvaNeural');
+    expect(saved.edgeVoiceName).toBe('Ava');
   });
 
   it('persists full configuration roundtrip', () => {
@@ -228,7 +223,7 @@ describe('tts-store', () => {
     store.setFishVoice('voice-rt', 'RoundTrip Voice');
 
     // Reset store state to defaults
-    useTTSStore.setState(DEFAULT_STATE);
+    useTTSStore.setState({ ...DEFAULT_STATE, hydrated: false });
 
     // Hydrate from storage
     useTTSStore.getState().hydrate();

--- a/src/__tests__/tts-store.test.ts
+++ b/src/__tests__/tts-store.test.ts
@@ -36,8 +36,8 @@ const DEFAULT_STATE = {
   kokoroApiKey: '',
   kokoroVoiceId: '',
   kokoroVoiceName: '',
-  edgeVoiceId: 'en-US-EmmaMultilingualNeural',
-  edgeVoiceName: 'Emma',
+  edgeVoiceId: 'en-US-JennyNeural',
+  edgeVoiceName: 'Jenny',
   targetLang: 'zh-CN',
   recommendationsEnabled: true,
   recommendationsCount: 5,
@@ -59,8 +59,8 @@ describe('tts-store', () => {
     expect(state.voiceSource).toBe('edge');
     expect(state.fishModel).toBe('s2-pro');
     expect(state.fishVoiceId).toBe('');
-    expect(state.edgeVoiceId).toBe('en-US-EmmaMultilingualNeural');
-    expect(state.edgeVoiceName).toBe('Emma');
+    expect(state.edgeVoiceId).toBe('en-US-JennyNeural');
+    expect(state.edgeVoiceName).toBe('Jenny');
   });
 
   it('persists Fish settings to localStorage', () => {
@@ -117,8 +117,8 @@ describe('tts-store', () => {
 
     const state = useTTSStore.getState();
     expect(state.voiceSource).toBe('edge');
-    expect(state.edgeVoiceId).toBe('en-US-EmmaMultilingualNeural');
-    expect(state.edgeVoiceName).toBe('Emma');
+    expect(state.edgeVoiceId).toBe('en-US-JennyNeural');
+    expect(state.edgeVoiceName).toBe('Jenny');
     expect(state.kokoroServerUrl).toBe('http://localhost:8880');
     expect(state.kokoroApiKey).toBe('persisted-kokoro-key');
     expect(state.kokoroVoiceId).toBe('bm_daniel');
@@ -126,7 +126,7 @@ describe('tts-store', () => {
 
     const saved = JSON.parse(storage.get('echotype_tts_settings') ?? '{}');
     expect(saved.voiceSource).toBe('edge');
-    expect(saved.edgeVoiceId).toBe('en-US-EmmaMultilingualNeural');
+    expect(saved.edgeVoiceId).toBe('en-US-JennyNeural');
   });
 
   it('auto-saves Fish API key on change', () => {

--- a/src/app/(app)/library/page.tsx
+++ b/src/app/(app)/library/page.tsx
@@ -22,7 +22,7 @@ import {
   X,
 } from 'lucide-react';
 import Link from 'next/link';
-import { useEffect, useMemo, useState } from 'react';
+import { useDeferredValue, useEffect, useMemo, useState } from 'react';
 import { IOSInlineChatButton } from '@/components/chat/ios-inline-chat-button';
 import { QuickAddDialog } from '@/components/library/quick-add-dialog';
 import {
@@ -62,6 +62,13 @@ import type { WordBook } from '@/types/wordbook';
 const ITEMS_PER_GROUP = 10;
 
 type ViewTab = 'all' | 'collection' | 'wordbook' | 'book' | 'phrase' | 'sentence' | 'article' | 'scenario';
+
+type LibraryDerivedData = {
+  filteredItems: ContentItem[];
+  grouped: Record<'phrase' | 'sentence' | 'article', ContentItem[]>;
+  vocabBookItems: Record<string, ContentItem[]>;
+  scenarioBookItems: Record<string, ContentItem[]>;
+};
 
 const VIEW_TAB_ICON_MAP: Record<ViewTab, typeof BookMarked | undefined> = {
   all: undefined,
@@ -717,6 +724,7 @@ export default function LibraryPage() {
   const [batchTagInput, setBatchTagInput] = useState('');
   const [showBatchTagInput, setShowBatchTagInput] = useState(false);
   const [showTagFilters, setShowTagFilters] = useState(false);
+  const deferredSearch = useDeferredValue(filter.search);
 
   const toggleSelect = (id: string) => {
     setSelectedIds((prev) => {
@@ -796,66 +804,53 @@ export default function LibraryPage() {
     setFilter({ difficulty: diff || undefined });
   };
 
-  // Filter items based on current filters
-  const filteredItems = useMemo(() => {
-    let result = items;
+  const derivedData = useMemo<LibraryDerivedData>(() => {
+    const searchQuery = deferredSearch.trim().toLowerCase();
+    const grouped: LibraryDerivedData['grouped'] = { phrase: [], sentence: [], article: [] };
+    const vocabBookItems: LibraryDerivedData['vocabBookItems'] = {};
+    const scenarioBookItems: LibraryDerivedData['scenarioBookItems'] = {};
+    const vocabBookIds = new Set(importedVocabBooks.map((book) => book.id));
+    const scenarioBookIds = new Set(importedScenarioBooks.map((book) => book.id));
+    const filteredItems: ContentItem[] = [];
 
-    if (viewMode === 'media') {
-      result = result.filter((item) => item.metadata?.audioUrl || item.metadata?.platform);
-    }
+    for (const item of items) {
+      if (viewMode === 'media' && !item.metadata?.audioUrl && !item.metadata?.platform) continue;
+      if (diffFilter && item.difficulty !== diffFilter) continue;
+      if (tagFilter.length > 0 && !tagFilter.every((tag) => item.tags.includes(tag))) continue;
+      if (searchQuery) {
+        const matchesSearch =
+          item.title.toLowerCase().includes(searchQuery) ||
+          item.text.toLowerCase().includes(searchQuery) ||
+          item.tags.some((tag) => tag.toLowerCase().includes(searchQuery));
+        if (!matchesSearch) continue;
+      }
 
-    if (diffFilter) {
-      result = result.filter((item) => item.difficulty === diffFilter);
-    }
+      filteredItems.push(item);
 
-    if (tagFilter.length > 0) {
-      result = result.filter((item) => tagFilter.every((t) => item.tags.includes(t)));
-    }
-
-    if (filter.search) {
-      const q = filter.search.toLowerCase();
-      result = result.filter(
-        (item) =>
-          item.title.toLowerCase().includes(q) ||
-          item.text.toLowerCase().includes(q) ||
-          item.tags.some((t) => t.toLowerCase().includes(q)),
-      );
-    }
-
-    return result;
-  }, [items, viewMode, diffFilter, tagFilter, filter.search]);
-
-  // Group items by type (excluding words and book chapters for standalone display)
-  const grouped = useMemo(() => {
-    const groups: Record<string, ContentItem[]> = { phrase: [], sentence: [], article: [] };
-    for (const item of filteredItems) {
-      if (item.type !== 'word' && groups[item.type]) {
-        // Exclude book chapters from the article group
+      if (item.category && vocabBookIds.has(item.category)) {
+        if (!vocabBookItems[item.category]) {
+          vocabBookItems[item.category] = [];
+        }
+        vocabBookItems[item.category].push(item);
+      }
+      if (item.category && scenarioBookIds.has(item.category)) {
+        if (!scenarioBookItems[item.category]) {
+          scenarioBookItems[item.category] = [];
+        }
+        scenarioBookItems[item.category].push(item);
+      }
+      if (item.type !== 'word' && item.type in grouped) {
         if (item.type === 'article' && item.category?.startsWith('book-')) continue;
-        groups[item.type].push(item);
+        grouped[item.type].push(item);
       }
     }
-    return groups;
-  }, [filteredItems]);
 
-  // Group items by word book
-  const vocabBookItems = useMemo(() => {
-    const map: Record<string, ContentItem[]> = {};
-    for (const book of importedVocabBooks) {
-      map[book.id] = filteredItems.filter((item) => item.category === book.id);
-    }
-    return map;
-  }, [filteredItems, importedVocabBooks]);
+    return { filteredItems, grouped, vocabBookItems, scenarioBookItems };
+  }, [deferredSearch, diffFilter, importedScenarioBooks, importedVocabBooks, items, tagFilter, viewMode]);
 
-  const scenarioBookItems = useMemo(() => {
-    const map: Record<string, ContentItem[]> = {};
-    for (const book of importedScenarioBooks) {
-      map[book.id] = filteredItems.filter((item) => item.category === book.id);
-    }
-    return map;
-  }, [filteredItems, importedScenarioBooks]);
+  const { filteredItems, grouped, vocabBookItems, scenarioBookItems } = derivedData;
 
-  const allTags = useMemo(() => getAllTags(), [getAllTags, items]);
+  const allTags = useMemo(() => getAllTags(), [getAllTags]);
 
   // Total item count
   const totalCount = filteredItems.length;

--- a/src/app/(app)/library/page.tsx
+++ b/src/app/(app)/library/page.tsx
@@ -286,6 +286,7 @@ function ContentRow({
         <div className="flex items-center gap-1 shrink-0 self-end sm:self-auto">
           <Link
             href={`/listen/${item.id}`}
+            prefetch={false}
             onClick={() => onSetActive(item.id)}
             data-testid={`library-action-listen-${item.id}`}
             aria-label={`Library listen ${item.title}`}
@@ -306,6 +307,7 @@ function ContentRow({
           </Link>
           <Link
             href={`/read/${item.id}`}
+            prefetch={false}
             onClick={() => onSetActive(item.id)}
             data-testid={`library-action-read-${item.id}`}
             aria-label={`Library read ${item.title}`}
@@ -326,6 +328,7 @@ function ContentRow({
           </Link>
           <Link
             href={`/write/${item.id}`}
+            prefetch={false}
             onClick={() => onSetActive(item.id)}
             data-testid={`library-action-write-${item.id}`}
             aria-label={`Library write ${item.title}`}
@@ -482,7 +485,7 @@ function ScenarioCollectionsGroup({ collections }: { collections: CollectionItem
       <AccordionContent>
         <div className="space-y-6 pb-2">
           <div className="flex justify-end">
-            <Link href="/library/collections/generate">
+            <Link href="/library/collections/generate" prefetch={false}>
               <Button
                 size="sm"
                 variant="outline"
@@ -507,7 +510,7 @@ function ScenarioCollectionsGroup({ collections }: { collections: CollectionItem
                 </h3>
                 <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
                   {catCollections.map((collection) => (
-                    <Link key={collection.id} href={`/library/collections/${collection.id}`}>
+                    <Link key={collection.id} href={`/library/collections/${collection.id}`} prefetch={false}>
                       <Card className="bg-white/70 backdrop-blur-sm border-indigo-100 shadow-sm hover:shadow-md hover:border-indigo-200 transition-all duration-200 cursor-pointer h-full">
                         <CardContent className="p-4">
                           <div className="flex items-start gap-3">
@@ -609,7 +612,7 @@ function WordBookGroup({
             <span className={cn('mr-1 text-xs', isIOSNativeHost ? 'text-slate-500' : 'text-indigo-400')}>
               {messages.practiceAll}:
             </span>
-            <Link href={`/listen/book/${book.id}`}>
+            <Link href={`/listen/book/${book.id}`} prefetch={false}>
               <Button
                 variant="outline"
                 size="sm"
@@ -623,7 +626,7 @@ function WordBookGroup({
                 <Headphones className="w-3 h-3 mr-1" /> {messages.actions.listen}
               </Button>
             </Link>
-            <Link href={`/speak/book/${book.id}`}>
+            <Link href={`/speak/book/${book.id}`} prefetch={false}>
               <Button
                 variant="outline"
                 size="sm"
@@ -637,7 +640,7 @@ function WordBookGroup({
                 <Mic className="w-3 h-3 mr-1" /> {messages.actions.speak}
               </Button>
             </Link>
-            <Link href={`/read/book/${book.id}`}>
+            <Link href={`/read/book/${book.id}`} prefetch={false}>
               <Button
                 variant="outline"
                 size="sm"
@@ -651,7 +654,7 @@ function WordBookGroup({
                 <BookOpen className="w-3 h-3 mr-1" /> {messages.actions.read}
               </Button>
             </Link>
-            <Link href={`/write/book/${book.id}`}>
+            <Link href={`/write/book/${book.id}`} prefetch={false}>
               <Button
                 variant="outline"
                 size="sm"
@@ -962,7 +965,7 @@ export default function LibraryPage() {
                 <span className="hidden sm:inline">{messages.page.quickAdd}</span>
                 <span className="sm:hidden">Add</span>
               </Button>
-              <Link href="/library/import">
+              <Link href="/library/import" prefetch={false}>
                 <Button
                   size="sm"
                   className={
@@ -1272,7 +1275,7 @@ export default function LibraryPage() {
               <AccordionContent>
                 <div className="grid gap-2 pb-2">
                   {importedBooks.map((book) => (
-                    <Link key={book.id} href={`/library/books/${book.id}`}>
+                    <Link key={book.id} href={`/library/books/${book.id}`} prefetch={false}>
                       <Card
                         className={cn(
                           'transition-all duration-200 cursor-pointer',
@@ -1381,7 +1384,7 @@ export default function LibraryPage() {
             description="Import articles, phrases, books, or scenario packs and they will land here in the same iOS library system."
             action={
               activeViewTab === 'collection' ? (
-                <Link href="/library/collections/generate">
+                <Link href="/library/collections/generate" prefetch={false}>
                   <Button size="sm" variant="outline" className={`${IOS_TERTIARY_BUTTON_CLASS} cursor-pointer`}>
                     <Sparkles className="w-3.5 h-3.5 mr-1.5" />
                     AI Generate
@@ -1399,7 +1402,7 @@ export default function LibraryPage() {
           >
             <p>{messages.noContent}</p>
             {activeViewTab === 'collection' && (
-              <Link href="/library/collections/generate">
+              <Link href="/library/collections/generate" prefetch={false}>
                 <Button
                   size="sm"
                   variant="outline"

--- a/src/app/(app)/listen/[id]/page.tsx
+++ b/src/app/(app)/listen/[id]/page.tsx
@@ -36,6 +36,7 @@ import { getIOSNativeQAMode } from '@/lib/ios-native-qa';
 import { scoreDictationAttempt } from '@/lib/listen-dictation';
 import { estimateSentenceHighlightTimings } from '@/lib/listen-highlight';
 import { getListenTranslationDisplayState } from '@/lib/listen-translation';
+import { attachWordBoundaryTracking, isSpeechSynthesisUtteranceResult } from '@/lib/read-aloud-playback';
 import { detectIOSNativeHost, reportNativeQAState } from '@/lib/tauri';
 import { cn } from '@/lib/utils';
 import { resolveWeakSpot, upsertWeakSpot } from '@/lib/weak-spots';
@@ -93,7 +94,6 @@ export default function ListenDetailPage() {
     isSpeaking: isTTSPlaying,
     browserVoices,
     currentVoice,
-    boundaryPlaybackNotice,
     resolvedVoiceSource,
   } = useTTS();
   const { speed, setSpeed, voiceURI, edgeVoiceName } = useTTSStore();
@@ -164,27 +164,45 @@ export default function ListenDetailPage() {
   }, []);
 
   useEffect(() => {
-    if (!bootstrapReady) return;
+    const contentId = typeof params.id === 'string' ? params.id : null;
+    if (!contentId) {
+      setContent(null);
+      setContentNotFound(true);
+      return;
+    }
 
-    const storeItems = useContentStore.getState().items;
-    const itemFromStore = storeItems.find((item) => item.id === params.id);
-
+    const itemFromStore = useContentStore.getState().items.find((item) => item.id === contentId);
     if (itemFromStore) {
       setContent(itemFromStore);
       setContentNotFound(false);
       return;
     }
 
+    setContent((current) => (current?.id === contentId ? current : null));
+    setContentNotFound(false);
+
+    let cancelled = false;
+
     async function load() {
-      const item = await db.contents.get(params.id as string);
+      const item = await db.contents.get(contentId);
+      if (cancelled) return;
+
       if (item) {
         setContent(item);
         setContentNotFound(false);
-      } else {
+        return;
+      }
+
+      if (bootstrapReady) {
         setContentNotFound(true);
       }
     }
-    load();
+
+    void load();
+
+    return () => {
+      cancelled = true;
+    };
   }, [bootstrapReady, params.id]);
 
   useEffect(() => {
@@ -248,12 +266,6 @@ export default function ListenDetailPage() {
   const activeListenVoiceName = isCloudListenMode
     ? currentVoice?.name || edgeVoiceName || cloudSourceLabel
     : browserVoice?.name;
-  const playbackNotice =
-    isCloudListenMode && !hasWordAlignment
-      ? t.header.cloudPlaybackNotice.replace('{{source}}', cloudSourceLabel)
-      : isCloudListenMode
-        ? null
-        : boundaryPlaybackNotice;
   const activeSentenceIndex =
     currentSentenceIndex >= 0
       ? currentSentenceIndex
@@ -513,6 +525,22 @@ export default function ListenDetailPage() {
         void (async () => {
           try {
             const result = await speakWithSelectedVoice(content.text, { rate: speed });
+            if (isSpeechSynthesisUtteranceResult(result)) {
+              raSetCurrentWordIndex(0);
+              attachWordBoundaryTracking(result, {
+                startWordIndex: 0,
+                onWord: raSetCurrentWordIndex,
+                onEnd: () => {
+                  raResetProgress();
+                  persistListenSession();
+                },
+                onError: () => {
+                  raSetPlaying(false);
+                  cloudPlaybackStartedRef.current = false;
+                },
+              });
+              return;
+            }
             if (result && 'blob' in result && result.blob && result.audio) {
               const wordTimestamps = 'wordTimestamps' in result ? result.wordTimestamps : undefined;
               if (!wordTimestamps?.length) {
@@ -604,6 +632,22 @@ export default function ListenDetailPage() {
 
       void (async () => {
         const result = await speakWithSelectedVoice(content.text, { rate: speed });
+        if (isSpeechSynthesisUtteranceResult(result)) {
+          raSetCurrentWordIndex(0);
+          attachWordBoundaryTracking(result, {
+            startWordIndex: 0,
+            onWord: raSetCurrentWordIndex,
+            onEnd: () => {
+              raResetProgress();
+              persistListenSession();
+            },
+            onError: () => {
+              raSetPlaying(false);
+              cloudPlaybackStartedRef.current = false;
+            },
+          });
+          return;
+        }
         if (result && 'blob' in result && result.blob && result.audio) {
           const wordTimestamps = 'wordTimestamps' in result ? result.wordTimestamps : undefined;
           if (!wordTimestamps?.length) {
@@ -642,10 +686,25 @@ export default function ListenDetailPage() {
       if (isCloudListenMode) {
         raSetPlaying(true);
         setTtsError(null);
-        void speakWithSelectedVoice(sentenceText, { rate: speed }).catch(() => {
-          raSetPlaying(false);
-          setTtsError(t.errors.ttsFailed);
-        });
+        void speakWithSelectedVoice(sentenceText, { rate: speed })
+          .then((result) => {
+            if (isSpeechSynthesisUtteranceResult(result)) {
+              attachWordBoundaryTracking(result, {
+                startWordIndex,
+                onWord: raSetCurrentWordIndex,
+                onEnd: () => {
+                  raSetPlaying(false);
+                },
+                onError: () => {
+                  raSetPlaying(false);
+                },
+              });
+            }
+          })
+          .catch(() => {
+            raSetPlaying(false);
+            setTtsError(t.errors.ttsFailed);
+          });
         return;
       }
 
@@ -809,6 +868,7 @@ export default function ListenDetailPage() {
           <p className="text-sm text-slate-500">{t.notFound.description}</p>
           <Link
             href="/library"
+            prefetch={false}
             className="mt-2 inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 transition-colors"
           >
             {t.notFound.goToLibrary}
@@ -877,7 +937,7 @@ export default function ListenDetailPage() {
       )}
       {!isIOSNativeHost && (
         <div className="flex items-center gap-3">
-          <Link href="/listen">
+          <Link href="/listen" prefetch={false}>
             <Button
               variant="ghost"
               size="icon"
@@ -956,12 +1016,6 @@ export default function ListenDetailPage() {
 
           {ttsError && (
             <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{ttsError}</div>
-          )}
-
-          {playbackNotice && (
-            <div className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
-              {playbackNotice}
-            </div>
           )}
 
           {listenMode === 'repeat' && activeSentence && (

--- a/src/app/(app)/listen/[id]/page.tsx
+++ b/src/app/(app)/listen/[id]/page.tsx
@@ -79,8 +79,8 @@ export default function ListenDetailPage() {
   const [dictationResult, setDictationResult] = useState<ReturnType<typeof scoreDictationAttempt> | null>(null);
   const nativeQAScreenshotStateAppliedRef = useRef(false);
   const listenStartRef = useRef<number | null>(null);
-  const kokoroPlaybackStartedRef = useRef(false);
-  const kokoroShouldPersistCompletionRef = useRef(false);
+  const cloudPlaybackStartedRef = useRef(false);
+  const cloudShouldPersistCompletionRef = useRef(false);
   const sentenceHighlightTimersRef = useRef<number[]>([]);
   const alignmentPlayerRef = useRef<WordAlignmentPlayer | null>(null);
   const alignmentAbortRef = useRef<AbortController | null>(null);
@@ -96,7 +96,7 @@ export default function ListenDetailPage() {
     boundaryPlaybackNotice,
     resolvedVoiceSource,
   } = useTTS();
-  const { speed, setSpeed, voiceURI, kokoroVoiceName } = useTTSStore();
+  const { speed, setSpeed, voiceURI, edgeVoiceName } = useTTSStore();
   const showTranslation = usePracticeTranslationStore((s) => s.visibility.listen);
   const targetLang = useTTSStore((s) => s.targetLang);
   const recommendationsEnabled = useTTSStore((s) => s.recommendationsEnabled);
@@ -232,7 +232,7 @@ export default function ListenDetailPage() {
     function handleGlobalStop() {
       raResetProgress();
       stopAlignmentPlayer();
-      kokoroPlaybackStartedRef.current = false;
+      cloudPlaybackStartedRef.current = false;
     }
 
     window.addEventListener('echotype:stop-tts', handleGlobalStop);
@@ -243,12 +243,10 @@ export default function ListenDetailPage() {
   const duration = content ? estimateListenDuration(content.text, speed) : 0;
 
   const browserVoice = browserVoices.find((voice) => voice.voiceURI === voiceURI);
-  const isCloudListenMode =
-    resolvedVoiceSource === 'kokoro' || resolvedVoiceSource === 'fish' || resolvedVoiceSource === 'edge';
-  const cloudSourceLabel =
-    resolvedVoiceSource === 'fish' ? 'Fish Audio' : resolvedVoiceSource === 'edge' ? 'Edge TTS' : 'Kokoro';
+  const isCloudListenMode = resolvedVoiceSource === 'fish' || resolvedVoiceSource === 'edge';
+  const cloudSourceLabel = resolvedVoiceSource === 'fish' ? 'Fish Audio' : 'Edge TTS';
   const activeListenVoiceName = isCloudListenMode
-    ? currentVoice?.name || kokoroVoiceName || cloudSourceLabel
+    ? currentVoice?.name || edgeVoiceName || cloudSourceLabel
     : browserVoice?.name;
   const playbackNotice =
     isCloudListenMode && !hasWordAlignment
@@ -335,28 +333,15 @@ export default function ListenDetailPage() {
         player.start();
         setHasWordAlignment(true);
 
-        const {
-          voiceSource: vs,
-          fishVoiceId: fvId,
-          kokoroVoiceId: kvId,
-          edgeVoiceId: evId,
-          speed: spd,
-        } = useTTSStore.getState();
-        const voiceId = vs === 'fish' ? fvId : vs === 'kokoro' ? kvId : evId;
+        const { voiceSource: vs, fishVoiceId: fvId, edgeVoiceId: evId, speed: spd } = useTTSStore.getState();
+        const voiceId = vs === 'fish' ? fvId : evId;
         const duration = audio.duration || matched[matched.length - 1]?.end || 0;
         void setAlignmentCache(contentId, voiceId, spd, matched, duration);
         return;
       }
 
-      const {
-        voiceSource: vs,
-        fishVoiceId: fvId,
-        kokoroVoiceId: kvId,
-        edgeVoiceId: evId,
-        speed: spd,
-        groqApiKey,
-      } = useTTSStore.getState();
-      const voiceId = vs === 'fish' ? fvId : vs === 'kokoro' ? kvId : evId;
+      const { voiceSource: vs, fishVoiceId: fvId, edgeVoiceId: evId, speed: spd, groqApiKey } = useTTSStore.getState();
+      const voiceId = vs === 'fish' ? fvId : evId;
 
       const cached = await getAlignmentCache(contentId, voiceId, spd);
       if (cached) {
@@ -434,7 +419,7 @@ export default function ListenDetailPage() {
     [createUtterance, persistListenSession, raSetCurrentWordIndex, raSetPlaying, raResetProgress],
   );
 
-  const startKokoroSentenceHighlight = useCallback(
+  const startCloudSentenceHighlight = useCallback(
     (rate: number) => {
       clearSentenceHighlightTimers();
       if (raSentences.length === 0) return;
@@ -465,22 +450,22 @@ export default function ListenDetailPage() {
     if (!isCloudListenMode) return;
 
     if (isTTSPlaying) {
-      kokoroPlaybackStartedRef.current = true;
+      cloudPlaybackStartedRef.current = true;
       if (!raIsPlaying) {
         raSetPlaying(true);
       }
       return;
     }
 
-    if (raIsPlaying && kokoroPlaybackStartedRef.current) {
+    if (raIsPlaying && cloudPlaybackStartedRef.current) {
       raResetProgress();
       clearSentenceHighlightTimers();
       stopAlignmentPlayer();
-      if (kokoroShouldPersistCompletionRef.current) {
+      if (cloudShouldPersistCompletionRef.current) {
         persistListenSession();
       }
-      kokoroPlaybackStartedRef.current = false;
-      kokoroShouldPersistCompletionRef.current = false;
+      cloudPlaybackStartedRef.current = false;
+      cloudShouldPersistCompletionRef.current = false;
     }
   }, [
     clearSentenceHighlightTimers,
@@ -511,19 +496,19 @@ export default function ListenDetailPage() {
         persistListenSession();
       }
 
-      kokoroShouldPersistCompletionRef.current = false;
+      cloudShouldPersistCompletionRef.current = false;
       clearSentenceHighlightTimers();
       stopAlignmentPlayer();
       stop();
       raResetProgress();
-      kokoroPlaybackStartedRef.current = false;
+      cloudPlaybackStartedRef.current = false;
     } else {
       if (isCloudListenMode) {
         listenStartRef.current = Date.now();
-        kokoroShouldPersistCompletionRef.current = true;
+        cloudShouldPersistCompletionRef.current = true;
         raSetPlaying(true);
         setTtsError(null);
-        kokoroPlaybackStartedRef.current = false;
+        cloudPlaybackStartedRef.current = false;
 
         void (async () => {
           try {
@@ -531,7 +516,7 @@ export default function ListenDetailPage() {
             if (result && 'blob' in result && result.blob && result.audio) {
               const wordTimestamps = 'wordTimestamps' in result ? result.wordTimestamps : undefined;
               if (!wordTimestamps?.length) {
-                startKokoroSentenceHighlight(speed);
+                startCloudSentenceHighlight(speed);
               }
               void startLazyAlignment(result.blob, result.audio, content.text, content.id, wordTimestamps);
             }
@@ -539,7 +524,7 @@ export default function ListenDetailPage() {
             clearSentenceHighlightTimers();
             stopAlignmentPlayer();
             raSetPlaying(false);
-            kokoroPlaybackStartedRef.current = false;
+            cloudPlaybackStartedRef.current = false;
             setTtsError(t.errors.ttsFailed);
           }
         })();
@@ -560,7 +545,7 @@ export default function ListenDetailPage() {
     raResetProgress,
     isCloudListenMode,
     raSetPlaying,
-    startKokoroSentenceHighlight,
+    startCloudSentenceHighlight,
     speakWithSelectedVoice,
     speakWithWordHighlight,
     startLazyAlignment,
@@ -569,22 +554,22 @@ export default function ListenDetailPage() {
 
   const handlePause = useCallback(() => {
     if (!content || !raIsPlaying) return;
-    kokoroShouldPersistCompletionRef.current = false;
+    cloudShouldPersistCompletionRef.current = false;
     clearSentenceHighlightTimers();
     stopAlignmentPlayer();
     stop();
     raSetPlaying(false);
-    kokoroPlaybackStartedRef.current = false;
+    cloudPlaybackStartedRef.current = false;
   }, [content, raIsPlaying, clearSentenceHighlightTimers, stopAlignmentPlayer, stop, raSetPlaying]);
 
   const handleWordClick = useCallback(
     (word: string) => {
-      kokoroShouldPersistCompletionRef.current = false;
+      cloudShouldPersistCompletionRef.current = false;
       clearSentenceHighlightTimers();
       stopAlignmentPlayer();
       stop();
       raSetPlaying(false);
-      kokoroPlaybackStartedRef.current = false;
+      cloudPlaybackStartedRef.current = false;
       if (isCloudListenMode) {
         void speakWithSelectedVoice(word, { rate: speed });
         return;
@@ -606,15 +591,15 @@ export default function ListenDetailPage() {
 
   const handleRestart = useCallback(() => {
     if (!content) return;
-    kokoroShouldPersistCompletionRef.current = false;
+    cloudShouldPersistCompletionRef.current = false;
     clearSentenceHighlightTimers();
     stopAlignmentPlayer();
     stop();
     raResetProgress();
-    kokoroPlaybackStartedRef.current = false;
+    cloudPlaybackStartedRef.current = false;
     if (isCloudListenMode) {
       listenStartRef.current = Date.now();
-      kokoroShouldPersistCompletionRef.current = true;
+      cloudShouldPersistCompletionRef.current = true;
       raSetPlaying(true);
 
       void (async () => {
@@ -622,7 +607,7 @@ export default function ListenDetailPage() {
         if (result && 'blob' in result && result.blob && result.audio) {
           const wordTimestamps = 'wordTimestamps' in result ? result.wordTimestamps : undefined;
           if (!wordTimestamps?.length) {
-            startKokoroSentenceHighlight(speed);
+            startCloudSentenceHighlight(speed);
           }
           void startLazyAlignment(result.blob, result.audio, content.text, content.id, wordTimestamps);
         }
@@ -638,7 +623,7 @@ export default function ListenDetailPage() {
     raResetProgress,
     isCloudListenMode,
     raSetPlaying,
-    startKokoroSentenceHighlight,
+    startCloudSentenceHighlight,
     speed,
     speakWithSelectedVoice,
     speakWithWordHighlight,
@@ -647,11 +632,11 @@ export default function ListenDetailPage() {
 
   const playSentenceSegment = useCallback(
     (sentenceText: string, startWordIndex: number) => {
-      kokoroShouldPersistCompletionRef.current = false;
+      cloudShouldPersistCompletionRef.current = false;
       clearSentenceHighlightTimers();
       stopAlignmentPlayer();
       stop();
-      kokoroPlaybackStartedRef.current = false;
+      cloudPlaybackStartedRef.current = false;
       raSetCurrentWordIndex(startWordIndex);
 
       if (isCloudListenMode) {

--- a/src/app/(app)/listen/[id]/page.tsx
+++ b/src/app/(app)/listen/[id]/page.tsx
@@ -166,6 +166,15 @@ export default function ListenDetailPage() {
   useEffect(() => {
     if (!bootstrapReady) return;
 
+    const storeItems = useContentStore.getState().items;
+    const itemFromStore = storeItems.find((item) => item.id === params.id);
+
+    if (itemFromStore) {
+      setContent(itemFromStore);
+      setContentNotFound(false);
+      return;
+    }
+
     async function load() {
       const item = await db.contents.get(params.id as string);
       if (item) {

--- a/src/app/(app)/read/[id]/page.tsx
+++ b/src/app/(app)/read/[id]/page.tsx
@@ -205,23 +205,42 @@ export default function ReadDetailPage() {
   }, []);
 
   useEffect(() => {
-    if (!bootstrapReady) return;
+    const contentId = typeof params.id === 'string' ? params.id : null;
+    if (!contentId) {
+      setContent(null);
+      setContentNotFound(true);
+      return;
+    }
 
-    // Try to get from store first (instant), fallback to DB if not found
-    const storeItems = useContentStore.getState().items;
-    const itemFromStore = storeItems.find((item) => item.id === params.id);
-
+    const itemFromStore = useContentStore.getState().items.find((item) => item.id === contentId);
     if (itemFromStore) {
       setContent(itemFromStore);
       setContentNotFound(false);
-    } else {
-      db.contents.get(params.id as string).then((item) => {
-        if (item) {
-          setContent(item);
-          setContentNotFound(false);
-        } else setContentNotFound(true);
-      });
+      return;
     }
+
+    setContent((current) => (current?.id === contentId ? current : null));
+    setContentNotFound(false);
+
+    let cancelled = false;
+
+    void db.contents.get(contentId).then((item) => {
+      if (cancelled) return;
+
+      if (item) {
+        setContent(item);
+        setContentNotFound(false);
+        return;
+      }
+
+      if (bootstrapReady) {
+        setContentNotFound(true);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
   }, [bootstrapReady, params.id]);
 
   useEffect(() => {
@@ -913,6 +932,7 @@ export default function ReadDetailPage() {
           <p className="text-sm text-slate-500">{t.notFound.description}</p>
           <Link
             href="/library"
+            prefetch={false}
             className="mt-2 inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 transition-colors"
           >
             {t.notFound.goToLibrary}
@@ -968,7 +988,7 @@ export default function ReadDetailPage() {
       )}
       {!isIOSNativeHost && (
         <div className="flex items-center gap-3 md:gap-4 py-3 md:py-4 shrink-0">
-          <Link href="/read">
+          <Link href="/read" prefetch={false}>
             <Button variant="ghost" size="icon" className="text-indigo-600 cursor-pointer">
               <ArrowLeft className="w-5 h-5" />
             </Button>

--- a/src/app/(app)/read/[id]/page.tsx
+++ b/src/app/(app)/read/[id]/page.tsx
@@ -49,7 +49,7 @@ import {
 import { estimateSentenceHighlightTimings } from '@/lib/listen-highlight';
 import { attachWordBoundaryTracking, isSpeechSynthesisUtteranceResult } from '@/lib/read-aloud-playback';
 import { matchesShortcutEvent } from '@/lib/shortcut-utils';
-import { detectIOSNativeHost, IS_NATIVE_HOST, IS_TAURI, reportNativeQAState } from '@/lib/tauri';
+import { detectIOSNativeHost, IS_TAURI, reportNativeQAState } from '@/lib/tauri';
 import { cn } from '@/lib/utils';
 import { fetchAlignment, matchTimestampsToText, WordAlignmentPlayer } from '@/lib/word-alignment';
 import { useContentStore } from '@/stores/content-store';
@@ -449,8 +449,7 @@ export default function ReadDetailPage() {
   const raIsPlaying = useReadAloudStore((s) => s.isPlaying);
   const raSentences = useReadAloudStore((s) => s.sentences);
 
-  const isCloudReadMode =
-    resolvedVoiceSource === 'kokoro' || resolvedVoiceSource === 'fish' || resolvedVoiceSource === 'edge';
+  const isCloudReadMode = resolvedVoiceSource === 'fish' || resolvedVoiceSource === 'edge';
   const cloudPlaybackStartedRef = useRef(false);
   const alignmentPlayerRef = useRef<WordAlignmentPlayer | null>(null);
   const alignmentAbortRef = useRef<AbortController | null>(null);
@@ -491,28 +490,15 @@ export default function ReadDetailPage() {
         alignmentPlayerRef.current = player;
         player.start();
 
-        const {
-          voiceSource: vs,
-          fishVoiceId: fvId,
-          kokoroVoiceId: kvId,
-          edgeVoiceId: evId,
-          speed: spd,
-        } = useTTSStore.getState();
-        const voiceId = vs === 'fish' ? fvId : vs === 'kokoro' ? kvId : evId;
+        const { voiceSource: vs, fishVoiceId: fvId, edgeVoiceId: evId, speed: spd } = useTTSStore.getState();
+        const voiceId = vs === 'fish' ? fvId : evId;
         const duration = audio.duration || matched[matched.length - 1]?.end || 0;
         void setAlignmentCache(contentId, voiceId, spd, matched, duration);
         return;
       }
 
-      const {
-        voiceSource: vs,
-        fishVoiceId: fvId,
-        kokoroVoiceId: kvId,
-        edgeVoiceId: evId,
-        speed: spd,
-        groqApiKey,
-      } = useTTSStore.getState();
-      const voiceId = vs === 'fish' ? fvId : vs === 'kokoro' ? kvId : evId;
+      const { voiceSource: vs, fishVoiceId: fvId, edgeVoiceId: evId, speed: spd, groqApiKey } = useTTSStore.getState();
+      const voiceId = vs === 'fish' ? fvId : evId;
 
       const cached = await getAlignmentCache(contentId, voiceId, spd);
       if (cached) {
@@ -763,6 +749,7 @@ export default function ReadDetailPage() {
     isCloudReadMode,
     ttsSpeak,
     speed,
+    raSetCurrentWordIndex,
     startLazyAlignment,
   ]);
 
@@ -833,6 +820,7 @@ export default function ReadDetailPage() {
     isCloudReadMode,
     ttsSpeak,
     speed,
+    raSetCurrentWordIndex,
     startLazyAlignment,
   ]);
 

--- a/src/app/(app)/review/today/page.tsx
+++ b/src/app/(app)/review/today/page.tsx
@@ -2,7 +2,7 @@
 
 import { ArrowLeft, CheckCircle2, Clock3, RotateCcw } from 'lucide-react';
 import Link from 'next/link';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { IOSInlineChatButton } from '@/components/chat/ios-inline-chat-button';
 import { RatingButtons } from '@/components/review/rating-buttons';
 import {
@@ -40,11 +40,18 @@ export default function TodayReviewPage() {
   const [items, setItems] = useState<TodayReviewItem[]>([]);
   const [baselineCount, setBaselineCount] = useState(0);
   const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
   const [showRating, setShowRating] = useState(false);
   const [ratingItem, setRatingItem] = useState<TodayReviewItem | null>(null);
+  const hasLoadedOnceRef = useRef(false);
 
   const loadQueue = useCallback(async () => {
-    setLoading(true);
+    const backgroundRefresh = hasLoadedOnceRef.current;
+    if (backgroundRefresh) {
+      setRefreshing(true);
+    } else {
+      setLoading(true);
+    }
     try {
       const now = Date.now();
       const nextItems = await getTodayReviewItems(now);
@@ -61,6 +68,8 @@ export default function TodayReviewPage() {
       setBaselineCount(nextBaseline);
     } finally {
       setLoading(false);
+      setRefreshing(false);
+      hasLoadedOnceRef.current = true;
     }
   }, []);
 
@@ -191,7 +200,11 @@ export default function TodayReviewPage() {
               }
               onClick={() => void loadQueue()}
             >
-              <RotateCcw className="w-4 h-4 mr-1" />
+              {refreshing ? (
+                <RotateCcw className="w-4 h-4 mr-1 animate-spin" />
+              ) : (
+                <RotateCcw className="w-4 h-4 mr-1" />
+              )}
               {messages.progress.refresh}
             </Button>
           </div>

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -1572,10 +1572,6 @@ function SettingsContent() {
     setFishApiKey,
     fishModel,
     setFishModel,
-    kokoroServerUrl,
-    setKokoroServerUrl,
-    kokoroApiKey,
-    setKokoroApiKey,
     groqApiKey,
     setGroqApiKey,
     targetLang,
@@ -1595,8 +1591,8 @@ function SettingsContent() {
   const [authSuccess, setAuthSuccess] = useState<string | null>(null);
   const [oauthSuccessProvider, setOauthSuccessProvider] = useState<ProviderId | undefined>();
   const [showFishKey, setShowFishKey] = useState(false);
-  const [showKokoroKey, setShowKokoroKey] = useState(false);
   const [showGroqKey, setShowGroqKey] = useState(false);
+  const [showVoicePicker, setShowVoicePicker] = useState(false);
 
   const {
     speechSuperAppKey,
@@ -1632,6 +1628,22 @@ function SettingsContent() {
     void hydrateProviders();
     hydratePronunciation();
   }, [hydrateProviders, hydratePronunciation]);
+
+  useEffect(() => {
+    const win = window as Window &
+      typeof globalThis & {
+        requestIdleCallback?: (callback: IdleRequestCallback, options?: IdleRequestOptions) => number;
+        cancelIdleCallback?: (handle: number) => void;
+      };
+
+    if (typeof win.requestIdleCallback === 'function') {
+      const handle = win.requestIdleCallback(() => setShowVoicePicker(true), { timeout: 1200 });
+      return () => win.cancelIdleCallback?.(handle);
+    }
+
+    const handle = window.setTimeout(() => setShowVoicePicker(true), 300);
+    return () => window.clearTimeout(handle);
+  }, []);
 
   // Handle OAuth callback redirect
   useEffect(() => {
@@ -1771,7 +1783,7 @@ function SettingsContent() {
         <div className="space-y-5">
           <div className="space-y-2">
             <p className="text-sm font-medium text-slate-700">{voiceMessages.sourceTitle}</p>
-            <div className="grid gap-2 grid-cols-2 md:grid-cols-4">
+            <div className="grid gap-2 grid-cols-2 md:grid-cols-3">
               {[
                 {
                   id: 'browser' as const,
@@ -1782,11 +1794,6 @@ function SettingsContent() {
                   id: 'fish' as const,
                   title: voiceMessages.fishTitle,
                   description: voiceMessages.fishDescription,
-                },
-                {
-                  id: 'kokoro' as const,
-                  title: voiceMessages.kokoroTitle,
-                  description: voiceMessages.kokoroDescription,
                 },
                 {
                   id: 'edge' as const,
@@ -1956,64 +1963,6 @@ function SettingsContent() {
             </div>
           )}
 
-          {voiceSource === 'kokoro' && (
-            <div className="space-y-4 rounded-2xl border border-indigo-100 bg-indigo-50/60 p-4">
-              <div className="flex items-start justify-between gap-3">
-                <div>
-                  <p className="text-sm font-semibold text-indigo-950">{voiceMessages.kokoroRemoteVoicesTitle}</p>
-                  <p className="mt-1 text-xs leading-relaxed text-indigo-700">
-                    {voiceMessages.kokoroRemoteVoicesDescription}
-                  </p>
-                </div>
-                <a
-                  href={`${kokoroServerUrl.replace(/\/+$/, '')}/v1/audio/voices`}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="inline-flex items-center gap-1 rounded-lg border border-indigo-200 bg-white px-2.5 py-1.5 text-xs font-medium text-indigo-700 hover:bg-indigo-100"
-                >
-                  {voiceMessages.voicesApi}
-                  <ExternalLink className="h-3 w-3" />
-                </a>
-              </div>
-
-              <div className="space-y-2">
-                <p className="text-sm font-medium text-slate-700">{voiceMessages.kokoroServerUrlLabel}</p>
-                <Input
-                  value={kokoroServerUrl}
-                  onChange={(e) => setKokoroServerUrl(e.target.value)}
-                  placeholder="http://54.166.253.41:8880"
-                  className="bg-white border-indigo-200"
-                />
-                <p className="text-[11px] text-indigo-700">{voiceMessages.kokoroServerUrlHelp}</p>
-              </div>
-
-              <div className="space-y-2">
-                <p className="text-sm font-medium text-slate-700">{voiceMessages.kokoroApiKeyLabel}</p>
-                <div className="relative">
-                  <Input
-                    type={showKokoroKey ? 'text' : 'password'}
-                    value={kokoroApiKey}
-                    onChange={(e) => setKokoroApiKey(e.target.value)}
-                    placeholder={voiceMessages.kokoroApiKeyPlaceholder}
-                    className="pr-10 bg-white border-indigo-200"
-                  />
-                  <button
-                    type="button"
-                    onClick={() => setShowKokoroKey((value) => !value)}
-                    className="absolute inset-y-0 right-0 flex items-center px-3 text-slate-400 hover:text-slate-600 cursor-pointer"
-                    aria-label={showKokoroKey ? voiceMessages.hideKokoroApiKey : voiceMessages.showKokoroApiKey}
-                  >
-                    {showKokoroKey ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-                  </button>
-                </div>
-              </div>
-
-              <div className="rounded-xl border border-amber-200 bg-amber-50 px-3 py-2.5 text-xs leading-relaxed text-amber-800">
-                {voiceMessages.browserFallbackWarning}
-              </div>
-            </div>
-          )}
-
           {voiceSource === 'edge' && (
             <div className="space-y-3 rounded-2xl border border-indigo-100 bg-indigo-50/60 p-4">
               <div>
@@ -2026,7 +1975,14 @@ function SettingsContent() {
             </div>
           )}
 
-          <VoicePicker />
+          {showVoicePicker ? (
+            <VoicePicker />
+          ) : (
+            <div className="flex items-center justify-center gap-2 rounded-xl border border-slate-200 bg-slate-50/80 px-4 py-6 text-sm text-slate-500">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Loading voices...
+            </div>
+          )}
           <div>
             <div className="flex items-center justify-between mb-2">
               <p className="text-sm font-medium text-slate-700">{voiceMessages.speed}</p>
@@ -2059,7 +2015,7 @@ function SettingsContent() {
             <Slider value={[volume]} onValueChange={(v) => setVolume(v[0])} min={0} max={1} step={0.1} />
           </div>
 
-          {(voiceSource === 'fish' || voiceSource === 'kokoro') && (
+          {voiceSource === 'fish' && (
             <div className="rounded-2xl border border-slate-200 bg-slate-50/80 p-4 space-y-3">
               <div>
                 <p className="text-sm font-semibold text-slate-800">{voiceMessages.wordAlignmentTitle}</p>

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -30,18 +30,14 @@ import {
   X,
   Zap,
 } from 'lucide-react';
+import dynamic from 'next/dynamic';
 import Link from 'next/link';
 import { Suspense, type SyntheticEvent, useCallback, useEffect, useRef, useState } from 'react';
-import { AssessmentSection } from '@/components/assessment/assessment-section';
 import { IOSInlineChatButton } from '@/components/chat/ios-inline-chat-button';
 import { OllamaWarningBanner } from '@/components/ollama/ollama-warning-banner';
-import { AboutSection } from '@/components/settings/about-section';
 import { AppearanceSection } from '@/components/settings/appearance-section';
-import { DataBackup } from '@/components/settings/data-backup';
 import { LanguageSection } from '@/components/settings/language-section';
 import { Section } from '@/components/settings/section';
-import { ShortcutSettings } from '@/components/settings/shortcut-settings';
-import { TagManagement } from '@/components/settings/tag-management';
 import {
   IOS_EYEBROW_CLASS,
   IOS_SECTION_CARD_CLASS,
@@ -57,7 +53,6 @@ import { Input } from '@/components/ui/input';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Slider } from '@/components/ui/slider';
-import { VoicePicker } from '@/components/voice-picker';
 import { getLocalizedFishAudioModels } from '@/lib/fish-audio-shared';
 import { useI18n } from '@/lib/i18n/use-i18n';
 import {
@@ -94,6 +89,46 @@ import { useShadowReadingStore } from '@/stores/shadow-reading-store';
 import { useSyncStore } from '@/stores/sync-store';
 import { useTTSStore } from '@/stores/tts-store';
 import type { PracticeModule } from '@/types/translation';
+
+function SettingsChunkPlaceholder({ label }: { label: string }) {
+  return (
+    <div className="flex items-center justify-center gap-2 rounded-xl border border-slate-200 bg-slate-50/80 px-4 py-6 text-sm text-slate-500">
+      <Loader2 className="h-4 w-4 animate-spin" />
+      {label}
+    </div>
+  );
+}
+
+const AssessmentSection = dynamic(
+  () => import('@/components/assessment/assessment-section').then((mod) => mod.AssessmentSection),
+  {
+    loading: () => <SettingsChunkPlaceholder label="Loading assessment..." />,
+  },
+);
+
+const VoicePicker = dynamic(() => import('@/components/voice-picker').then((mod) => mod.VoicePicker), {
+  ssr: false,
+  loading: () => <SettingsChunkPlaceholder label="Loading voices..." />,
+});
+
+const ShortcutSettings = dynamic(
+  () => import('@/components/settings/shortcut-settings').then((mod) => mod.ShortcutSettings),
+  {
+    loading: () => <SettingsChunkPlaceholder label="Loading shortcuts..." />,
+  },
+);
+
+const DataBackup = dynamic(() => import('@/components/settings/data-backup').then((mod) => mod.DataBackup), {
+  loading: () => <SettingsChunkPlaceholder label="Loading backup tools..." />,
+});
+
+const TagManagement = dynamic(() => import('@/components/settings/tag-management').then((mod) => mod.TagManagement), {
+  loading: () => <SettingsChunkPlaceholder label="Loading tag tools..." />,
+});
+
+const AboutSection = dynamic(() => import('@/components/settings/about-section').then((mod) => mod.AboutSection), {
+  loading: () => <SettingsChunkPlaceholder label="Loading app info..." />,
+});
 
 // ─── Provider brand styles ────────────────────────────────────────────────────
 

--- a/src/app/(app)/write/[id]/page.tsx
+++ b/src/app/(app)/write/[id]/page.tsx
@@ -123,6 +123,16 @@ export default function WriteDetailPage() {
   useEffect(() => {
     if (!bootstrapReady) return;
 
+    const storeItems = useContentStore.getState().items;
+    const itemFromStore = storeItems.find((item) => item.id === params.id);
+
+    if (itemFromStore) {
+      setContent(itemFromStore);
+      setContentNotFound(false);
+      dispatch({ type: 'INIT', text: itemFromStore.text });
+      return;
+    }
+
     async function load() {
       const item = await db.contents.get(params.id as string);
       if (item) {

--- a/src/app/(app)/write/[id]/page.tsx
+++ b/src/app/(app)/write/[id]/page.tsx
@@ -121,11 +121,14 @@ export default function WriteDetailPage() {
   }, []);
 
   useEffect(() => {
-    if (!bootstrapReady) return;
+    const contentId = typeof params.id === 'string' ? params.id : null;
+    if (!contentId) {
+      setContent(null);
+      setContentNotFound(true);
+      return;
+    }
 
-    const storeItems = useContentStore.getState().items;
-    const itemFromStore = storeItems.find((item) => item.id === params.id);
-
+    const itemFromStore = useContentStore.getState().items.find((item) => item.id === contentId);
     if (itemFromStore) {
       setContent(itemFromStore);
       setContentNotFound(false);
@@ -133,17 +136,32 @@ export default function WriteDetailPage() {
       return;
     }
 
+    setContent((current) => (current?.id === contentId ? current : null));
+    setContentNotFound(false);
+
+    let cancelled = false;
+
     async function load() {
-      const item = await db.contents.get(params.id as string);
+      const item = await db.contents.get(contentId);
+      if (cancelled) return;
+
       if (item) {
         setContent(item);
         setContentNotFound(false);
         dispatch({ type: 'INIT', text: item.text });
-      } else {
+        return;
+      }
+
+      if (bootstrapReady) {
         setContentNotFound(true);
       }
     }
-    load();
+
+    void load();
+
+    return () => {
+      cancelled = true;
+    };
   }, [bootstrapReady, params.id]);
 
   useEffect(() => {
@@ -347,6 +365,7 @@ export default function WriteDetailPage() {
           <p className="text-sm text-slate-500">This content may have been deleted or the link is invalid.</p>
           <Link
             href="/library"
+            prefetch={false}
             className="mt-2 inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 transition-colors"
           >
             Go to Library
@@ -412,7 +431,7 @@ export default function WriteDetailPage() {
       )}
       {!isIOSNativeHost && (
         <div className="flex items-center gap-4">
-          <Link href="/write">
+          <Link href="/write" prefetch={false}>
             <Button variant="ghost" size="icon" className="text-indigo-600 cursor-pointer">
               <ArrowLeft className="w-5 h-5" />
             </Button>

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -74,6 +74,7 @@ function NavLink({
       const link = (
         <Link
           href={item.href}
+          prefetch={false}
           className={cn(
             'flex items-center gap-2.5 rounded-lg text-sm transition-colors duration-150 cursor-pointer select-none',
             collapsed ? 'justify-center px-2 py-2' : 'px-3 py-2',
@@ -106,6 +107,7 @@ function NavLink({
       const link = (
         <Link
           href={item.href}
+          prefetch={false}
           className={cn(
             'flex items-center justify-center px-2 py-2 rounded-lg text-sm transition-colors duration-150 cursor-pointer select-none',
             active
@@ -166,6 +168,7 @@ function NavLink({
   return (
     <Link
       href={item.href}
+      prefetch={false}
       className={cn(
         'flex items-center gap-2 px-2 py-1.5 rounded-md text-[13px] transition-colors duration-150 cursor-pointer',
         childActive

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -295,7 +295,7 @@ export function Sidebar({ open = false, onOpenChange }: SidebarProps = {}) {
 
       {/* Logo */}
       <div className={cn('border-b border-slate-100', collapsed ? 'px-2 py-4' : 'px-4 py-4')}>
-        <Link href="/" className="flex items-center gap-2.5 cursor-pointer group">
+        <Link href="/" prefetch={false} className="flex items-center gap-2.5 cursor-pointer group">
           <div className="w-8 h-8 rounded-xl bg-gradient-to-br from-indigo-500 to-violet-600 flex items-center justify-center shadow-sm shadow-indigo-200 shrink-0">
             <Zap className="w-4 h-4 text-white" />
           </div>

--- a/src/components/shared/content-list.tsx
+++ b/src/components/shared/content-list.tsx
@@ -110,13 +110,13 @@ function EmptyState({
         <p className="text-sm text-indigo-400 mt-1 max-w-xs">{clMessages.empty.description}</p>
       </div>
       <div className="flex gap-3">
-        <Link href="/library/wordbooks">
+        <Link href="/library/wordbooks" prefetch={false}>
           <Button size="sm" className="bg-indigo-600 hover:bg-indigo-700 cursor-pointer">
             <BookMarked className="w-4 h-4 mr-1.5" />
             {clMessages.empty.wordBooks}
           </Button>
         </Link>
-        <Link href="/library/import">
+        <Link href="/library/import" prefetch={false}>
           <Button
             size="sm"
             variant="outline"
@@ -148,7 +148,7 @@ function WordBookCard({
   const diff = difficultyColors[book.difficulty];
 
   return (
-    <Link href={`/${module}/book/${book.id}`}>
+    <Link href={`/${module}/book/${book.id}`} prefetch={false}>
       <Card
         data-testid={`${module}-book-card-${book.id}`}
         className={cn(
@@ -230,7 +230,7 @@ function ContentRow({
   const { messages: srMessages } = useI18n('shadowReading');
   const isIOSNativeHost = detectIOSNativeHost();
   return (
-    <Link href={href} onClick={onNavigate}>
+    <Link href={href} prefetch={false} onClick={onNavigate}>
       <Card
         data-testid={`${module}-content-row-${item.id}`}
         className={cn(
@@ -572,7 +572,7 @@ export function ContentList({ title, description, module, icon: Icon, iconBg, ic
                 {activeTab === 'wordbook' ? clMessages.empty.importWordBooksHint : clMessages.empty.importScenariosHint}
               </p>
             </div>
-            <Link href="/library/wordbooks">
+            <Link href="/library/wordbooks" prefetch={false}>
               <Button size="sm" className="bg-indigo-600 hover:bg-indigo-700 cursor-pointer">
                 <BookMarked className="w-4 h-4 mr-1.5" />
                 {clMessages.empty.browseWordBooks}

--- a/src/components/shared/cross-module-nav.tsx
+++ b/src/components/shared/cross-module-nav.tsx
@@ -46,6 +46,7 @@ export function CrossModuleNav({ contentId, currentModule }: CrossModuleNavProps
           <Link
             key={mod}
             href={`${path}/${contentId}`}
+            prefetch={false}
             title={navT.practiceIn.replace('{{label}}', label)}
             className={cn(
               'flex items-center gap-1 px-2 py-1 rounded-lg text-xs font-medium transition-colors',

--- a/src/components/shared/practice-complete-banner.tsx
+++ b/src/components/shared/practice-complete-banner.tsx
@@ -79,7 +79,7 @@ export function PracticeCompleteBanner({ module, stats }: PracticeCompleteBanner
           </div>
         </div>
         <div className="flex gap-3 mt-4 ml-16">
-          <Link href="/dashboard">
+          <Link href="/dashboard" prefetch={false}>
             <Button size="sm" className="bg-green-600 hover:bg-green-700 cursor-pointer">
               {t.backToDashboard}
             </Button>

--- a/src/components/shared/recommendation-panel.tsx
+++ b/src/components/shared/recommendation-panel.tsx
@@ -141,6 +141,7 @@ export function RecommendationPanel({ content, text, contentType, onNavigate }: 
                     error.toLowerCase().includes('401') ? (
                       <Link
                         href="/settings"
+                        prefetch={false}
                         className="inline-flex items-center gap-1 text-xs text-indigo-500 hover:text-indigo-600 font-medium"
                       >
                         <Settings className="w-3 h-3" />

--- a/src/components/shared/shadow-reading-completion.tsx
+++ b/src/components/shared/shadow-reading-completion.tsx
@@ -129,13 +129,13 @@ export function ShadowReadingCompletion() {
         </div>
 
         <div className="px-6 pb-6 space-y-2">
-          <Link href="/library" className="block" onClick={dismissCompletion}>
+          <Link href="/library" prefetch={false} className="block" onClick={dismissCompletion}>
             <Button className="w-full bg-indigo-600 hover:bg-indigo-700 cursor-pointer">
               {compMessages.startAnother}
             </Button>
           </Link>
           <div className="grid grid-cols-2 gap-2">
-            <Link href={`/listen/${session.contentId}`} onClick={handleRepeat}>
+            <Link href={`/listen/${session.contentId}`} prefetch={false} onClick={handleRepeat}>
               <Button
                 variant="outline"
                 size="sm"
@@ -145,7 +145,7 @@ export function ShadowReadingCompletion() {
                 {compMessages.repeatPractice}
               </Button>
             </Link>
-            <Link href={`/speak/free`} onClick={dismissCompletion}>
+            <Link href={`/speak/free`} prefetch={false} onClick={dismissCompletion}>
               <Button
                 variant="outline"
                 size="sm"

--- a/src/components/shared/shadow-reading-progress-bar.tsx
+++ b/src/components/shared/shadow-reading-progress-bar.tsx
@@ -171,7 +171,11 @@ export function ShadowReadingProgressBar({
               {isCurrent ? (
                 stepContent
               ) : (
-                <Link href={`${path}/${contentId}`} title={pbMessages.practiceIn.replace('{{module}}', label)}>
+                <Link
+                  href={`${path}/${contentId}`}
+                  prefetch={false}
+                  title={pbMessages.practiceIn.replace('{{module}}', label)}
+                >
                   {stepContent}
                 </Link>
               )}
@@ -184,6 +188,7 @@ export function ShadowReadingProgressBar({
             <StepConnector status="pending" />
             <Link
               href={speakHref}
+              prefetch={false}
               className="flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-xs font-medium text-slate-300 hover:text-indigo-400 transition-colors border border-dashed border-slate-200 hover:border-indigo-200"
             >
               <Mic className="w-3.5 h-3.5" />
@@ -208,6 +213,7 @@ export function ShadowReadingProgressBar({
           >
             <Link
               href={`${MODULE_CONFIG[nextModule].path}/${contentId}`}
+              prefetch={false}
               onClick={() => setShowNextPrompt(false)}
               className="flex items-center justify-between gap-2 bg-indigo-50 hover:bg-indigo-100 border border-indigo-200 rounded-lg px-3 py-2 transition-colors group"
             >

--- a/src/components/shared/word-book-practice.tsx
+++ b/src/components/shared/word-book-practice.tsx
@@ -957,7 +957,7 @@ function WordBookCompleteScreen({
             <Button onClick={onRestart} className="bg-indigo-600 hover:bg-indigo-700 cursor-pointer">
               <RotateCcw className="w-4 h-4 mr-2" /> {t.completion.practiceAgain}
             </Button>
-            <Link href="/dashboard">
+            <Link href="/dashboard" prefetch={false}>
               <Button variant="outline" className="border-green-300 text-green-700 hover:bg-green-50 cursor-pointer">
                 {t.completion.backToDashboard}
               </Button>

--- a/src/components/translation/translation-display.tsx
+++ b/src/components/translation/translation-display.tsx
@@ -63,6 +63,7 @@ export function TranslationDisplay({
             {isApiKeyError(error) ? (
               <Link
                 href="/settings"
+                prefetch={false}
                 className="inline-flex items-center gap-1 text-xs text-indigo-500 hover:text-indigo-600 font-medium"
               >
                 <Settings className="w-3 h-3" />

--- a/src/components/voice-picker.tsx
+++ b/src/components/voice-picker.tsx
@@ -121,7 +121,6 @@ function getProviderBadge(provider: string, locale: VoicePickerLocale): string {
 
 function getSearchPlaceholder(voiceSource: string, locale: VoicePickerLocale): string {
   if (voiceSource === 'fish') return locale.search.fish;
-  if (voiceSource === 'kokoro') return locale.search.kokoro;
   if (voiceSource === 'edge') return locale.search.edge;
   return locale.search.browser;
 }
@@ -264,28 +263,15 @@ export function VoicePicker() {
     isReady,
     isSpeaking,
     isFishLoading,
-    isKokoroLoading,
     isEdgeLoading,
     fishError,
-    kokoroError,
     edgeError,
     previewingURI,
     previewVoice,
     stop,
     voiceSource,
   } = useTTS();
-  const {
-    voiceURI,
-    fishVoiceId,
-    kokoroVoiceId,
-    edgeVoiceId,
-    setVoiceURI,
-    setFishVoice,
-    setKokoroVoice,
-    setEdgeVoice,
-    fishApiKey,
-    kokoroServerUrl,
-  } = useTTSStore();
+  const { voiceURI, fishVoiceId, edgeVoiceId, setVoiceURI, setFishVoice, setEdgeVoice, fishApiKey } = useTTSStore();
   const interfaceLanguage = useLanguageStore((state) => state.interfaceLanguage);
   const [tab, setTab] = useState<BrowserVoicePickerTab>('english');
   const [edgeLocaleTab, setEdgeLocaleTab] = useState<string>('all');
@@ -318,7 +304,7 @@ export function VoicePicker() {
   }, [voiceSource, voices]);
 
   const visibleVoices = useMemo(() => {
-    if (voiceSource === 'fish' || voiceSource === 'kokoro') return voices;
+    if (voiceSource === 'fish') return voices;
     if (voiceSource === 'edge') {
       if (edgeLocaleTab === 'all') return voices;
       return voices.filter((v) => v.lang === edgeLocaleTab);
@@ -345,7 +331,7 @@ export function VoicePicker() {
     return result;
   }, [visibleVoices, searchQuery]);
 
-  if (!isReady || isFishLoading || isKokoroLoading || isEdgeLoading) {
+  if (!isReady || isFishLoading || isEdgeLoading) {
     return (
       <div className="flex items-center justify-center gap-2 py-8 text-sm text-indigo-400">
         <Loader2 className="w-4 h-4 animate-spin" />
@@ -366,22 +352,6 @@ export function VoicePicker() {
     return (
       <div className="rounded-xl border border-rose-200 bg-rose-50 px-4 py-6 text-sm text-rose-700">
         {locale.errors.fish} {fishError}
-      </div>
-    );
-  }
-
-  if (voiceSource === 'kokoro' && !kokoroServerUrl.trim()) {
-    return (
-      <div className="rounded-xl border border-dashed border-indigo-200 bg-indigo-50/70 px-4 py-6 text-sm text-indigo-700">
-        {locale.kokoroSetup}
-      </div>
-    );
-  }
-
-  if (voiceSource === 'kokoro' && kokoroError) {
-    return (
-      <div className="rounded-xl border border-rose-200 bg-rose-50 px-4 py-6 text-sm text-rose-700">
-        {locale.errors.kokoro} {kokoroError}
       </div>
     );
   }
@@ -500,18 +470,14 @@ export function VoicePicker() {
                   isSelected={
                     voiceSource === 'fish'
                       ? v.voiceURI === fishVoiceId
-                      : voiceSource === 'kokoro'
-                        ? v.voiceURI === kokoroVoiceId
-                        : voiceSource === 'edge'
-                          ? v.voiceURI === edgeVoiceId
-                          : v.voiceURI === voiceURI
+                      : voiceSource === 'edge'
+                        ? v.voiceURI === edgeVoiceId
+                        : v.voiceURI === voiceURI
                   }
                   isPreviewing={isSpeaking && previewingURI === v.voiceURI}
                   onSelect={() => {
                     if (voiceSource === 'fish') {
                       setFishVoice(v.voiceURI, v.name);
-                    } else if (voiceSource === 'kokoro') {
-                      setKokoroVoice(v.voiceURI, v.name);
                     } else if (voiceSource === 'edge') {
                       setEdgeVoice(v.voiceURI, v.name);
                     } else {
@@ -521,7 +487,7 @@ export function VoicePicker() {
                   onPreview={() => previewVoice(v.voiceURI)}
                   onStop={stop}
                 />
-                {(voiceSource === 'fish' || voiceSource === 'kokoro' || voiceSource === 'edge') && (
+                {(voiceSource === 'fish' || voiceSource === 'edge') && (
                   <div className="space-y-1 px-1 text-[11px] text-slate-500">
                     {v.authorName && (
                       <p className="truncate">

--- a/src/hooks/use-tts.ts
+++ b/src/hooks/use-tts.ts
@@ -6,7 +6,7 @@ import type { FishVoice } from '@/lib/fish-audio-shared';
 import { resolveTTSSource } from '@/lib/fish-audio-shared';
 import { getIOSNativeQAMockEdgeVoices, getIOSNativeQAMode } from '@/lib/ios-native-qa';
 import type { WordTimestamp } from '@/lib/word-alignment';
-import { useTTSStore } from '@/stores/tts-store';
+import { type TTSSource, useTTSStore } from '@/stores/tts-store';
 
 export interface VoiceOption {
   source: 'browser' | 'fish' | 'edge';
@@ -90,6 +90,11 @@ export function formatDuration(seconds: number): string {
   return secs > 0 ? `${mins}m ${secs}s` : `${mins}m`;
 }
 
+const EDGE_FALLBACK_COOLDOWN_MS = 10 * 60 * 1000;
+const EDGE_TIMEOUT_MESSAGE = 'Edge TTS timed out. Browser voice is temporarily active for stability.';
+const EDGE_UNAVAILABLE_MESSAGE =
+  'Edge TTS is temporarily unavailable. Browser voice is temporarily active for stability.';
+
 export function useTTS() {
   const { voiceSource, voiceURI, speed, pitch, volume, fishApiKey, fishVoiceId, fishModel, edgeVoiceId } =
     useTTSStore();
@@ -103,10 +108,31 @@ export function useTTS() {
   const [edgeError, setEdgeError] = useState<string | null>(null);
   const [isSpeaking, setIsSpeaking] = useState(false);
   const [previewingURI, setPreviewingURI] = useState<string | null>(null);
+  const [lastPlaybackSource, setLastPlaybackSource] = useState<TTSSource | null>(null);
+  const [lastPlaybackSourceReason, setLastPlaybackSourceReason] = useState<string | null>(null);
+  const [edgeFallbackUntil, setEdgeFallbackUntil] = useState(0);
+  const [edgeFallbackReason, setEdgeFallbackReason] = useState<string | null>(null);
   const utteranceRef = useRef<SpeechSynthesisUtterance | null>(null);
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const objectUrlRef = useRef<string | null>(null);
   const requestAbortRef = useRef<AbortController | null>(null);
+
+  const markPlaybackSource = useCallback((source: TTSSource, reason?: string | null) => {
+    setLastPlaybackSource(source);
+    setLastPlaybackSourceReason(reason ?? null);
+  }, []);
+
+  const isEdgeTemporarilyUnavailable = edgeFallbackUntil > Date.now();
+
+  const activateEdgeFallback = useCallback((message: string) => {
+    setEdgeFallbackUntil(Date.now() + EDGE_FALLBACK_COOLDOWN_MS);
+    setEdgeFallbackReason(message);
+  }, []);
+
+  const clearEdgeFallback = useCallback(() => {
+    setEdgeFallbackUntil(0);
+    setEdgeFallbackReason(null);
+  }, []);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -379,7 +405,7 @@ export function useTTS() {
     if (currentSelection) return;
 
     const preferredVoice =
-      edgeVoices.find((voice) => voice.voiceURI === 'en-US-EmmaMultilingualNeural') ??
+      edgeVoices.find((voice) => voice.voiceURI === 'en-US-JennyNeural') ??
       edgeVoices.find((voice) => voice.lang === 'en-US' && voice.voiceType === 'natural' && voice.isPremium) ??
       edgeVoices[0];
 
@@ -434,11 +460,14 @@ export function useTTS() {
   );
 
   const playBrowserSpeech = useCallback(
-    (text: string, overrides?: { rate?: number }) => {
+    (text: string, overrides?: { rate?: number }, reason?: string | null) => {
       window.speechSynthesis.cancel();
       const utterance = createUtterance(text, overrides);
       utteranceRef.current = utterance;
-      utterance.onstart = () => setIsSpeaking(true);
+      utterance.onstart = () => {
+        markPlaybackSource('browser', reason);
+        setIsSpeaking(true);
+      };
       utterance.onend = () => {
         setIsSpeaking(false);
         setPreviewingURI(null);
@@ -450,7 +479,7 @@ export function useTTS() {
       window.speechSynthesis.speak(utterance);
       return utterance;
     },
-    [createUtterance],
+    [createUtterance, markPlaybackSource],
   );
 
   const playAudioBlob = useCallback((blob: Blob): { audio: HTMLAudioElement; objectUrl: string } => {
@@ -506,46 +535,12 @@ export function useTTS() {
 
       const blob = await response.blob();
       const { audio } = playAudioBlob(blob);
+      markPlaybackSource('fish');
 
       await audio.play();
       return { blob, audio };
     },
-    [fishApiKey, fishModel, speed, stop, playAudioBlob],
-  );
-
-  const playEdgeSpeech = useCallback(
-    async (
-      text: string,
-      voiceId: string,
-      overrides?: { rate?: number },
-    ): Promise<{ blob: Blob; audio: HTMLAudioElement }> => {
-      stop();
-      const controller = new AbortController();
-      requestAbortRef.current = controller;
-
-      const response = await fetch('/api/tts/edge/speak', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          text,
-          voice: voiceId,
-          speed: overrides?.rate ?? speed,
-        }),
-        signal: controller.signal,
-      });
-
-      if (!response.ok) {
-        const data = (await response.json().catch(() => ({}))) as { error?: string };
-        throw new Error(data.error || 'Edge TTS synthesis failed.');
-      }
-
-      const blob = await response.blob();
-      const { audio } = playAudioBlob(blob);
-
-      await audio.play();
-      return { blob, audio };
-    },
-    [speed, stop, playAudioBlob],
+    [fishApiKey, fishModel, speed, stop, playAudioBlob, markPlaybackSource],
   );
 
   const synthesizeEdgeWithAlignment = useCallback(
@@ -587,11 +582,13 @@ export function useTTS() {
       }
       const blob = new Blob([bytes], { type: data.contentType });
       const { audio } = playAudioBlob(blob);
+      markPlaybackSource('edge');
+      clearEdgeFallback();
 
       await audio.play();
       return { blob, audio, wordTimestamps: data.words };
     },
-    [speed, stop, playAudioBlob],
+    [speed, stop, playAudioBlob, markPlaybackSource, clearEdgeFallback],
   );
 
   const resolvedPlayback = useMemo(
@@ -601,8 +598,10 @@ export function useTTS() {
         hasFishCredentials: Boolean(fishApiKey.trim()),
         hasFishVoice: Boolean(fishVoiceId.trim()),
         hasEdgeVoice: Boolean(edgeVoiceId.trim()),
+        edgeTemporarilyUnavailable: isEdgeTemporarilyUnavailable,
+        edgeTemporarilyUnavailableReason: edgeFallbackReason ?? undefined,
       }),
-    [voiceSource, fishApiKey, fishVoiceId, edgeVoiceId],
+    [voiceSource, fishApiKey, fishVoiceId, edgeVoiceId, isEdgeTemporarilyUnavailable, edgeFallbackReason],
   );
 
   const boundaryPlayback = useMemo(
@@ -628,21 +627,35 @@ export function useTTS() {
         try {
           return await playFishSpeech(text, fishVoiceId, overrides);
         } catch {
-          return playBrowserSpeech(text, overrides);
+          return playBrowserSpeech(text, overrides, 'Fish Audio failed. Browser voice is active for stability.');
         }
       }
 
       if (resolvedPlayback.source === 'edge') {
         try {
           return await synthesizeEdgeWithAlignment(text, edgeVoiceId, overrides);
-        } catch {
-          return playBrowserSpeech(text, overrides);
+        } catch (error) {
+          const message =
+            error instanceof Error && error.message.includes('timed out')
+              ? EDGE_TIMEOUT_MESSAGE
+              : EDGE_UNAVAILABLE_MESSAGE;
+          activateEdgeFallback(message);
+          return playBrowserSpeech(text, overrides, message);
         }
       }
 
-      return playBrowserSpeech(text, overrides);
+      return playBrowserSpeech(text, overrides, resolvedPlayback.reason ?? null);
     },
-    [resolvedPlayback.source, playFishSpeech, fishVoiceId, synthesizeEdgeWithAlignment, edgeVoiceId, playBrowserSpeech],
+    [
+      resolvedPlayback.source,
+      resolvedPlayback.reason,
+      playFishSpeech,
+      fishVoiceId,
+      synthesizeEdgeWithAlignment,
+      edgeVoiceId,
+      playBrowserSpeech,
+      activateEdgeFallback,
+    ],
   );
 
   const getAudioElement = useCallback((): HTMLAudioElement | null => {
@@ -669,10 +682,20 @@ export function useTTS() {
       }
 
       if (voiceSource === 'edge') {
-        try {
-          await playEdgeSpeech(text, uri);
+        if (isEdgeTemporarilyUnavailable) {
+          setPreviewingURI(null);
+          playBrowserSpeech(text, undefined, edgeFallbackReason ?? EDGE_UNAVAILABLE_MESSAGE);
           return;
-        } catch {
+        }
+        try {
+          await synthesizeEdgeWithAlignment(text, uri);
+          return;
+        } catch (error) {
+          activateEdgeFallback(
+            error instanceof Error && error.message.includes('timed out')
+              ? EDGE_TIMEOUT_MESSAGE
+              : EDGE_UNAVAILABLE_MESSAGE,
+          );
           setPreviewingURI(null);
         }
       }
@@ -687,7 +710,10 @@ export function useTTS() {
       utterance.lang = voice?.lang ?? 'en-US';
       if (voice) utterance.voice = voice;
       utteranceRef.current = utterance;
-      utterance.onstart = () => setIsSpeaking(true);
+      utterance.onstart = () => {
+        markPlaybackSource('browser');
+        setIsSpeaking(true);
+      };
       utterance.onend = () => {
         setIsSpeaking(false);
         setPreviewingURI(null);
@@ -698,7 +724,19 @@ export function useTTS() {
       };
       window.speechSynthesis.speak(utterance);
     },
-    [voiceSource, speed, pitch, volume, playFishSpeech, playEdgeSpeech],
+    [
+      voiceSource,
+      speed,
+      pitch,
+      volume,
+      playFishSpeech,
+      synthesizeEdgeWithAlignment,
+      isEdgeTemporarilyUnavailable,
+      edgeFallbackReason,
+      playBrowserSpeech,
+      activateEdgeFallback,
+      markPlaybackSource,
+    ],
   );
 
   const voices = useMemo(() => {
@@ -736,6 +774,8 @@ export function useTTS() {
     voiceSource,
     resolvedVoiceSource: resolvedPlayback.source,
     resolvedVoiceSourceReason: resolvedPlayback.reason ?? sourceError ?? undefined,
+    actualPlaybackSource: lastPlaybackSource,
+    actualPlaybackSourceReason: lastPlaybackSourceReason ?? undefined,
     boundaryVoiceSource: boundaryPlayback.source,
     boundaryPlaybackNotice: boundaryPlayback.reason,
     speak,

--- a/src/hooks/use-tts.ts
+++ b/src/hooks/use-tts.ts
@@ -5,12 +5,11 @@ import { getBrowserVoiceMetadata } from '@/lib/browser-voice-metadata';
 import type { FishVoice } from '@/lib/fish-audio-shared';
 import { resolveTTSSource } from '@/lib/fish-audio-shared';
 import { getIOSNativeQAMockEdgeVoices, getIOSNativeQAMode } from '@/lib/ios-native-qa';
-import type { KokoroVoice } from '@/lib/kokoro-shared';
 import type { WordTimestamp } from '@/lib/word-alignment';
 import { useTTSStore } from '@/stores/tts-store';
 
 export interface VoiceOption {
-  source: 'browser' | 'fish' | 'kokoro' | 'edge';
+  source: 'browser' | 'fish' | 'edge';
   voiceURI: string;
   name: string;
   lang: string;
@@ -26,7 +25,7 @@ export interface VoiceOption {
   tags?: string[];
   taskCount?: number;
   likeCount?: number;
-  provider?: 'apple' | 'google' | 'microsoft' | 'browser-cloud' | 'other' | 'kokoro';
+  provider?: 'apple' | 'google' | 'microsoft' | 'browser-cloud' | 'other';
   voiceType?: 'natural' | 'standard' | 'novelty';
   accent?: 'us' | 'uk' | 'au' | 'ca' | 'in' | 'ie' | 'za' | 'nz' | 'sg' | 'other-english' | 'non-english';
   isEnglish?: boolean;
@@ -78,35 +77,6 @@ function normalizeFishVoiceToOption(voice: FishVoice): VoiceOption {
   };
 }
 
-function normalizeKokoroVoiceToOption(voice: KokoroVoice): VoiceOption {
-  const accent =
-    voice.langCode === 'en-US'
-      ? 'us'
-      : voice.langCode === 'en-GB'
-        ? 'uk'
-        : voice.langCode.startsWith('en')
-          ? 'other-english'
-          : 'non-english';
-
-  return {
-    source: 'kokoro',
-    voiceURI: voice.id,
-    name: voice.name,
-    lang: voice.langCode,
-    localService: false,
-    isPremium: true,
-    label: `${voice.name} (${voice.language})`,
-    description: `${voice.language} • ${voice.gender === 'female' ? 'Female' : 'Male'} voice`,
-    languages: [voice.langCode],
-    tags: [voice.language, voice.gender],
-    provider: 'kokoro',
-    voiceType: 'natural',
-    accent,
-    isEnglish: voice.langCode.startsWith('en'),
-    isFeatured: voice.langCode.startsWith('en'),
-  };
-}
-
 export function estimateListenDuration(text: string, rate: number = 1): number {
   const words = text.trim().split(/\s+/).length;
   const wpm = 150 * rate;
@@ -121,30 +91,15 @@ export function formatDuration(seconds: number): string {
 }
 
 export function useTTS() {
-  const {
-    voiceSource,
-    voiceURI,
-    speed,
-    pitch,
-    volume,
-    fishApiKey,
-    fishVoiceId,
-    fishModel,
-    kokoroServerUrl,
-    kokoroApiKey,
-    kokoroVoiceId,
-    edgeVoiceId,
-  } = useTTSStore();
+  const { voiceSource, voiceURI, speed, pitch, volume, fishApiKey, fishVoiceId, fishModel, edgeVoiceId } =
+    useTTSStore();
   const [browserVoices, setBrowserVoices] = useState<VoiceOption[]>([]);
   const [fishVoices, setFishVoices] = useState<VoiceOption[]>([]);
-  const [kokoroVoices, setKokoroVoices] = useState<VoiceOption[]>([]);
   const [edgeVoices, setEdgeVoices] = useState<VoiceOption[]>([]);
   const [isBrowserReady, setIsBrowserReady] = useState(false);
   const [isFishLoading, setIsFishLoading] = useState(false);
-  const [isKokoroLoading, setIsKokoroLoading] = useState(false);
   const [isEdgeLoading, setIsEdgeLoading] = useState(false);
   const [fishError, setFishError] = useState<string | null>(null);
-  const [kokoroError, setKokoroError] = useState<string | null>(null);
   const [edgeError, setEdgeError] = useState<string | null>(null);
   const [isSpeaking, setIsSpeaking] = useState(false);
   const [previewingURI, setPreviewingURI] = useState<string | null>(null);
@@ -331,50 +286,6 @@ export function useTTS() {
   }, [fishApiKey, voiceSource]);
 
   useEffect(() => {
-    if (voiceSource !== 'kokoro') return;
-    if (!kokoroServerUrl.trim()) {
-      setKokoroVoices([]);
-      setKokoroError(null);
-      setIsKokoroLoading(false);
-      return;
-    }
-
-    const controller = new AbortController();
-    setIsKokoroLoading(true);
-    setKokoroError(null);
-
-    void fetch('/api/tts/kokoro/voices', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        serverUrl: kokoroServerUrl,
-        apiKey: kokoroApiKey || undefined,
-      }),
-      signal: controller.signal,
-    })
-      .then(async (response) => {
-        const data = (await response.json()) as { voices?: KokoroVoice[]; error?: string };
-        if (!response.ok) {
-          throw new Error(data.error || 'Failed to load Kokoro voices.');
-        }
-
-        setKokoroVoices((data.voices ?? []).map(normalizeKokoroVoiceToOption));
-      })
-      .catch((error) => {
-        if (error instanceof DOMException && error.name === 'AbortError') return;
-        setKokoroVoices([]);
-        setKokoroError(error instanceof Error ? error.message : 'Failed to load Kokoro voices.');
-      })
-      .finally(() => {
-        if (!controller.signal.aborted) {
-          setIsKokoroLoading(false);
-        }
-      });
-
-    return () => controller.abort();
-  }, [kokoroApiKey, kokoroServerUrl, voiceSource]);
-
-  useEffect(() => {
     if (voiceSource !== 'edge') return;
 
     if (getIOSNativeQAMode()) {
@@ -460,6 +371,22 @@ export function useTTS() {
       })
       .finally(() => setIsEdgeLoading(false));
   }, [voiceSource]);
+
+  useEffect(() => {
+    if (voiceSource !== 'edge' || edgeVoices.length === 0) return;
+
+    const currentSelection = edgeVoices.find((voice) => voice.voiceURI === edgeVoiceId);
+    if (currentSelection) return;
+
+    const preferredVoice =
+      edgeVoices.find((voice) => voice.voiceURI === 'en-US-EmmaMultilingualNeural') ??
+      edgeVoices.find((voice) => voice.lang === 'en-US' && voice.voiceType === 'natural' && voice.isPremium) ??
+      edgeVoices[0];
+
+    if (preferredVoice) {
+      useTTSStore.getState().setEdgeVoice(preferredVoice.voiceURI, preferredVoice.name);
+    }
+  }, [edgeVoices, edgeVoiceId, voiceSource]);
 
   const stop = useCallback(() => {
     requestAbortRef.current?.abort();
@@ -586,43 +513,6 @@ export function useTTS() {
     [fishApiKey, fishModel, speed, stop, playAudioBlob],
   );
 
-  const playKokoroSpeech = useCallback(
-    async (
-      text: string,
-      voiceId: string,
-      overrides?: { rate?: number },
-    ): Promise<{ blob: Blob; audio: HTMLAudioElement }> => {
-      stop();
-      const controller = new AbortController();
-      requestAbortRef.current = controller;
-
-      const response = await fetch('/api/tts/kokoro/speak', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          serverUrl: kokoroServerUrl,
-          apiKey: kokoroApiKey || undefined,
-          text,
-          voice: voiceId,
-          speed: overrides?.rate ?? speed,
-        }),
-        signal: controller.signal,
-      });
-
-      if (!response.ok) {
-        const data = (await response.json().catch(() => ({}))) as { error?: string };
-        throw new Error(data.error || 'Kokoro speech synthesis failed.');
-      }
-
-      const blob = await response.blob();
-      const { audio } = playAudioBlob(blob);
-
-      await audio.play();
-      return { blob, audio };
-    },
-    [kokoroApiKey, kokoroServerUrl, speed, stop, playAudioBlob],
-  );
-
   const playEdgeSpeech = useCallback(
     async (
       text: string,
@@ -710,11 +600,9 @@ export function useTTS() {
         requestedSource: voiceSource,
         hasFishCredentials: Boolean(fishApiKey.trim()),
         hasFishVoice: Boolean(fishVoiceId.trim()),
-        hasKokoroServerUrl: Boolean(kokoroServerUrl.trim()),
-        hasKokoroVoice: Boolean(kokoroVoiceId.trim()),
         hasEdgeVoice: Boolean(edgeVoiceId.trim()),
       }),
-    [voiceSource, fishApiKey, fishVoiceId, kokoroServerUrl, kokoroVoiceId, edgeVoiceId],
+    [voiceSource, fishApiKey, fishVoiceId, edgeVoiceId],
   );
 
   const boundaryPlayback = useMemo(
@@ -723,12 +611,10 @@ export function useTTS() {
         requestedSource: voiceSource,
         hasFishCredentials: Boolean(fishApiKey.trim()),
         hasFishVoice: Boolean(fishVoiceId.trim()),
-        hasKokoroServerUrl: Boolean(kokoroServerUrl.trim()),
-        hasKokoroVoice: Boolean(kokoroVoiceId.trim()),
         hasEdgeVoice: Boolean(edgeVoiceId.trim()),
         requiresBoundaryEvents: true,
       }),
-    [voiceSource, fishApiKey, fishVoiceId, kokoroServerUrl, kokoroVoiceId, edgeVoiceId],
+    [voiceSource, fishApiKey, fishVoiceId, edgeVoiceId],
   );
 
   const speak = useCallback(
@@ -746,14 +632,6 @@ export function useTTS() {
         }
       }
 
-      if (resolvedPlayback.source === 'kokoro') {
-        try {
-          return await playKokoroSpeech(text, kokoroVoiceId, overrides);
-        } catch {
-          return playBrowserSpeech(text, overrides);
-        }
-      }
-
       if (resolvedPlayback.source === 'edge') {
         try {
           return await synthesizeEdgeWithAlignment(text, edgeVoiceId, overrides);
@@ -764,16 +642,7 @@ export function useTTS() {
 
       return playBrowserSpeech(text, overrides);
     },
-    [
-      resolvedPlayback.source,
-      playFishSpeech,
-      fishVoiceId,
-      playKokoroSpeech,
-      kokoroVoiceId,
-      synthesizeEdgeWithAlignment,
-      edgeVoiceId,
-      playBrowserSpeech,
-    ],
+    [resolvedPlayback.source, playFishSpeech, fishVoiceId, synthesizeEdgeWithAlignment, edgeVoiceId, playBrowserSpeech],
   );
 
   const getAudioElement = useCallback((): HTMLAudioElement | null => {
@@ -793,15 +662,6 @@ export function useTTS() {
       if (voiceSource === 'fish') {
         try {
           await playFishSpeech(text, uri);
-          return;
-        } catch {
-          setPreviewingURI(null);
-        }
-      }
-
-      if (voiceSource === 'kokoro') {
-        try {
-          await playKokoroSpeech(text, uri);
           return;
         } catch {
           setPreviewingURI(null);
@@ -838,70 +698,39 @@ export function useTTS() {
       };
       window.speechSynthesis.speak(utterance);
     },
-    [voiceSource, speed, pitch, volume, playFishSpeech, playKokoroSpeech, playEdgeSpeech],
+    [voiceSource, speed, pitch, volume, playFishSpeech, playEdgeSpeech],
   );
 
   const voices = useMemo(() => {
     if (voiceSource === 'fish') return fishVoices;
-    if (voiceSource === 'kokoro') return kokoroVoices;
     if (voiceSource === 'edge') return edgeVoices;
     return browserVoices;
-  }, [voiceSource, fishVoices, kokoroVoices, edgeVoices, browserVoices]);
+  }, [voiceSource, fishVoices, edgeVoices, browserVoices]);
 
   const currentVoice = useMemo(() => {
     if (voiceSource === 'fish') {
       return fishVoices.find((voice) => voice.voiceURI === fishVoiceId) ?? null;
     }
-    if (voiceSource === 'kokoro') {
-      return kokoroVoices.find((voice) => voice.voiceURI === kokoroVoiceId) ?? null;
-    }
     if (voiceSource === 'edge') {
       return edgeVoices.find((voice) => voice.voiceURI === edgeVoiceId) ?? null;
     }
     return browserVoices.find((voice) => voice.voiceURI === voiceURI) ?? null;
-  }, [
-    voiceSource,
-    fishVoices,
-    fishVoiceId,
-    kokoroVoices,
-    kokoroVoiceId,
-    edgeVoices,
-    edgeVoiceId,
-    browserVoices,
-    voiceURI,
-  ]);
+  }, [voiceSource, fishVoices, fishVoiceId, edgeVoices, edgeVoiceId, browserVoices, voiceURI]);
 
-  const sourceError =
-    voiceSource === 'fish'
-      ? fishError
-      : voiceSource === 'kokoro'
-        ? kokoroError
-        : voiceSource === 'edge'
-          ? edgeError
-          : null;
-  const isSourceLoading =
-    voiceSource === 'fish'
-      ? isFishLoading
-      : voiceSource === 'kokoro'
-        ? isKokoroLoading
-        : voiceSource === 'edge'
-          ? isEdgeLoading
-          : false;
+  const sourceError = voiceSource === 'fish' ? fishError : voiceSource === 'edge' ? edgeError : null;
+  const isSourceLoading = voiceSource === 'fish' ? isFishLoading : voiceSource === 'edge' ? isEdgeLoading : false;
 
   return {
     voices,
     browserVoices,
     fishVoices,
-    kokoroVoices,
     edgeVoices,
     currentVoice,
     isReady: isBrowserReady && !isSourceLoading,
     isSpeaking,
     isFishLoading,
-    isKokoroLoading,
     isEdgeLoading,
     fishError,
-    kokoroError,
     edgeError,
     previewingURI,
     voiceSource,

--- a/src/lib/edge-tts.test.ts
+++ b/src/lib/edge-tts.test.ts
@@ -138,6 +138,29 @@ describe('edge-tts', () => {
       const voices = await listEdgeVoices();
       expect(voices[0].id).toBe('en-US-JennyNeural');
     });
+
+    it('returns fallback voices when voice loading times out', async () => {
+      mockCreate.mockImplementation(() => new Promise(() => {}));
+
+      const { listEdgeVoices } = await import('./edge-tts');
+      const promise = listEdgeVoices();
+      await vi.advanceTimersByTimeAsync(4_000);
+
+      const voices = await promise;
+      expect(voices[0].id).toBe('en-US-AriaNeural');
+    });
+
+    it('caches fallback voices briefly after timeout', async () => {
+      mockCreate.mockImplementation(() => new Promise(() => {}));
+
+      const { listEdgeVoices } = await import('./edge-tts');
+      const firstPromise = listEdgeVoices();
+      await vi.advanceTimersByTimeAsync(4_000);
+      await firstPromise;
+
+      await listEdgeVoices();
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('synthesizeEdgeSpeech', () => {
@@ -188,13 +211,13 @@ describe('edge-tts', () => {
       expect(mockEdgeTTS).toHaveBeenCalledWith('test', 'en-US-AriaNeural', { rate: '-50%' });
     });
 
-    it('scales word boundaries to the actual playback timeline for slow speech', async () => {
+    it('uses Edge word boundaries as-is for slow speech', async () => {
       mockTTSInstance([1], [{ text: 'Hello', offset: 1_000_000, duration: 3_750_000 }]);
 
       const { synthesizeEdgeSpeech } = await import('./edge-tts');
       const result = await synthesizeEdgeSpeech({ text: 'Hello', voice: 'en-US-AriaNeural', speed: 0.5 });
 
-      expect(result.wordBoundaries).toEqual([{ word: 'Hello', start: 0.2, end: 0.95 }]);
+      expect(result.wordBoundaries).toEqual([{ word: 'Hello', start: 0.1, end: 0.475 }]);
     });
 
     it('defaults speed to 1.0 (+0%)', async () => {
@@ -204,6 +227,20 @@ describe('edge-tts', () => {
       await synthesizeEdgeSpeech({ text: 'test', voice: 'en-US-AriaNeural' });
 
       expect(mockEdgeTTS).toHaveBeenCalledWith('test', 'en-US-AriaNeural', { rate: '+0%' });
+    });
+
+    it('times out stalled synthesis requests', async () => {
+      mockEdgeTTS.mockImplementation(function (this: unknown) {
+        return {
+          synthesize: vi.fn().mockImplementation(() => new Promise(() => {})),
+        };
+      });
+
+      const { synthesizeEdgeSpeech } = await import('./edge-tts');
+      const promise = synthesizeEdgeSpeech({ text: 'test', voice: 'en-US-AriaNeural' });
+      const assertion = expect(promise).rejects.toThrow('Edge TTS synthesis timed out.');
+      await vi.advanceTimersByTimeAsync(6_000);
+      await assertion;
     });
   });
 });

--- a/src/lib/edge-tts.ts
+++ b/src/lib/edge-tts.ts
@@ -11,7 +11,28 @@ export interface EdgeTTSVoice {
 
 let cachedVoices: EdgeTTSVoice[] | null = null;
 let cacheTimestamp = 0;
+let cachedVoiceSource: 'remote' | 'fallback' | null = null;
 const CACHE_TTL_MS = 60 * 60 * 1000;
+const FALLBACK_CACHE_TTL_MS = 5 * 60 * 1000;
+const VOICE_FETCH_TIMEOUT_MS = 4_000;
+const SYNTHESIS_TIMEOUT_MS = 6_000;
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number, errorMessage: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(errorMessage)), timeoutMs);
+
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}
 
 function normalizeVoice(v: Voice): EdgeTTSVoice {
   const match = v.ShortName.match(/^[\w-]+-(\w+?)(Multilingual|Expressive)?Neural$/);
@@ -30,12 +51,17 @@ function normalizeVoice(v: Voice): EdgeTTSVoice {
 }
 
 export async function listEdgeVoices(): Promise<EdgeTTSVoice[]> {
-  if (cachedVoices && Date.now() - cacheTimestamp < CACHE_TTL_MS) {
+  const cacheTtl = cachedVoiceSource === 'fallback' ? FALLBACK_CACHE_TTL_MS : CACHE_TTL_MS;
+  if (cachedVoices && Date.now() - cacheTimestamp < cacheTtl) {
     return cachedVoices;
   }
 
   try {
-    const manager = await VoicesManager.create();
+    const manager = await withTimeout(
+      VoicesManager.create(),
+      VOICE_FETCH_TIMEOUT_MS,
+      'Edge voice list request timed out.',
+    );
     const englishVoices = manager.find({ Language: 'en' });
     const voices = englishVoices.map(normalizeVoice);
     voices.sort((a, b) => {
@@ -51,9 +77,13 @@ export async function listEdgeVoices(): Promise<EdgeTTSVoice[]> {
 
     cachedVoices = voices;
     cacheTimestamp = Date.now();
+    cachedVoiceSource = 'remote';
     return voices;
   } catch {
     if (cachedVoices) return cachedVoices;
+    cachedVoices = FALLBACK_VOICES;
+    cacheTimestamp = Date.now();
+    cachedVoiceSource = 'fallback';
     return FALLBACK_VOICES;
   }
 }
@@ -77,16 +107,15 @@ export async function synthesizeEdgeSpeech({
   const rateStr = `${ratePercent >= 0 ? '+' : ''}${ratePercent}%`;
 
   const tts = new EdgeTTS(text, voice, { rate: rateStr });
-  const result = await tts.synthesize();
+  const result = await withTimeout(tts.synthesize(), SYNTHESIS_TIMEOUT_MS, 'Edge TTS synthesis timed out.');
 
   const audioBuffer = Buffer.from(await result.audio.arrayBuffer());
 
   const HNS_PER_SEC = 10_000_000;
-  const timelineScale = 1 / Math.max(speed, 0.1);
   const wordBoundaries: EdgeWordBoundary[] = result.subtitle.map((wb) => ({
     word: wb.text,
-    start: (wb.offset / HNS_PER_SEC) * timelineScale,
-    end: ((wb.offset + wb.duration) / HNS_PER_SEC) * timelineScale,
+    start: wb.offset / HNS_PER_SEC,
+    end: (wb.offset + wb.duration) / HNS_PER_SEC,
   }));
 
   return {

--- a/src/lib/fish-audio-shared.test.ts
+++ b/src/lib/fish-audio-shared.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { resolveTTSSource } from '@/lib/fish-audio-shared';
+
+describe('resolveTTSSource', () => {
+  it('falls back to browser when Edge is temporarily unavailable', () => {
+    expect(
+      resolveTTSSource({
+        requestedSource: 'edge',
+        hasFishCredentials: false,
+        hasFishVoice: false,
+        hasEdgeVoice: true,
+        edgeTemporarilyUnavailable: true,
+        edgeTemporarilyUnavailableReason: 'Edge TTS timed out. Browser voice is temporarily active for stability.',
+      }),
+    ).toEqual({
+      source: 'browser',
+      reason: 'Edge TTS timed out. Browser voice is temporarily active for stability.',
+    });
+  });
+
+  it('keeps Edge selected when a voice is configured and no cooldown is active', () => {
+    expect(
+      resolveTTSSource({
+        requestedSource: 'edge',
+        hasFishCredentials: false,
+        hasFishVoice: false,
+        hasEdgeVoice: true,
+      }),
+    ).toEqual({
+      source: 'edge',
+    });
+  });
+});

--- a/src/lib/fish-audio-shared.ts
+++ b/src/lib/fish-audio-shared.ts
@@ -55,25 +55,21 @@ export function resolveTTSSource({
   requestedSource,
   hasFishCredentials,
   hasFishVoice,
-  hasKokoroServerUrl = false,
-  hasKokoroVoice = false,
   hasEdgeVoice = false,
   requiresBoundaryEvents = false,
 }: {
   requestedSource: TTSSource;
   hasFishCredentials: boolean;
   hasFishVoice: boolean;
-  hasKokoroServerUrl?: boolean;
-  hasKokoroVoice?: boolean;
   hasEdgeVoice?: boolean;
   requiresBoundaryEvents?: boolean;
 }): ResolvedTTSSource {
   if (requiresBoundaryEvents) {
-    const cloudSources: TTSSource[] = ['fish', 'kokoro', 'edge'];
+    const cloudSources: TTSSource[] = ['fish', 'edge'];
     if (cloudSources.includes(requestedSource)) {
       return {
         source: 'browser',
-        reason: `Boundary-based highlighting still requires browser speech when ${requestedSource === 'fish' ? 'Fish Audio' : requestedSource === 'kokoro' ? 'Kokoro' : 'Edge TTS'} is selected.`,
+        reason: `Boundary-based highlighting still requires browser speech when ${requestedSource === 'fish' ? 'Fish Audio' : 'Edge TTS'} is selected.`,
       };
     }
     return { source: 'browser' };
@@ -90,21 +86,6 @@ export function resolveTTSSource({
       return {
         source: 'browser',
         reason: 'Fish Audio is selected but no cloud voice is chosen yet.',
-      };
-    }
-  }
-
-  if (requestedSource === 'kokoro') {
-    if (!hasKokoroServerUrl) {
-      return {
-        source: 'browser',
-        reason: 'Kokoro is selected but no server URL is configured.',
-      };
-    }
-    if (!hasKokoroVoice) {
-      return {
-        source: 'browser',
-        reason: 'Kokoro is selected but no voice is chosen yet.',
       };
     }
   }

--- a/src/lib/fish-audio-shared.ts
+++ b/src/lib/fish-audio-shared.ts
@@ -57,12 +57,16 @@ export function resolveTTSSource({
   hasFishVoice,
   hasEdgeVoice = false,
   requiresBoundaryEvents = false,
+  edgeTemporarilyUnavailable = false,
+  edgeTemporarilyUnavailableReason,
 }: {
   requestedSource: TTSSource;
   hasFishCredentials: boolean;
   hasFishVoice: boolean;
   hasEdgeVoice?: boolean;
   requiresBoundaryEvents?: boolean;
+  edgeTemporarilyUnavailable?: boolean;
+  edgeTemporarilyUnavailableReason?: string;
 }): ResolvedTTSSource {
   if (requiresBoundaryEvents) {
     const cloudSources: TTSSource[] = ['fish', 'edge'];
@@ -91,6 +95,13 @@ export function resolveTTSSource({
   }
 
   if (requestedSource === 'edge') {
+    if (edgeTemporarilyUnavailable) {
+      return {
+        source: 'browser',
+        reason:
+          edgeTemporarilyUnavailableReason ?? 'Edge TTS is temporarily unavailable. Using browser voice for stability.',
+      };
+    }
     if (!hasEdgeVoice) {
       return {
         source: 'browser',

--- a/src/lib/fish-audio.test.ts
+++ b/src/lib/fish-audio.test.ts
@@ -238,59 +238,43 @@ describe('fish-audio helpers', () => {
     ).toEqual({ source: 'browser', reason: undefined });
   });
 
-  it('returns browser fallback when Kokoro is not fully configured', () => {
+  it('returns browser fallback when Edge TTS has no voice selected', () => {
     expect(
       resolveTTSSource({
-        requestedSource: 'kokoro',
+        requestedSource: 'edge',
         hasFishCredentials: false,
         hasFishVoice: false,
-        hasKokoroServerUrl: false,
-        hasKokoroVoice: false,
+        hasEdgeVoice: false,
       }),
     ).toEqual({
       source: 'browser',
-      reason: 'Kokoro is selected but no server URL is configured.',
-    });
-
-    expect(
-      resolveTTSSource({
-        requestedSource: 'kokoro',
-        hasFishCredentials: false,
-        hasFishVoice: false,
-        hasKokoroServerUrl: true,
-        hasKokoroVoice: false,
-      }),
-    ).toEqual({
-      source: 'browser',
-      reason: 'Kokoro is selected but no voice is chosen yet.',
+      reason: 'Edge TTS is selected but no voice is chosen yet.',
     });
   });
 
-  it('returns Kokoro when server URL and voice are present', () => {
+  it('returns Edge TTS when a voice is present', () => {
     expect(
       resolveTTSSource({
-        requestedSource: 'kokoro',
+        requestedSource: 'edge',
         hasFishCredentials: false,
         hasFishVoice: false,
-        hasKokoroServerUrl: true,
-        hasKokoroVoice: true,
+        hasEdgeVoice: true,
       }),
-    ).toEqual({ source: 'kokoro' });
+    ).toEqual({ source: 'edge' });
   });
 
-  it('falls back to browser for boundary events when Kokoro is selected', () => {
+  it('falls back to browser for boundary events when Edge TTS is selected', () => {
     expect(
       resolveTTSSource({
-        requestedSource: 'kokoro',
+        requestedSource: 'edge',
         hasFishCredentials: false,
         hasFishVoice: false,
-        hasKokoroServerUrl: true,
-        hasKokoroVoice: true,
+        hasEdgeVoice: true,
         requiresBoundaryEvents: true,
       }),
     ).toEqual({
       source: 'browser',
-      reason: 'Boundary-based highlighting still requires browser speech when Kokoro is selected.',
+      reason: 'Boundary-based highlighting still requires browser speech when Edge TTS is selected.',
     });
   });
 

--- a/src/lib/i18n/messages/listen-detail/en.json
+++ b/src/lib/i18n/messages/listen-detail/en.json
@@ -6,7 +6,14 @@
   },
   "header": {
     "words": "{{count}} words",
-    "cloudPlaybackNotice": "{{source}} playback is active. Sentence-level highlighting is estimated, so it will feel less precise than browser word highlighting."
+    "cloudPlaybackNotice": "{{source}} playback is active. Sentence-level highlighting is estimated, so it will feel less precise than browser word highlighting.",
+    "selectedPlaybackNotice": "Selected: {{selected}}. Playing with: {{actual}}.",
+    "browserFallbackNotice": "Selected: {{selected}}. Playing with: {{actual}} for stability because Edge TTS is temporarily unavailable."
+  },
+  "sources": {
+    "edge": "Edge TTS",
+    "fish": "Fish Audio",
+    "browser": "Browser voice"
   },
   "modes": {
     "title": "Practice mode",

--- a/src/lib/i18n/messages/listen-detail/zh.json
+++ b/src/lib/i18n/messages/listen-detail/zh.json
@@ -6,7 +6,14 @@
   },
   "header": {
     "words": "{{count}} 个单词",
-    "cloudPlaybackNotice": "{{source}} 正在播放。句子级高亮为估算值，精度不及浏览器逐词高亮。"
+    "cloudPlaybackNotice": "{{source}} 正在播放。句子级高亮为估算值，精度不及浏览器逐词高亮。",
+    "selectedPlaybackNotice": "已选择：{{selected}}。当前实际播放源：{{actual}}。",
+    "browserFallbackNotice": "已选择：{{selected}}。由于 Edge TTS 当前不稳定，现已切换为 {{actual}} 以保证播放稳定。"
+  },
+  "sources": {
+    "edge": "Edge TTS",
+    "fish": "Fish Audio",
+    "browser": "浏览器语音"
   },
   "modes": {
     "title": "练习模式",

--- a/src/lib/today-review.ts
+++ b/src/lib/today-review.ts
@@ -65,8 +65,19 @@ export function buildTodayReviewItems(
 }
 
 export async function getTodayReviewItems(now: number = Date.now()): Promise<TodayReviewItem[]> {
-  const [records, contents] = await Promise.all([db.records.toArray(), db.contents.toArray()]);
-  return buildTodayReviewItems(records, contents, now);
+  const records = await db.records.toArray();
+  const dueRecords = records.filter((record) => {
+    const dueTime = record.fsrsCard?.due ?? record.nextReview;
+    return typeof dueTime === 'number' && dueTime <= now;
+  });
+
+  if (dueRecords.length === 0) {
+    return [];
+  }
+
+  const contentIds = [...new Set(dueRecords.map((record) => record.contentId))];
+  const contents = await db.contents.where('id').anyOf(contentIds).toArray();
+  return buildTodayReviewItems(dueRecords, contents, now);
 }
 
 function labelForModule(module: LearningRecord['module']): string {

--- a/src/stores/tts-store.ts
+++ b/src/stores/tts-store.ts
@@ -1,9 +1,10 @@
 import { create } from 'zustand';
-import { DEFAULT_KOKORO_SERVER_URL } from '@/lib/kokoro-shared';
 
 const STORAGE_KEY = 'echotype_tts_settings';
+export const DEFAULT_EDGE_VOICE_ID = 'en-US-EmmaMultilingualNeural';
+export const DEFAULT_EDGE_VOICE_NAME = 'Emma';
 
-export type TTSSource = 'browser' | 'fish' | 'kokoro' | 'edge';
+export type TTSSource = 'browser' | 'fish' | 'edge';
 
 export interface TTSSettings {
   voiceSource: TTSSource;
@@ -54,7 +55,7 @@ interface TTSStore extends TTSSettings {
   hydrate: () => void;
 }
 
-function loadFromStorage(): Partial<TTSSettings> {
+function loadFromStorage(): Partial<Omit<TTSSettings, 'voiceSource'>> & { voiceSource?: string } {
   if (typeof window === 'undefined') return {};
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
@@ -65,13 +66,61 @@ function loadFromStorage(): Partial<TTSSettings> {
   return {};
 }
 
-function saveToStorage(settings: TTSSettings) {
+function toPersistedSettings(settings: TTSSettings | TTSStore): TTSSettings {
+  return {
+    voiceSource: settings.voiceSource,
+    voiceURI: settings.voiceURI,
+    speed: settings.speed,
+    pitch: settings.pitch,
+    volume: settings.volume,
+    fishApiKey: settings.fishApiKey,
+    fishVoiceId: settings.fishVoiceId,
+    fishVoiceName: settings.fishVoiceName,
+    fishModel: settings.fishModel,
+    kokoroServerUrl: settings.kokoroServerUrl,
+    kokoroApiKey: settings.kokoroApiKey,
+    kokoroVoiceId: settings.kokoroVoiceId,
+    kokoroVoiceName: settings.kokoroVoiceName,
+    edgeVoiceId: settings.edgeVoiceId,
+    edgeVoiceName: settings.edgeVoiceName,
+    targetLang: settings.targetLang,
+    recommendationsEnabled: settings.recommendationsEnabled,
+    recommendationsCount: settings.recommendationsCount,
+    groqApiKey: settings.groqApiKey,
+    openaiKey: settings.openaiKey,
+    anthropicKey: settings.anthropicKey,
+    deepseekKey: settings.deepseekKey,
+  };
+}
+
+function saveToStorage(settings: TTSSettings | TTSStore) {
   if (typeof window === 'undefined') return;
   try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(toPersistedSettings(settings)));
   } catch {
     /* ignore */
   }
+}
+
+function normalizeSavedSettings(
+  saved: Partial<Omit<TTSSettings, 'voiceSource'>> & { voiceSource?: string },
+): Partial<TTSSettings> {
+  const normalized = { ...saved } as Partial<TTSSettings>;
+
+  if (saved.voiceSource === 'kokoro') {
+    normalized.voiceSource = 'edge';
+  }
+
+  if (normalized.voiceSource === 'edge' && (!normalized.edgeVoiceId || !normalized.edgeVoiceId.trim())) {
+    normalized.edgeVoiceId = DEFAULT_EDGE_VOICE_ID;
+    normalized.edgeVoiceName = DEFAULT_EDGE_VOICE_NAME;
+  }
+
+  if ('kokoroServerUrl' in normalized && !normalized.kokoroServerUrl?.trim()) {
+    delete normalized.kokoroServerUrl;
+  }
+
+  return normalized;
 }
 
 const defaults: TTSSettings = {
@@ -84,12 +133,12 @@ const defaults: TTSSettings = {
   fishVoiceId: '',
   fishVoiceName: '',
   fishModel: 's2-pro',
-  kokoroServerUrl: DEFAULT_KOKORO_SERVER_URL,
+  kokoroServerUrl: '',
   kokoroApiKey: '',
-  kokoroVoiceId: 'af_heart',
-  kokoroVoiceName: 'Heart',
-  edgeVoiceId: 'en-US-AriaNeural',
-  edgeVoiceName: 'Aria',
+  kokoroVoiceId: '',
+  kokoroVoiceName: '',
+  edgeVoiceId: DEFAULT_EDGE_VOICE_ID,
+  edgeVoiceName: DEFAULT_EDGE_VOICE_NAME,
   targetLang: 'zh-CN',
   recommendationsEnabled: true,
   recommendationsCount: 5,
@@ -200,13 +249,10 @@ export const useTTSStore = create<TTSStore>((set, get) => ({
 
   hydrate: () => {
     if (get().hydrated) return;
-    const saved = loadFromStorage();
+    const saved = normalizeSavedSettings(loadFromStorage());
     if (Object.keys(saved).length > 0) {
-      // Don't overwrite the default Kokoro server URL with an empty string
-      if ('kokoroServerUrl' in saved && !saved.kokoroServerUrl?.trim()) {
-        delete saved.kokoroServerUrl;
-      }
       set({ ...saved, hydrated: true });
+      saveToStorage({ ...get(), ...saved });
       return;
     }
     set({ hydrated: true });

--- a/src/stores/tts-store.ts
+++ b/src/stores/tts-store.ts
@@ -1,8 +1,8 @@
 import { create } from 'zustand';
 
 const STORAGE_KEY = 'echotype_tts_settings';
-export const DEFAULT_EDGE_VOICE_ID = 'en-US-EmmaMultilingualNeural';
-export const DEFAULT_EDGE_VOICE_NAME = 'Emma';
+export const DEFAULT_EDGE_VOICE_ID = 'en-US-JennyNeural';
+export const DEFAULT_EDGE_VOICE_NAME = 'Jenny';
 
 export type TTSSource = 'browser' | 'fish' | 'edge';
 


### PR DESCRIPTION
## Summary
- stabilize listen TTS with Edge fallback cooldowns and a better default free Edge voice
- speed up listen/read/write detail hydration by loading content from store/IndexedDB before global bootstrap completes
- reduce route prefetch churn across library, detail pages, sidebar, and hidden shared UI so entering library and listen detail stops fan-out fetching unrelated routes
- smooth review/settings perceived performance by avoiding full-page loading resets and lazily loading heavy settings sections

## Verification
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- local Playwright smoke on `http://127.0.0.1:3203`
  - `library`: visible in `401ms`
  - `listen` list -> `Shopping list`: `902ms`, play button switched to `Pause`
  - `read` list -> `Shopping list`: `188ms`
  - `write` list -> `Shopping list`: `171ms`
  - `review/today`: `48ms`, refresh no longer falls back to loading card
  - `settings`: `108ms`, voice section visible
  - `library` action listen jump: `137ms`
- local fetch-chain check after the prefetch changes
  - `/library` now only fetched wordbook JSON on idle
  - `/library -> listen` now reduced to the target detail RSC plus `/api/tts/edge/voices` and `/api/translate/free`
  - direct `listen` detail no longer fan-out fetched `/library`, `/settings`, `/favorites`, `/review/today`, `/dashboard`
