### PR TITLE
fix: use pdfjs for server PDF imports

### DIFF
--- a/src/app/api/import/pdf/route.ts
+++ b/src/app/api/import/pdf/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { PDFParse } from 'pdf-parse';
+import { extractPdf } from '@/lib/extract-text';
 
 export const runtime = 'nodejs';
 export const maxDuration = 30;
@@ -18,19 +18,14 @@ export async function POST(req: Request) {
     }
 
     const arrayBuffer = await file.arrayBuffer();
-    const parser = new PDFParse({ data: new Uint8Array(arrayBuffer) });
-
-    const textResult = await parser.getText();
-    const infoResult = await parser.getInfo();
-
-    await parser.destroy();
+    const result = await extractPdf(Buffer.from(arrayBuffer));
 
     return NextResponse.json({
-      text: textResult.text,
-      pageCount: textResult.total,
+      text: result.text,
+      pageCount: result.metadata.pageCount,
       metadata: {
-        title: infoResult.info?.Title || infoResult.info?.title || null,
-        author: infoResult.info?.Author || infoResult.info?.author || null,
+        title: result.metadata.title,
+        author: result.metadata.author,
       },
     });
   } catch (error: unknown) {

--- a/src/lib/extract-text.test.ts
+++ b/src/lib/extract-text.test.ts
@@ -1,12 +1,21 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
+  extractPdf,
   extractEpub,
   extractPlainText,
   getExtension,
   splitTextIntoChapters,
 } from './extract-text';
+
+const { mockGetDocument } = vi.hoisted(() => ({
+  mockGetDocument: vi.fn(),
+}));
+
+vi.mock('pdfjs-dist/legacy/build/pdf.mjs', () => ({
+  getDocument: mockGetDocument,
+}));
 
 const EPUB_PATH = path.resolve(__dirname, '../../test-data/little-prince.epub');
 
@@ -139,6 +148,51 @@ describe('extractPlainText', () => {
       expect(result.chapters).toBeUndefined();
       expect(result.metadata.pageCount).toBeNull();
     });
+  });
+});
+
+describe('extractPdf', () => {
+  it('extracts page text and metadata through pdfjs-dist', async () => {
+    const pageOne = {
+      getTextContent: vi.fn().mockResolvedValue({
+        items: [
+          { str: 'Hello', hasEOL: false },
+          { str: 'world', hasEOL: true },
+        ],
+      }),
+      cleanup: vi.fn(),
+    };
+    const pageTwo = {
+      getTextContent: vi.fn().mockResolvedValue({
+        items: [
+          { str: 'Second', hasEOL: false },
+          { str: 'page', hasEOL: false },
+        ],
+      }),
+      cleanup: vi.fn(),
+    };
+    const document = {
+      numPages: 2,
+      getPage: vi.fn().mockResolvedValueOnce(pageOne).mockResolvedValueOnce(pageTwo),
+      getMetadata: vi.fn().mockResolvedValue({
+        info: { Title: 'Sample PDF', Author: 'BBC' },
+      }),
+    };
+    const destroy = vi.fn().mockResolvedValue(undefined);
+    mockGetDocument.mockReturnValue({
+      promise: Promise.resolve(document),
+      destroy,
+    });
+
+    const result = await extractPdf(Buffer.from('fake pdf'));
+
+    expect(result.text).toBe('Hello world\n\nSecond page');
+    expect(result.metadata.title).toBe('Sample PDF');
+    expect(result.metadata.author).toBe('BBC');
+    expect(result.metadata.pageCount).toBe(2);
+    expect(pageOne.cleanup).toHaveBeenCalled();
+    expect(pageTwo.cleanup).toHaveBeenCalled();
+    expect(destroy).toHaveBeenCalled();
   });
 });
 

--- a/src/lib/extract-text.ts
+++ b/src/lib/extract-text.ts
@@ -1,6 +1,5 @@
 import JSZip from 'jszip';
 import mammoth from 'mammoth';
-import { PDFParse } from 'pdf-parse';
 
 export interface ExtractResult {
   text: string;
@@ -28,20 +27,58 @@ export function getExtension(filename: string): string {
 }
 
 export async function extractPdf(buffer: Buffer): Promise<ExtractResult> {
-  const parser = new PDFParse({ data: new Uint8Array(buffer) });
-  const textResult = await parser.getText();
-  const infoResult = await parser.getInfo();
-  await parser.destroy();
+  const pdfjs = await import('pdfjs-dist/legacy/build/pdf.mjs');
+  const loadingTask = pdfjs.getDocument({
+    data: new Uint8Array(buffer),
+    useWorkerFetch: false,
+    isEvalSupported: false,
+  });
+  const document = await loadingTask.promise;
 
-  const chapters = splitTextIntoChapters(textResult.text);
+  let text = '';
+  let metadata: { info?: { Title?: string; title?: string; Author?: string; author?: string } } | null = null;
+
+  try {
+    for (let pageNumber = 1; pageNumber <= document.numPages; pageNumber += 1) {
+      const page = await document.getPage(pageNumber);
+      try {
+        const content = await page.getTextContent();
+        const pageText = content.items
+          .map((item) => {
+            if (!('str' in item)) return '';
+            return item.hasEOL ? `${item.str}\n` : `${item.str} `;
+          })
+          .join('')
+          .replace(/[ \t]+\n/g, '\n')
+          .replace(/[ \t]{2,}/g, ' ')
+          .trim();
+
+        if (pageText) {
+          text += text ? `\n\n${pageText}` : pageText;
+        }
+      } finally {
+        page.cleanup();
+      }
+    }
+
+    try {
+      metadata = await document.getMetadata();
+    } catch {
+      metadata = null;
+    }
+  } finally {
+    await loadingTask.destroy();
+  }
+
+  const chapters = splitTextIntoChapters(text);
 
   return {
-    text: textResult.text,
+    text,
     chapters: chapters.length > 1 ? chapters : undefined,
     metadata: {
-      title: infoResult.info?.Title || infoResult.info?.title || null,
-      author: infoResult.info?.Author || infoResult.info?.author || null,
-      pageCount: chapters.length > 1 ? chapters.length : textResult.total,
+      title: metadata?.info?.Title || metadata?.info?.title || null,
+      author: metadata?.info?.Author || metadata?.info?.author || null,
+      pageCount: chapters.length > 1 ? chapters.length : document.numPages,
       format: 'pdf',
     },
   };


### PR DESCRIPTION
## Summary
- replace server-side PDF parsing with pdfjs-dist text extraction to avoid the production DOMMatrix crash from pdf-parse
- reuse the shared extractPdf helper from the PDF upload route
- add a focused unit test for the PDF extraction flow

## Testing
- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm test