### PR TITLE
fix: stabilize production URL import for PDFs

### DIFF
--- a/src/app/api/import/extract-text/route.ts
+++ b/src/app/api/import/extract-text/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from 'next/server';
 import { FORMAT_HANDLERS, getExtension } from '@/lib/extract-text';
 
 const MAX_FILE_SIZE = 20 * 1024 * 1024; // 20MB
+export const runtime = 'nodejs';
+export const maxDuration = 30;
 
 export async function POST(req: Request) {
   try {

--- a/src/app/api/import/pdf/route.ts
+++ b/src/app/api/import/pdf/route.ts
@@ -1,6 +1,9 @@
 import { NextResponse } from 'next/server';
 import { PDFParse } from 'pdf-parse';
 
+export const runtime = 'nodejs';
+export const maxDuration = 30;
+
 export async function POST(req: Request) {
   try {
     const formData = await req.formData();

--- a/src/components/import/document-import.tsx
+++ b/src/components/import/document-import.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { ClipboardPaste, FileUp, Globe } from 'lucide-react';
-import { useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { useEffect, useState } from 'react';
 import { FileUploadImport } from '@/components/import/file-upload-import';
 import { TextImport } from '@/components/import/text-import';
 import { UrlImport } from '@/components/import/url-import';
@@ -12,9 +13,41 @@ import { nativeHaptic } from '@/lib/tauri';
 type SubTab = 'paste' | 'upload' | 'url';
 
 export function DocumentImport() {
+  const searchParams = useSearchParams();
   const [activeTab, setActiveTab] = useState<SubTab>('paste');
   const { messages } = useI18n('library');
   const m = messages.documentImport;
+
+  useEffect(() => {
+    const subtab = searchParams.get('subtab');
+    const sourceUrl = searchParams.get('sourceUrl');
+    if (subtab === 'url' || sourceUrl) {
+      setActiveTab('url');
+      return;
+    }
+
+    if (subtab === 'upload') {
+      setActiveTab('upload');
+      return;
+    }
+
+    if (subtab === 'paste') {
+      setActiveTab('paste');
+    }
+  }, [searchParams]);
+
+  useEffect(() => {
+    const nextParams = new URLSearchParams(window.location.search);
+    nextParams.set('subtab', activeTab);
+    if (activeTab !== 'url') {
+      nextParams.delete('sourceUrl');
+    }
+    const nextSearch = nextParams.toString();
+    const nextUrl = nextSearch ? `${window.location.pathname}?${nextSearch}` : window.location.pathname;
+    if (nextUrl !== `${window.location.pathname}${window.location.search}`) {
+      window.history.replaceState(null, '', nextUrl);
+    }
+  }, [activeTab]);
 
   const selectTab = (tab: SubTab) => {
     setActiveTab(tab);

--- a/src/components/import/url-import.tsx
+++ b/src/components/import/url-import.tsx
@@ -2,7 +2,8 @@
 
 import { AlertCircle, Check, ChevronDown, ExternalLink, Globe, Loader2, Sparkles } from 'lucide-react';
 import { nanoid } from 'nanoid';
-import { useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { useEffect, useState } from 'react';
 import { ImportPracticeActions } from '@/components/import/import-practice-actions';
 import { TagSelector } from '@/components/shared/tag-selector';
 import { Badge } from '@/components/ui/badge';
@@ -24,6 +25,7 @@ interface FetchResult {
 }
 
 export function UrlImport() {
+  const searchParams = useSearchParams();
   const { addContent } = useContentStore();
   const { messages } = useI18n('library');
   const m = messages.urlImport;
@@ -39,6 +41,28 @@ export function UrlImport() {
   const [tags, setTags] = useState('');
   const [showFullText, setShowFullText] = useState(false);
   const [savedItem, setSavedItem] = useState<ContentItem | null>(null);
+
+  useEffect(() => {
+    const sourceUrl = searchParams.get('sourceUrl') || '';
+    if (sourceUrl !== url) {
+      setUrl(sourceUrl);
+    }
+  }, [searchParams]);
+
+  useEffect(() => {
+    const nextParams = new URLSearchParams(window.location.search);
+    nextParams.set('subtab', 'url');
+    if (url.trim()) {
+      nextParams.set('sourceUrl', url.trim());
+    } else {
+      nextParams.delete('sourceUrl');
+    }
+    const nextSearch = nextParams.toString();
+    const nextUrl = nextSearch ? `${window.location.pathname}?${nextSearch}` : window.location.pathname;
+    if (nextUrl !== `${window.location.pathname}${window.location.search}`) {
+      window.history.replaceState(null, '', nextUrl);
+    }
+  }, [url]);
 
   const handleFetch = async () => {
     if (!url.trim()) return;
@@ -98,7 +122,9 @@ export function UrlImport() {
             <Input
               id="url-import-input"
               value={url}
-              onChange={(e) => setUrl(e.target.value)}
+              onChange={(e) => {
+                setUrl(e.target.value);
+              }}
               onKeyDown={(e) => e.key === 'Enter' && handleFetch()}
               placeholder={m.placeholderUrl}
               className="pl-10 bg-white border-indigo-200 focus:border-indigo-500 focus:ring-indigo-500"

--- a/src/lib/web-page.ts
+++ b/src/lib/web-page.ts
@@ -1,5 +1,3 @@
-import * as extractText from './extract-text';
-
 const URL_REGEX = /https?:\/\/[^\s]+/i;
 const HTTP_FALLBACK_HOSTS = new Set(['downloads.bbc.co.uk']);
 
@@ -186,6 +184,11 @@ async function fetchRemoteResponse(url: string): Promise<Response> {
   }
 }
 
+async function extractPdfFromBuffer(buffer: Buffer) {
+  const extractText = await import('./extract-text');
+  return extractText.extractPdf(buffer);
+}
+
 export function extractFirstUrl(input: string): string | null {
   const match = input.match(URL_REGEX);
   return match?.[0] ?? null;
@@ -230,7 +233,7 @@ export async function fetchWebPageContent(url: string): Promise<{ title: string;
       throw new Error('Fetched PDF is empty');
     }
 
-    const extracted = await extractText.extractPdf(raw);
+    const extracted = await extractPdfFromBuffer(raw);
     const text = normalizeWhitespace(extracted.text);
     if (!text) {
       throw new Error('Could not extract readable text from the PDF');


### PR DESCRIPTION
## Summary
- lazy-load PDF extraction in URL import so the production route does not eagerly pull PDF parsing into startup
- force PDF and extract-text import routes onto Node.js runtime with a longer max duration
- sync document import subtab and source URL into the page query string so URL imports can be reloaded and shared

## Testing
- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm test
- local browser verification on /library/import with the BBC PDF URL