### PR TITLE
[codex] unify practice controls and provider fallbacks

### DIFF
--- a/src/app/api/chat/route.test.ts
+++ b/src/app/api/chat/route.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { CHAT_TOOL_INPUT_SCHEMAS, CHAT_TOOL_NAMES, createChatTools } from '@/lib/chat-tools';
+import { isToolUnsupportedError } from './route';
 
 describe('chat API tool schemas', () => {
   it('all 17 tools are defined', () => {
@@ -35,5 +36,19 @@ describe('chat API tool schemas', () => {
     expect(CHAT_TOOL_INPUT_SCHEMAS.showTodaySessions.safeParse({}).success).toBe(true);
     expect(CHAT_TOOL_INPUT_SCHEMAS.showTodayStats.safeParse({}).success).toBe(true);
     expect(CHAT_TOOL_INPUT_SCHEMAS.showDueReviews.safeParse({}).success).toBe(true);
+  });
+});
+
+describe('chat API tool routing', () => {
+  it('recognizes explicit unsupported-tool errors', () => {
+    expect(isToolUnsupportedError('No endpoints found that support tool use')).toBe(true);
+    expect(isToolUnsupportedError('This model does not support function calling')).toBe(true);
+    expect(isToolUnsupportedError('tool_use_failed')).toBe(true);
+  });
+
+  it('does not downgrade unrelated provider errors', () => {
+    expect(isToolUnsupportedError('User not found')).toBe(false);
+    expect(isToolUnsupportedError('Rate limit exceeded')).toBe(false);
+    expect(isToolUnsupportedError('Requested 4096 tokens but only 48 available')).toBe(false);
   });
 });

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -10,12 +10,24 @@ import { resolveApiKey, resolveModel } from '@/lib/ai-model';
 import { createChatTools, createMobileChatTools } from '@/lib/chat-tools';
 import { enforcePlatformRateLimit } from '@/lib/platform-provider';
 import { ProviderResolutionError, resolveProviderForCapability } from '@/lib/provider-resolver';
+import { resolveProviderRetryMaxTokens } from '@/lib/provider-token-budget';
 import { PROVIDER_REGISTRY, type ProviderConfig, type ProviderId } from '@/lib/providers';
 import type { ChatContext, ChatUIMessage } from '@/types/chat';
 import type { ContentType } from '@/types/content';
 
 export const runtime = 'nodejs';
 export const maxDuration = 60;
+
+export function isToolUnsupportedError(message: string): boolean {
+  return (
+    /no endpoints? found.*(?:tool|parameter)/i.test(message) ||
+    /(?:tool|function)(?:s| calling| use)? (?:is|are|were)? ?not supported/i.test(message) ||
+    /does not support.*(?:tool|function)/i.test(message) ||
+    /unsupported.*(?:tool|function)/i.test(message) ||
+    /tool_use_failed/i.test(message) ||
+    /failed to call a function/i.test(message)
+  );
+}
 
 const BASE_SYSTEM_PROMPT = `You are a friendly and patient English tutor. Your role is to:
 - Help students improve their English skills
@@ -709,7 +721,7 @@ export async function POST(req: NextRequest) {
       const reader = uiStream.getReader();
       // biome-ignore lint/suspicious/noExplicitAny: stream chunk types from AI SDK are not easily narrowed
       const earlyBuffer: any[] = [];
-      let hitError = false;
+      let earlyErrorText: string | null = null;
 
       // Read early events and check for error before any content arrives
       for (;;) {
@@ -717,7 +729,7 @@ export async function POST(req: NextRequest) {
         if (done) break;
 
         if ('type' in value && value.type === 'error') {
-          hitError = true;
+          earlyErrorText = value.errorText;
           // Drain remaining events from the failed stream
           for (;;) {
             const rest = await reader.read();
@@ -744,16 +756,36 @@ export async function POST(req: NextRequest) {
         return;
       }
 
-      if (hitError) {
-        // Tool calling failed — retry without tools for a text-only response
-        const noToolMessages = await convertToModelMessages(uiMessages);
-        const fallback = streamText({
-          model,
-          system: systemPrompt,
-          messages: noToolMessages,
-          maxOutputTokens: maxTokens,
-        });
-        writer.merge(fallback.toUIMessageStream());
+      if (earlyErrorText) {
+        const fallbackMaxTokens = resolveProviderRetryMaxTokens(maxTokens, earlyErrorText);
+
+        if (isToolUnsupportedError(earlyErrorText)) {
+          const noToolMessages = await convertToModelMessages(uiMessages);
+          const fallback = streamText({
+            model,
+            system: systemPrompt,
+            messages: noToolMessages,
+            maxOutputTokens: fallbackMaxTokens,
+          });
+          writer.merge(fallback.toUIMessageStream());
+          return;
+        }
+
+        if (fallbackMaxTokens < maxTokens) {
+          const fallback = streamText({
+            model,
+            system: systemPrompt,
+            messages: modelMessages,
+            tools,
+            maxOutputTokens: fallbackMaxTokens,
+            stopWhen: stepCountIs(3),
+          });
+          writer.merge(fallback.toUIMessageStream());
+          return;
+        }
+
+        for (const buffered of earlyBuffer) writer.write(buffered);
+        writer.write({ type: 'error', errorText: earlyErrorText });
       }
     },
   });

--- a/src/components/chat/chat-panel.tsx
+++ b/src/components/chat/chat-panel.tsx
@@ -29,6 +29,7 @@ import { executeTool } from '@/lib/chat-tool-executor';
 import { toRenderableChatMessage } from '@/lib/chat-ui';
 import enChat from '@/lib/i18n/messages/chat/en.json';
 import zhChat from '@/lib/i18n/messages/chat/zh.json';
+import { parseProviderTokenBudget } from '@/lib/provider-token-budget';
 import { PROVIDER_REGISTRY, type ProviderId } from '@/lib/providers';
 import { detectIOSNativeHost } from '@/lib/tauri';
 import { type CEFRLevel, useAssessmentStore } from '@/stores/assessment-store';
@@ -71,13 +72,13 @@ function parseProviderError(message: string, locale: ChatLocale): ParsedError | 
   const e = locale.errors;
 
   if (lower.includes('max_tokens') || lower.includes('credits') || lower.includes('can only afford')) {
-    const tokenMatch = message.match(/requested up to (\d+) tokens.*afford (\d+)/i);
+    const tokenBudget = parseProviderTokenBudget(message);
     return {
       title: e.tokenLimit.title,
-      description: tokenMatch
+      description: tokenBudget?.requested
         ? e.tokenLimit.descriptionDetailed
-            .replace('{{requested}}', tokenMatch[1])
-            .replace('{{available}}', tokenMatch[2])
+            .replace('{{requested}}', String(tokenBudget.requested))
+            .replace('{{available}}', String(tokenBudget.available))
         : e.tokenLimit.descriptionGeneral,
       action: { label: e.openSettings, href: '/settings' },
     };

--- a/src/components/dashboard/today-plan.tsx
+++ b/src/components/dashboard/today-plan.tsx
@@ -320,93 +320,98 @@ export function TodayPlan() {
                       : 'bg-slate-50 hover:bg-indigo-50/50'
                 }`}
               >
-                <div className={`flex gap-3 ${isIOSNativeHost ? 'items-start' : 'items-center'}`}>
-                  {task.completed ? (
-                    <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-green-500" />
-                  ) : (
-                    <Circle className="mt-0.5 h-5 w-5 shrink-0 text-indigo-300" />
-                  )}
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+                  <div className={`flex min-w-0 flex-1 gap-3 ${isIOSNativeHost ? 'items-start' : 'items-center'}`}>
+                    {task.completed ? (
+                      <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-green-500" />
+                    ) : (
+                      <Circle className="mt-0.5 h-5 w-5 shrink-0 text-indigo-300" />
+                    )}
 
-                  <div
-                    className={`flex shrink-0 items-center justify-center ${isIOSNativeHost ? 'h-10 w-10 rounded-2xl shadow-[inset_0_1px_0_rgba(255,255,255,0.32)]' : 'h-8 w-8 rounded-lg'} ${color}`}
-                  >
-                    <Icon className={`${isIOSNativeHost ? 'h-5 w-5' : 'h-4 w-4'} text-white`} />
-                  </div>
+                    <div
+                      className={`flex shrink-0 items-center justify-center ${isIOSNativeHost ? 'h-10 w-10 rounded-2xl shadow-[inset_0_1px_0_rgba(255,255,255,0.32)]' : 'h-8 w-8 rounded-lg'} ${color}`}
+                    >
+                      <Icon className={`${isIOSNativeHost ? 'h-5 w-5' : 'h-4 w-4'} text-white`} />
+                    </div>
 
-                  <div className="min-w-0 flex-1">
-                    <p
-                      className={`${task.completed ? 'text-green-700' : isIOSNativeHost ? 'text-slate-900' : 'text-indigo-900'} ${isIOSNativeHost ? 'text-sm font-semibold leading-6' : 'text-sm font-medium'} ${task.completed ? 'line-through' : ''}`}
-                    >
-                      {task.title}
-                    </p>
-                    <p
-                      className={
-                        isIOSNativeHost ? 'text-sm leading-6 text-slate-500' : 'truncate text-xs text-indigo-400'
-                      }
-                    >
-                      {task.description}
-                    </p>
-                    {task.completed && latestSession && (
-                      <div
-                        className={`mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 ${isIOSNativeHost ? 'text-xs text-green-700/90' : 'text-[11px] text-green-700/90'}`}
+                    <div className="min-w-0 flex-1">
+                      <p
+                        className={`${task.completed ? 'text-green-700' : isIOSNativeHost ? 'text-slate-900' : 'text-indigo-900'} ${isIOSNativeHost ? 'text-sm font-semibold leading-6' : 'text-sm font-medium'} ${task.completed ? 'line-through' : ''}`}
                       >
-                        <span>
-                          {(todayPlanMessages.lastPracticed ?? 'Last practiced').replace(
-                            '{{time}}',
-                            timeAgo(latestSession.practicedAt, common),
-                          )}
-                        </span>
-                        {latestSession.accuracy > 0 && (
+                        {task.title}
+                      </p>
+                      <p
+                        className={
+                          isIOSNativeHost ? 'text-sm leading-6 text-slate-500' : 'truncate text-xs text-indigo-400'
+                        }
+                      >
+                        {task.description}
+                      </p>
+                      {task.completed && latestSession && (
+                        <div
+                          className={`mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 ${isIOSNativeHost ? 'text-xs text-green-700/90' : 'text-[11px] text-green-700/90'}`}
+                        >
                           <span>
-                            {(todayPlanMessages.accuracy ?? 'Accuracy {{value}}').replace(
-                              '{{value}}',
-                              `${latestSession.accuracy}%`,
+                            {(todayPlanMessages.lastPracticed ?? 'Last practiced').replace(
+                              '{{time}}',
+                              timeAgo(latestSession.practicedAt, common),
                             )}
                           </span>
-                        )}
-                        {latestSession.wpm > 0 && (
-                          <span>
-                            {(todayPlanMessages.wpm ?? 'WPM {{value}}').replace('{{value}}', String(latestSession.wpm))}
-                          </span>
-                        )}
-                      </div>
-                    )}
+                          {latestSession.accuracy > 0 && (
+                            <span>
+                              {(todayPlanMessages.accuracy ?? 'Accuracy {{value}}').replace(
+                                '{{value}}',
+                                `${latestSession.accuracy}%`,
+                              )}
+                            </span>
+                          )}
+                          {latestSession.wpm > 0 && (
+                            <span>
+                              {(todayPlanMessages.wpm ?? 'WPM {{value}}').replace(
+                                '{{value}}',
+                                String(latestSession.wpm),
+                              )}
+                            </span>
+                          )}
+                        </div>
+                      )}
+                    </div>
                   </div>
-                </div>
 
-                <div className={`mt-3 flex ${isIOSNativeHost ? 'justify-end' : 'items-center'} gap-1`}>
-                  {task.completed ? (
-                    <Link href={taskHref}>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        className={`h-9 shrink-0 cursor-pointer ${isIOSNativeHost ? 'rounded-full px-4 text-green-700 hover:bg-green-100 hover:text-green-800' : 'text-green-700 hover:bg-green-100 hover:text-green-800'}`}
-                      >
-                        <Play className="mr-1 h-3.5 w-3.5" />
-                        {todayPlanMessages.reopen ?? 'Open'}
-                      </Button>
-                    </Link>
-                  ) : (
-                    <>
-                      <button
-                        type="button"
-                        onClick={() => skipTask(task.id)}
-                        className={`cursor-pointer transition-colors ${isIOSNativeHost ? 'rounded-full border border-slate-200 px-3 py-2 text-slate-400 hover:bg-slate-100 hover:text-slate-600' : 'rounded-md p-1.5 text-indigo-300 hover:bg-indigo-50 hover:text-indigo-500'}`}
-                        title={messages.todayPlan.skip}
-                      >
-                        <SkipForward className="h-4 w-4" />
-                      </button>
-                      <Link href={getTaskHref(task)}>
+                  <div className="flex shrink-0 items-center justify-end gap-1 pl-11 sm:pl-0">
+                    {task.completed ? (
+                      <Link href={taskHref}>
                         <Button
+                          variant="ghost"
                           size="sm"
-                          className={`cursor-pointer bg-indigo-600 hover:bg-indigo-700 ${isIOSNativeHost ? 'h-10 rounded-full px-4 text-sm font-semibold shadow-[0_10px_22px_rgba(79,70,229,0.18)]' : 'h-8 px-3'}`}
+                          className={`h-9 shrink-0 cursor-pointer ${isIOSNativeHost ? 'rounded-full px-4 text-green-700 hover:bg-green-100 hover:text-green-800' : 'text-green-700 hover:bg-green-100 hover:text-green-800'}`}
                         >
                           <Play className="mr-1 h-3.5 w-3.5" />
-                          {messages.todayPlan.start}
+                          {todayPlanMessages.reopen ?? 'Open'}
                         </Button>
                       </Link>
-                    </>
-                  )}
+                    ) : (
+                      <>
+                        <button
+                          type="button"
+                          onClick={() => skipTask(task.id)}
+                          className={`cursor-pointer transition-colors ${isIOSNativeHost ? 'rounded-full border border-slate-200 px-3 py-2 text-slate-400 hover:bg-slate-100 hover:text-slate-600' : 'rounded-md p-1.5 text-indigo-300 hover:bg-indigo-50 hover:text-indigo-500'}`}
+                          title={messages.todayPlan.skip}
+                        >
+                          <SkipForward className="h-4 w-4" />
+                        </button>
+                        <Link href={getTaskHref(task)}>
+                          <Button
+                            size="sm"
+                            className={`cursor-pointer bg-indigo-600 hover:bg-indigo-700 ${isIOSNativeHost ? 'h-10 rounded-full px-4 text-sm font-semibold shadow-[0_10px_22px_rgba(79,70,229,0.18)]' : 'h-8 px-3'}`}
+                          >
+                            <Play className="mr-1 h-3.5 w-3.5" />
+                            {messages.todayPlan.start}
+                          </Button>
+                        </Link>
+                      </>
+                    )}
+                  </div>
                 </div>
               </div>
             );

--- a/src/components/read-aloud/read-aloud-floating-bar.test.tsx
+++ b/src/components/read-aloud/read-aloud-floating-bar.test.tsx
@@ -27,6 +27,14 @@ describe('ReadAloudFloatingBar', () => {
     expect(markup).toBe('');
   });
 
+  it('can hide immersive mode for word-book practice pages', () => {
+    useReadAloudStore.getState().activate('hello world');
+    const markup = renderToStaticMarkup(<ReadAloudFloatingBar {...defaultProps} showImmersive={false} />);
+
+    expect(markup).not.toContain('Immersive mode');
+    expect(markup).not.toContain('沉浸模式');
+  });
+
   describe('SPEED_STEPS logic (unit)', () => {
     const SPEED_STEPS = [0.5, 0.75, 1, 1.25, 1.5, 2];
 

--- a/src/components/read-aloud/read-aloud-floating-bar.tsx
+++ b/src/components/read-aloud/read-aloud-floating-bar.tsx
@@ -17,9 +17,16 @@ interface ReadAloudFloatingBarProps {
   onPrev: () => void;
   onNext: () => void;
   onRestart?: () => void;
+  showImmersive?: boolean;
 }
 
-export function ReadAloudFloatingBar({ onPlay, onPause, onPrev, onNext }: ReadAloudFloatingBarProps) {
+export function ReadAloudFloatingBar({
+  onPlay,
+  onPause,
+  onPrev,
+  onNext,
+  showImmersive = true,
+}: ReadAloudFloatingBarProps) {
   const raT = PRACTICE_UI_LOCALES[useLanguageStore((s) => s.interfaceLanguage)].readAloud;
   const isPlaying = useReadAloudStore((s) => s.isPlaying);
   const isActive = useReadAloudStore((s) => s.isActive);
@@ -125,18 +132,22 @@ export function ReadAloudFloatingBar({ onPlay, onPause, onPrev, onNext }: ReadAl
         </span>
       </div>
 
-      {/* Divider */}
-      <div className="w-6 h-px bg-indigo-100 my-0.5" />
+      {showImmersive && (
+        <>
+          {/* Divider */}
+          <div className="w-6 h-px bg-indigo-100 my-0.5" />
 
-      {/* Immersive mode */}
-      <button
-        type="button"
-        onClick={toggleImmersiveMode}
-        className="w-8 h-8 rounded-lg flex items-center justify-center text-indigo-400 hover:text-indigo-600 hover:bg-indigo-50 transition-colors cursor-pointer"
-        aria-label={raT.immersiveMode}
-      >
-        <Maximize2 className="w-3.5 h-3.5" />
-      </button>
+          {/* Immersive mode */}
+          <button
+            type="button"
+            onClick={toggleImmersiveMode}
+            className="w-8 h-8 rounded-lg flex items-center justify-center text-indigo-400 hover:text-indigo-600 hover:bg-indigo-50 transition-colors cursor-pointer"
+            aria-label={raT.immersiveMode}
+          >
+            <Maximize2 className="w-3.5 h-3.5" />
+          </button>
+        </>
+      )}
     </div>
   );
 }

--- a/src/components/shared/word-book-practice.tsx
+++ b/src/components/shared/word-book-practice.tsx
@@ -21,6 +21,7 @@ import { nanoid } from 'nanoid';
 import Link from 'next/link';
 import { useParams, useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { ReadAloudFloatingBar } from '@/components/read-aloud';
 import { PageSpinner } from '@/components/shared/page-spinner';
 import { fireConfetti } from '@/components/shared/practice-complete-banner';
 import { WordDictionaryInfo } from '@/components/shared/word-dictionary-info';
@@ -46,6 +47,7 @@ import { cn } from '@/lib/utils';
 import { getWordBook, loadWordBookItems } from '@/lib/wordbooks';
 import { useLanguageStore } from '@/stores/language-store';
 import { usePracticeTranslationStore } from '@/stores/practice-translation-store';
+import { useReadAloudStore } from '@/stores/read-aloud-store';
 import { useTTSStore } from '@/stores/tts-store';
 import type { ContentItem } from '@/types/content';
 import type { PracticeModule } from '@/types/translation';
@@ -217,45 +219,58 @@ function SentenceTranslation({
 
 // ─── Listen Practice ─────────────────────────────────────────────────────────
 
-function ListenPractice({
+function WordBookPlaybackControls({
   item,
+  module,
   persistProgress,
   onCompleted,
+  onPrev,
+  onNext,
 }: {
   item: ContentItem;
+  module: 'listen' | 'read';
   persistProgress: boolean;
   onCompleted?: () => void;
+  onPrev: () => void;
+  onNext: () => void;
 }) {
   const t = WB_LOCALES[useLanguageStore((s) => s.interfaceLanguage)];
-  const [isPlaying, setIsPlaying] = useState(false);
   const { createUtterance, boundaryPlaybackNotice } = useTTS();
   const speed = useTTSStore((s) => s.speed);
+  const isPlaying = useReadAloudStore((s) => s.isPlaying);
+  const activate = useReadAloudStore((s) => s.activate);
+  const deactivate = useReadAloudStore((s) => s.deactivate);
+  const setPlaying = useReadAloudStore((s) => s.setPlaying);
+  const setCurrentWordIndex = useReadAloudStore((s) => s.setCurrentWordIndex);
   const startedAtRef = useRef<number>(Date.now());
 
   useEffect(() => {
+    activate(item.text);
     return () => {
       window.speechSynthesis.cancel();
+      deactivate();
     };
-  }, []);
+  }, [activate, deactivate, item.text]);
 
-  // Reset when item changes
-  useEffect(() => {
+  const handlePause = useCallback(() => {
     window.speechSynthesis.cancel();
-    setIsPlaying(false);
-    startedAtRef.current = Date.now();
-  }, [item.id]);
+    setPlaying(false);
+  }, [setPlaying]);
 
   const handlePlay = useCallback(() => {
-    if (isPlaying) {
-      window.speechSynthesis.cancel();
-      setIsPlaying(false);
-    } else {
-      window.speechSynthesis.cancel();
-      const u = createUtterance(item.text, { rate: speed });
-      startedAtRef.current = Date.now();
-      u.onend = () => {
-        setIsPlaying(false);
-        if (!persistProgress) return;
+    window.speechSynthesis.cancel();
+    const utterance = createUtterance(item.text, { rate: speed });
+    startedAtRef.current = Date.now();
+    let wordIndex = -1;
+
+    utterance.onboundary = (event) => {
+      if (event.name !== 'word') return;
+      wordIndex += 1;
+      setCurrentWordIndex(wordIndex);
+    };
+    utterance.onend = () => {
+      setPlaying(false);
+      if (module === 'listen' && persistProgress) {
         void savePracticeSession({
           id: nanoid(),
           contentId: item.id,
@@ -271,12 +286,24 @@ function ListenPractice({
           completed: true,
         });
         onCompleted?.();
-      };
-      u.onerror = () => setIsPlaying(false);
-      window.speechSynthesis.speak(u);
-      setIsPlaying(true);
-    }
-  }, [isPlaying, item, createUtterance, onCompleted, persistProgress, speed]);
+      }
+    };
+    utterance.onerror = () => {
+      setPlaying(false);
+    };
+    window.speechSynthesis.speak(utterance);
+    setPlaying(true);
+  }, [createUtterance, item, module, onCompleted, persistProgress, setCurrentWordIndex, setPlaying, speed]);
+
+  const handlePrev = useCallback(() => {
+    handlePause();
+    onPrev();
+  }, [handlePause, onPrev]);
+
+  const handleNext = useCallback(() => {
+    handlePause();
+    onNext();
+  }, [handlePause, onNext]);
 
   return (
     <div className="space-y-3 pt-2">
@@ -285,9 +312,9 @@ function ListenPractice({
           {boundaryPlaybackNotice}
         </div>
       )}
-      <div className="flex items-center justify-center gap-3">
+      <div className="flex items-center justify-center gap-3 md:hidden">
         <Button
-          onClick={handlePlay}
+          onClick={isPlaying ? handlePause : handlePlay}
           className={cn(
             'cursor-pointer font-medium px-6',
             isPlaying ? 'bg-slate-700 hover:bg-slate-800' : 'bg-indigo-600 hover:bg-indigo-700',
@@ -311,6 +338,15 @@ function ListenPractice({
             </button>
           ))}
         </div>
+      </div>
+      <div className="hidden md:block">
+        <ReadAloudFloatingBar
+          onPlay={handlePlay}
+          onPause={handlePause}
+          onPrev={handlePrev}
+          onNext={handleNext}
+          showImmersive={false}
+        />
       </div>
     </div>
   );
@@ -787,9 +823,11 @@ function ReadSpeakPractice({
             )}
           </Button>
         </div>
-        <Button variant="outline" onClick={handleListen} className="border-indigo-200 text-indigo-600 cursor-pointer">
-          <Volume2 className="w-4 h-4 mr-1" /> {t.speak.listen}
-        </Button>
+        {module === 'speak' && (
+          <Button variant="outline" onClick={handleListen} className="border-indigo-200 text-indigo-600 cursor-pointer">
+            <Volume2 className="w-4 h-4 mr-1" /> {t.speak.listen}
+          </Button>
+        )}
       </div>
 
       {/* Status hint */}
@@ -1265,12 +1303,15 @@ export function WordBookPractice({ module }: WordBookPracticeProps) {
                 </div>
 
                 {/* Mode-specific practice area */}
-                {module === 'listen' && (
-                  <ListenPractice
+                {(module === 'listen' || module === 'read') && (
+                  <WordBookPlaybackControls
                     key={currentItem.id}
                     item={currentItem}
+                    module={module}
                     persistProgress={persistProgress}
                     onCompleted={handleItemCompleted}
+                    onPrev={goToPrev}
+                    onNext={goToNext}
                   />
                 )}
                 {module === 'write' && (
@@ -1413,8 +1454,15 @@ export function SingleItemPractice({ item, module, persistProgress = true, onCom
             <SentenceTranslation text={item.text} targetLang={targetLang} module={module} />
           </div>
 
-          {module === 'listen' && (
-            <ListenPractice item={item} persistProgress={persistProgress} onCompleted={onCompleted} />
+          {(module === 'listen' || module === 'read') && (
+            <WordBookPlaybackControls
+              item={item}
+              module={module}
+              persistProgress={persistProgress}
+              onCompleted={onCompleted}
+              onPrev={() => {}}
+              onNext={() => {}}
+            />
           )}
           {module === 'write' && (
             <WritePractice item={item} persistProgress={persistProgress} onCompleted={onCompleted} />

--- a/src/lib/ai-model.test.ts
+++ b/src/lib/ai-model.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { addOpenRouterProviderPreferences } from './ai-model';
+
+describe('addOpenRouterProviderPreferences', () => {
+  it('requires endpoints that support tools when tools are present', () => {
+    expect(addOpenRouterProviderPreferences({ tools: [{ type: 'function' }] })).toEqual({
+      tools: [{ type: 'function' }],
+      provider: { require_parameters: true },
+    });
+  });
+
+  it('preserves existing OpenRouter provider preferences', () => {
+    expect(
+      addOpenRouterProviderPreferences({
+        tools: [{ type: 'function' }],
+        provider: { sort: 'throughput' },
+      }),
+    ).toEqual({
+      tools: [{ type: 'function' }],
+      provider: { sort: 'throughput', require_parameters: true },
+    });
+  });
+
+  it('leaves text-only requests unchanged', () => {
+    const request = { model: 'meta-llama/llama-3.3-70b-instruct:free' };
+    expect(addOpenRouterProviderPreferences(request)).toBe(request);
+  });
+});

--- a/src/lib/ai-model.ts
+++ b/src/lib/ai-model.ts
@@ -50,6 +50,21 @@ function buildSdkBaseURL(origin: string, apiPath: string): string {
   return origin.replace(/\/$/, '') + prefix;
 }
 
+export function addOpenRouterProviderPreferences(args: Record<string, unknown>): Record<string, unknown> {
+  if (!Array.isArray(args.tools) || args.tools.length === 0) return args;
+
+  const provider =
+    typeof args.provider === 'object' && args.provider !== null ? (args.provider as Record<string, unknown>) : {};
+
+  return {
+    ...args,
+    provider: {
+      ...provider,
+      require_parameters: true,
+    },
+  };
+}
+
 export function resolveModel({ providerId, modelId, apiKey, baseUrl, apiPath }: ResolveOptions) {
   const effectiveModelId = modelId || getDefaultModelId(providerId);
   const def = PROVIDER_REGISTRY[providerId];
@@ -101,6 +116,7 @@ export function resolveModel({ providerId, modelId, apiKey, baseUrl, apiPath }: 
         name: providerId,
         apiKey: def.noKeyRequired ? 'ollama' : apiKey,
         baseURL: sdkBase,
+        ...(providerId === 'openrouter' ? { transformRequestBody: addOpenRouterProviderPreferences } : {}),
       })(effectiveModelId);
     }
   }

--- a/src/lib/provider-token-budget.test.ts
+++ b/src/lib/provider-token-budget.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { parseProviderTokenBudget, resolveProviderRetryMaxTokens } from './provider-token-budget';
+
+describe('parseProviderTokenBudget', () => {
+  it('parses the OpenRouter affordability error', () => {
+    expect(
+      parseProviderTokenBudget(
+        'This request requires more credits, or fewer max_tokens. You requested up to 4096 tokens, but can only afford 48.',
+      ),
+    ).toEqual({ requested: 4096, available: 48 });
+  });
+
+  it('parses a normalized token availability error', () => {
+    expect(parseProviderTokenBudget('Requested 4096 tokens but only 48 available.')).toEqual({
+      requested: 4096,
+      available: 48,
+    });
+  });
+
+  it('ignores unrelated errors and unusable budgets', () => {
+    expect(parseProviderTokenBudget('Rate limit exceeded')).toBeNull();
+    expect(parseProviderTokenBudget('Requested 4096 tokens but only 0 available.')).toBeNull();
+  });
+
+  it('reduces a rejected request to the provider affordable limit', () => {
+    expect(
+      resolveProviderRetryMaxTokens(
+        4096,
+        'This request requires more credits. You requested up to 4096 tokens, but can only afford 48.',
+      ),
+    ).toBe(48);
+  });
+
+  it('keeps the configured limit for unrelated errors', () => {
+    expect(resolveProviderRetryMaxTokens(4096, 'Tool calling is unsupported')).toBe(4096);
+  });
+});

--- a/src/lib/provider-token-budget.ts
+++ b/src/lib/provider-token-budget.ts
@@ -1,0 +1,27 @@
+export interface ProviderTokenBudget {
+  requested?: number;
+  available: number;
+}
+
+export function parseProviderTokenBudget(message: string): ProviderTokenBudget | null {
+  const requestedMatch = message.match(/requested(?:\s+up\s+to)?\s+(\d+)\s+tokens?/i);
+  const availableMatch =
+    message.match(/can\s+only\s+afford\s+(\d+)(?:\s+tokens?)?/i) ??
+    message.match(/only\s+(\d+)(?:\s+tokens?)?\s+available/i);
+
+  if (!availableMatch) return null;
+
+  const available = Number.parseInt(availableMatch[1], 10);
+  if (!Number.isFinite(available) || available <= 0) return null;
+
+  const requested = requestedMatch ? Number.parseInt(requestedMatch[1], 10) : undefined;
+  return {
+    ...(requested && Number.isFinite(requested) ? { requested } : {}),
+    available,
+  };
+}
+
+export function resolveProviderRetryMaxTokens(requestedMaxTokens: number, errorMessage: string): number {
+  const tokenBudget = parseProviderTokenBudget(errorMessage);
+  return tokenBudget ? Math.min(requestedMaxTokens, tokenBudget.available) : requestedMaxTokens;
+}


### PR DESCRIPTION
## What changed

- Move Today Plan task actions to the right on desktop so each task stays on one row.
- Use the shared floating playback controls on Listen and Read word-book practice pages.
- Improve OpenRouter chat recovery for token-budget and unsupported-tool errors.
- Require OpenRouter endpoints to support requested tool parameters before routing tool calls.
- Add focused tests for provider routing, token fallback, and playback control options.

## Why

The dashboard task controls were wrapping below the task content, playback controls differed across similar practice pages, and OpenRouter provider errors could make chat unusable or silently remove tool support.

## Validation

- `pnpm test` (96 files, 653 tests)
- `pnpm typecheck`
- `pnpm lint`
