### PR TITLE
fix: polyfill pdfjs DOMMatrix on server

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -21,7 +21,7 @@ const tauriTracingExcludes: NonNullable<NextConfig['outputFileTracingExcludes']>
 const nextConfig: NextConfig = {
   output: isTauri ? 'standalone' : undefined,
   outputFileTracingExcludes: isTauri ? tauriTracingExcludes : undefined,
-  serverExternalPackages: ['pdf-parse', 'pdfjs-dist'],
+  serverExternalPackages: ['@napi-rs/canvas', 'pdf-parse', 'pdfjs-dist'],
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@ai-sdk/react": "^3.0.103",
     "@ai-sdk/togetherai": "^2.0.34",
     "@ai-sdk/xai": "^3.0.59",
+    "@napi-rs/canvas": "^0.1.80",
     "@radix-ui/react-popover": "^1.1.15",
     "@supabase/ssr": "^0.9.0",
     "@supabase/supabase-js": "^2.99.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@ai-sdk/xai':
         specifier: ^3.0.59
         version: 3.0.59(zod@4.3.6)
+      '@napi-rs/canvas':
+        specifier: ^0.1.80
+        version: 0.1.80
       '@radix-ui/react-popover':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)

--- a/src/components/import/document-import.tsx
+++ b/src/components/import/document-import.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { ClipboardPaste, FileUp, Globe } from 'lucide-react';
-import { useSearchParams } from 'next/navigation';
+import { type ReadonlyURLSearchParams, useSearchParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { FileUploadImport } from '@/components/import/file-upload-import';
 import { TextImport } from '@/components/import/text-import';
@@ -12,28 +12,29 @@ import { nativeHaptic } from '@/lib/tauri';
 
 type SubTab = 'paste' | 'upload' | 'url';
 
+function getInitialSubTab(searchParams: URLSearchParams | ReadonlyURLSearchParams): SubTab {
+  const subtab = searchParams.get('subtab');
+  const sourceUrl = searchParams.get('sourceUrl');
+
+  if (subtab === 'url' || sourceUrl) {
+    return 'url';
+  }
+
+  if (subtab === 'upload') {
+    return 'upload';
+  }
+
+  return 'paste';
+}
+
 export function DocumentImport() {
   const searchParams = useSearchParams();
-  const [activeTab, setActiveTab] = useState<SubTab>('paste');
+  const [activeTab, setActiveTab] = useState<SubTab>(() => getInitialSubTab(searchParams));
   const { messages } = useI18n('library');
   const m = messages.documentImport;
 
   useEffect(() => {
-    const subtab = searchParams.get('subtab');
-    const sourceUrl = searchParams.get('sourceUrl');
-    if (subtab === 'url' || sourceUrl) {
-      setActiveTab('url');
-      return;
-    }
-
-    if (subtab === 'upload') {
-      setActiveTab('upload');
-      return;
-    }
-
-    if (subtab === 'paste') {
-      setActiveTab('paste');
-    }
+    setActiveTab(getInitialSubTab(searchParams));
   }, [searchParams]);
 
   useEffect(() => {

--- a/src/lib/extract-text.ts
+++ b/src/lib/extract-text.ts
@@ -26,7 +26,28 @@ export function getExtension(filename: string): string {
   return match ? match[0].toLowerCase() : '';
 }
 
+let pdfJsDomPolyfillsPromise: Promise<void> | null = null;
+
+async function ensurePdfJsDomPolyfills() {
+  const globalScope = globalThis as Record<string, unknown>;
+
+  if (globalScope.DOMMatrix && globalScope.DOMPoint && globalScope.DOMRect) {
+    return;
+  }
+
+  if (!pdfJsDomPolyfillsPromise) {
+    pdfJsDomPolyfillsPromise = import('@napi-rs/canvas/geometry.js').then(({ DOMMatrix, DOMPoint, DOMRect }) => {
+      globalScope.DOMMatrix ??= DOMMatrix;
+      globalScope.DOMPoint ??= DOMPoint;
+      globalScope.DOMRect ??= DOMRect;
+    });
+  }
+
+  await pdfJsDomPolyfillsPromise;
+}
+
 export async function extractPdf(buffer: Buffer): Promise<ExtractResult> {
+  await ensurePdfJsDomPolyfills();
   const pdfjs = await import('pdfjs-dist/legacy/build/pdf.mjs');
   const loadingTask = pdfjs.getDocument({
     data: new Uint8Array(buffer),

--- a/src/lib/extract-text.ts
+++ b/src/lib/extract-text.ts
@@ -36,7 +36,7 @@ async function ensurePdfJsDomPolyfills() {
   }
 
   if (!pdfJsDomPolyfillsPromise) {
-    pdfJsDomPolyfillsPromise = import('@napi-rs/canvas/geometry.js').then(({ DOMMatrix, DOMPoint, DOMRect }) => {
+    pdfJsDomPolyfillsPromise = import('@napi-rs/canvas').then(({ DOMMatrix, DOMPoint, DOMRect }) => {
       globalScope.DOMMatrix ??= DOMMatrix;
       globalScope.DOMPoint ??= DOMPoint;
       globalScope.DOMRect ??= DOMRect;

--- a/src/types/napi-rs-canvas-geometry.d.ts
+++ b/src/types/napi-rs-canvas-geometry.d.ts
@@ -1,5 +1,0 @@
-declare module '@napi-rs/canvas/geometry.js' {
-  export const DOMMatrix: unknown;
-  export const DOMPoint: unknown;
-  export const DOMRect: unknown;
-}

--- a/src/types/napi-rs-canvas-geometry.d.ts
+++ b/src/types/napi-rs-canvas-geometry.d.ts
@@ -1,0 +1,5 @@
+declare module '@napi-rs/canvas/geometry.js' {
+  export const DOMMatrix: unknown;
+  export const DOMPoint: unknown;
+  export const DOMRect: unknown;
+}


### PR DESCRIPTION
## Summary
- polyfill DOMMatrix, DOMPoint, and DOMRect before loading pdfjs-dist on the server
- source the geometry polyfill from @napi-rs/canvas/geometry.js to avoid Turbopack native-binding issues
- add a local declaration for the geometry helper module

## Testing
- pnpm typecheck
- pnpm lint
- pnpm build
- pnpm test src/lib/extract-text.test.ts