### PR TITLE
fix: stabilize BBC url imports

### DIFF
--- a/src/components/import/url-import.tsx
+++ b/src/components/import/url-import.tsx
@@ -11,6 +11,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { useI18n } from '@/lib/i18n/use-i18n';
 import { buildImportPracticeActions } from '@/lib/import-practice-actions';
+import { fetchUrlImportResult } from '@/lib/url-import-fetch';
 import { normalizeTags } from '@/lib/utils';
 import { useContentStore } from '@/stores/content-store';
 import type { ContentItem, Difficulty } from '@/types/content';
@@ -47,22 +48,11 @@ export function UrlImport() {
     setSaved(false);
 
     try {
-      const res = await fetch('/api/import/url', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ url: url.trim() }),
-      });
-
-      const data = await res.json();
-      if (!res.ok) {
-        setError(data.error || m.fetchFailed);
-        return;
-      }
-
+      const data = await fetchUrlImportResult(url.trim());
       setResult(data);
       setTitle(data.title);
-    } catch {
-      setError(m.networkError);
+    } catch (error) {
+      setError(error instanceof Error ? error.message : m.networkError);
     } finally {
       setFetching(false);
     }

--- a/src/lib/url-import-fetch.test.ts
+++ b/src/lib/url-import-fetch.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fetchUrlImportResult } from './url-import-fetch';
+
+describe('fetchUrlImportResult', () => {
+  it('returns the server-side import result when the API succeeds', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            title: 'Example Domain',
+            text: 'Example body',
+            url: 'https://example.com',
+            wordCount: 2,
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        ),
+      );
+
+    await expect(fetchUrlImportResult('https://example.com', fetchMock as typeof fetch)).resolves.toEqual({
+      title: 'Example Domain',
+      text: 'Example body',
+      url: 'https://example.com',
+      wordCount: 2,
+    });
+  });
+
+  it('falls back to browser-side pdf import when the server fetch fails', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('<html>Bad gateway</html>', { status: 502 }))
+      .mockResolvedValueOnce(
+        new Response(new Uint8Array([37, 80, 68, 70]), {
+          status: 200,
+          headers: { 'content-type': 'application/pdf' },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            text: 'PDF body text',
+            pageCount: 1,
+            metadata: { title: 'BBC Socialising', author: null },
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        ),
+      );
+
+    await expect(
+      fetchUrlImportResult(
+        'https://downloads.bbc.co.uk/learningenglish/office_english/260323_OfficeEnglish_socialising_transcript_.pdf',
+        fetchMock as typeof fetch,
+      ),
+    ).resolves.toEqual({
+      title: 'BBC Socialising',
+      text: 'PDF body text',
+      url: 'https://downloads.bbc.co.uk/learningenglish/office_english/260323_OfficeEnglish_socialising_transcript_.pdf',
+      wordCount: 3,
+    });
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      'https://downloads.bbc.co.uk/learningenglish/office_english/260323_OfficeEnglish_socialising_transcript_.pdf',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Accept: expect.stringContaining('application/pdf'),
+        }),
+      }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
+      '/api/import/pdf',
+      expect.objectContaining({
+        method: 'POST',
+        body: expect.any(FormData),
+      }),
+    );
+  });
+
+  it('falls back to browser-side text import when the server fetch fails for direct text files', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: 'fetch failed' }), {
+          status: 500,
+          headers: { 'content-type': 'application/json' },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response('Alpha\n\nBeta', {
+          status: 200,
+          headers: { 'content-type': 'text/plain; charset=utf-8' },
+        }),
+      );
+
+    await expect(
+      fetchUrlImportResult('https://gist.githubusercontent.com/user/raw/example.txt', fetchMock as typeof fetch),
+    ).resolves.toEqual({
+      title: 'example',
+      text: 'Alpha\n\nBeta',
+      url: 'https://gist.githubusercontent.com/user/raw/example.txt',
+      wordCount: 2,
+    });
+  });
+});

--- a/src/lib/url-import-fetch.ts
+++ b/src/lib/url-import-fetch.ts
@@ -1,0 +1,156 @@
+export interface UrlImportResult {
+  title: string;
+  text: string;
+  url: string;
+  wordCount: number;
+}
+
+interface UrlImportErrorPayload {
+  error?: string;
+}
+
+interface PdfImportPayload {
+  text: string;
+  pageCount: number;
+  metadata?: {
+    title?: string | null;
+    author?: string | null;
+  };
+}
+
+function getPathStem(url: string): string {
+  try {
+    const parsed = new URL(url);
+    const lastSegment = decodeURIComponent(parsed.pathname.split('/').filter(Boolean).pop() || '');
+    return lastSegment.replace(/\.[^.]+$/, '').trim();
+  } catch {
+    return '';
+  }
+}
+
+function fallbackTitleFromUrl(url: string): string {
+  const stem = getPathStem(url);
+  if (stem) return stem;
+
+  try {
+    return new URL(url).hostname.replace(/^www\./, '');
+  } catch {
+    return 'Imported article';
+  }
+}
+
+function countWords(text: string): number {
+  return text.split(/\s+/).filter(Boolean).length;
+}
+
+function isDirectPdfUrl(url: string): boolean {
+  return /\.pdf(?:[?#]|$)/i.test(url);
+}
+
+function isDirectTextUrl(url: string): boolean {
+  return /\.(?:txt|text|md)(?:[?#]|$)/i.test(url);
+}
+
+async function parseJsonIfPossible<T>(response: Response): Promise<T | null> {
+  const raw = await response.text();
+  if (!raw.trim()) return null;
+
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+}
+
+async function tryBrowserPdfImport(url: string, fetchImpl: typeof fetch): Promise<UrlImportResult> {
+  const remoteResponse = await fetchImpl(url, {
+    headers: {
+      Accept: 'application/pdf,*/*;q=0.8',
+    },
+  });
+
+  if (!remoteResponse.ok) {
+    throw new Error(`Failed to fetch PDF (${remoteResponse.status})`);
+  }
+
+  const blob = await remoteResponse.blob();
+  const formData = new FormData();
+  formData.append(
+    'file',
+    new File([blob], `${fallbackTitleFromUrl(url)}.pdf`, { type: blob.type || 'application/pdf' }),
+  );
+
+  const parseResponse = await fetchImpl('/api/import/pdf', {
+    method: 'POST',
+    body: formData,
+  });
+  const payload = await parseJsonIfPossible<PdfImportPayload & UrlImportErrorPayload>(parseResponse);
+
+  if (!parseResponse.ok || !payload?.text) {
+    throw new Error(payload?.error || `Failed to parse PDF (${parseResponse.status})`);
+  }
+
+  return {
+    title: payload.metadata?.title || fallbackTitleFromUrl(url),
+    text: payload.text,
+    url,
+    wordCount: countWords(payload.text),
+  };
+}
+
+async function tryBrowserTextImport(url: string, fetchImpl: typeof fetch): Promise<UrlImportResult> {
+  const remoteResponse = await fetchImpl(url, {
+    headers: {
+      Accept: 'text/plain,text/markdown,*/*;q=0.8',
+    },
+  });
+
+  if (!remoteResponse.ok) {
+    throw new Error(`Failed to fetch text file (${remoteResponse.status})`);
+  }
+
+  const text = (await remoteResponse.text()).trim();
+  if (!text) {
+    throw new Error('Fetched text file is empty');
+  }
+
+  return {
+    title: fallbackTitleFromUrl(url),
+    text,
+    url,
+    wordCount: countWords(text),
+  };
+}
+
+export async function fetchUrlImportResult(url: string, fetchImpl: typeof fetch = fetch): Promise<UrlImportResult> {
+  const response = await fetchImpl('/api/import/url', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ url: url.trim() }),
+  });
+  const payload = await parseJsonIfPossible<UrlImportResult & UrlImportErrorPayload>(response);
+
+  if (response.ok && payload?.text) {
+    return payload;
+  }
+
+  const serverError = payload?.error || `Import request failed (${response.status})`;
+
+  if (isDirectPdfUrl(url)) {
+    try {
+      return await tryBrowserPdfImport(url, fetchImpl);
+    } catch {
+      throw new Error(serverError);
+    }
+  }
+
+  if (isDirectTextUrl(url)) {
+    try {
+      return await tryBrowserTextImport(url, fetchImpl);
+    } catch {
+      throw new Error(serverError);
+    }
+  }
+
+  throw new Error(serverError);
+}

--- a/src/lib/web-page.test.ts
+++ b/src/lib/web-page.test.ts
@@ -88,4 +88,43 @@ describe('web-page helpers', () => {
       url: 'https://example.com/files/lesson.pdf',
     });
   });
+
+  it('retries BBC downloads over http when https fetch fails before TLS is established', async () => {
+    vi.spyOn(extractText, 'extractPdf').mockResolvedValue({
+      text: 'BBC PDF body',
+      metadata: {
+        title: 'BBC Office English',
+        author: null,
+        pageCount: 1,
+        format: 'pdf',
+      },
+    });
+
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError('fetch failed'))
+      .mockResolvedValueOnce(
+        new Response(new Uint8Array([37, 80, 68, 70]), {
+          status: 200,
+          headers: { 'content-type': 'application/pdf' },
+        }),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      fetchWebPageContent(
+        'https://downloads.bbc.co.uk/learningenglish/office_english/260323_OfficeEnglish_socialising_transcript_.pdf',
+      ),
+    ).resolves.toMatchObject({
+      title: 'BBC Office English',
+      text: 'BBC PDF body',
+      url: 'https://downloads.bbc.co.uk/learningenglish/office_english/260323_OfficeEnglish_socialising_transcript_.pdf',
+    });
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      'http://downloads.bbc.co.uk/learningenglish/office_english/260323_OfficeEnglish_socialising_transcript_.pdf',
+      expect.any(Object),
+    );
+  });
 });

--- a/src/lib/web-page.ts
+++ b/src/lib/web-page.ts
@@ -1,6 +1,7 @@
 import * as extractText from './extract-text';
 
 const URL_REGEX = /https?:\/\/[^\s]+/i;
+const HTTP_FALLBACK_HOSTS = new Set(['downloads.bbc.co.uk']);
 
 function isPrivateHostname(hostname: string): boolean {
   const normalized = hostname.toLowerCase();
@@ -149,6 +150,42 @@ function inferRemoteContentKind(url: string, contentType: string): 'html' | 'tex
   return 'unsupported';
 }
 
+function canRetryOverHttp(parsedUrl: URL, error: unknown): boolean {
+  if (parsedUrl.protocol !== 'https:' || !HTTP_FALLBACK_HOSTS.has(parsedUrl.hostname)) {
+    return false;
+  }
+
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  return /fetch failed|ECONNRESET|TLS|secure TLS connection/i.test(error.message);
+}
+
+async function fetchRemoteResponse(url: string): Promise<Response> {
+  const parsedUrl = new URL(url);
+  const requestInit: RequestInit = {
+    headers: {
+      'User-Agent':
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36',
+      Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,text/plain;q=0.8,*/*;q=0.7',
+    },
+    signal: AbortSignal.timeout(15_000),
+  };
+
+  try {
+    return await fetch(url, requestInit);
+  } catch (error) {
+    if (!canRetryOverHttp(parsedUrl, error)) {
+      throw error;
+    }
+
+    const fallbackUrl = new URL(url);
+    fallbackUrl.protocol = 'http:';
+    return fetch(fallbackUrl.toString(), requestInit);
+  }
+}
+
 export function extractFirstUrl(input: string): string | null {
   const match = input.match(URL_REGEX);
   return match?.[0] ?? null;
@@ -175,14 +212,7 @@ export async function fetchWebPageContent(url: string): Promise<{ title: string;
     throw new Error('Private or local URLs are not allowed');
   }
 
-  const response = await fetch(url, {
-    headers: {
-      'User-Agent':
-        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36',
-      Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,text/plain;q=0.8,*/*;q=0.7',
-    },
-    signal: AbortSignal.timeout(15_000),
-  });
+  const response = await fetchRemoteResponse(url);
 
   if (!response.ok) {
     throw new Error(`Failed to fetch page (${response.status})`);


### PR DESCRIPTION
## Summary
- add a browser-side fallback helper for direct PDF/TXT URL imports and preserve clearer API errors
- retry downloads.bbc.co.uk direct-file imports over http when Node https fetch fails before TLS is established
- cover the BBC fallback path and direct-file fallback behavior with regression tests

## Testing
- pnpm typecheck
- pnpm test
- pnpm build
- local browser smoke on http://127.0.0.1:3205/library/import with the BBC Office English PDF URL