### PR TITLE
fix: preload pdfjs worker for server imports

### DIFF
--- a/src/lib/extract-text.ts
+++ b/src/lib/extract-text.ts
@@ -27,6 +27,7 @@ export function getExtension(filename: string): string {
 }
 
 let pdfJsDomPolyfillsPromise: Promise<void> | null = null;
+let pdfJsRuntimePromise: Promise<typeof import('pdfjs-dist/legacy/build/pdf.mjs')> | null = null;
 
 async function ensurePdfJsDomPolyfills() {
   const globalScope = globalThis as Record<string, unknown>;
@@ -46,9 +47,27 @@ async function ensurePdfJsDomPolyfills() {
   await pdfJsDomPolyfillsPromise;
 }
 
+async function loadPdfJsRuntime() {
+  if (!pdfJsRuntimePromise) {
+    pdfJsRuntimePromise = (async () => {
+      await ensurePdfJsDomPolyfills();
+      const [pdfjs, pdfWorker] = await Promise.all([
+        import('pdfjs-dist/legacy/build/pdf.mjs'),
+        import('pdfjs-dist/legacy/build/pdf.worker.mjs'),
+      ]);
+
+      const globalScope = globalThis as Record<string, unknown>;
+      globalScope.pdfjsWorker ??= pdfWorker;
+
+      return pdfjs;
+    })();
+  }
+
+  return pdfJsRuntimePromise;
+}
+
 export async function extractPdf(buffer: Buffer): Promise<ExtractResult> {
-  await ensurePdfJsDomPolyfills();
-  const pdfjs = await import('pdfjs-dist/legacy/build/pdf.mjs');
+  const pdfjs = await loadPdfJsRuntime();
   const loadingTask = pdfjs.getDocument({
     data: new Uint8Array(buffer),
     useWorkerFetch: false,

--- a/src/types/pdfjs-dist-worker.d.ts
+++ b/src/types/pdfjs-dist-worker.d.ts
@@ -1,0 +1,5 @@
+declare module 'pdfjs-dist/legacy/build/pdf.worker.mjs' {
+  export const WorkerMessageHandler: {
+    setup(handler: unknown, port: unknown): void;
+  };
+}


### PR DESCRIPTION
## Summary
- preload `pdf.worker.mjs` in the Node PDF extraction path
- register `WorkerMessageHandler` on `globalThis.pdfjsWorker` so server imports do not rely on runtime relative worker resolution
- keep the existing DOM geometry polyfill path intact

## Verification
- pnpm typecheck
- pnpm lint
- pnpm test src/lib/extract-text.test.ts
- pnpm build
- node script: extract `/tmp/bbc-office-english.pdf` via `extractPdf`
- local `POST /api/import/pdf` with the BBC PDF file returns extracted text