### PR TITLE
fix: reliable live speech feedback

### DIFF
--- a/src/components/shared/word-book-practice.tsx
+++ b/src/components/shared/word-book-practice.tsx
@@ -500,10 +500,9 @@ function WritePractice({
 type SpeakPhase = 'idle' | 'listening' | 'transcribing' | 'result';
 
 const hasNativeSpeechRecognition = () => {
-  // Browser SpeechRecognition depends on an external browser service and often
-  // returns no-speech/network errors behind proxies. The server STT path uses
-  // the configured provider fallback chain and is consistent across platforms.
-  return false;
+  if (typeof window === 'undefined') return false;
+  const browserWindow = window as BrowserSpeechRecognition;
+  return Boolean(browserWindow.SpeechRecognition || browserWindow.webkitSpeechRecognition);
 };
 
 const encourageByAccuracy = (accuracy: number, enc: typeof enWordBook.encourage): string => {
@@ -542,38 +541,42 @@ function ReadSpeakPractice({
   const recognitionBaseTranscriptRef = useRef('');
   const currentSessionFinalRef = useRef('');
   const hasRecognitionResultRef = useRef(false);
-  const usingFallbackRef = useRef(false);
+  const liveTranscriptRef = useRef('');
   const itemIdRef = useRef(item.id);
   const activeRecognitionItemIdRef = useRef<string | null>(null);
-  const MAX_AUTO_RESTARTS = 3;
+  const MAX_AUTO_RESTARTS = 20;
 
   const transcript = resolveSpeechTranscript(finalTranscript, interimTranscript, useNative.current);
 
   // Fallback STT for Tauri / browsers without SpeechRecognition
   const fallbackSTT = useFallbackSTT({
     lang: 'en',
-    interimIntervalMs: 1200,
     onTranscript: useCallback((text: string) => {
       if (activeRecognitionItemIdRef.current !== itemIdRef.current) return;
-      usingFallbackRef.current = false;
       setInterimTranscript('');
       setFinalTranscript(text);
       setPhase(text ? 'result' : 'idle');
     }, []),
-    onInterimTranscript: useCallback((text: string) => {
-      if (activeRecognitionItemIdRef.current !== itemIdRef.current) return;
-      setInterimTranscript(text);
-    }, []),
+    onInterimTranscript: useNative.current
+      ? undefined
+      : (text: string) => {
+          if (activeRecognitionItemIdRef.current !== itemIdRef.current) return;
+          setInterimTranscript(text);
+        },
     onError: useCallback((error: string) => {
       if (activeRecognitionItemIdRef.current !== itemIdRef.current) return;
-      usingFallbackRef.current = false;
-      setSttError(error);
-      setPhase('idle');
+      setInterimTranscript('');
+      if (liveTranscriptRef.current) {
+        setFinalTranscript(liveTranscriptRef.current);
+        setSttError(`${error} Showing the live browser recognition result instead.`);
+        setPhase('result');
+      } else {
+        setFinalTranscript('');
+        setSttError(error);
+        setPhase('idle');
+      }
     }, []),
   });
-  const fallbackStartRef = useRef(fallbackSTT.startRecording);
-  fallbackStartRef.current = fallbackSTT.startRecording;
-
   // Reset when item changes
   useEffect(() => {
     itemIdRef.current = item.id;
@@ -591,7 +594,7 @@ function ReadSpeakPractice({
     recognitionBaseTranscriptRef.current = '';
     currentSessionFinalRef.current = '';
     hasRecognitionResultRef.current = false;
-    usingFallbackRef.current = false;
+    liveTranscriptRef.current = '';
   }, [fallbackSTT.stopRecording, item.id]);
 
   // Initialize native speech recognition
@@ -622,13 +625,15 @@ function ReadSpeakPractice({
         hasRecognitionResultRef.current = true;
       }
       currentSessionFinalRef.current = final.trim();
-      setFinalTranscript(joinSpeechTranscripts(recognitionBaseTranscriptRef.current, final));
+      const confirmed = joinSpeechTranscripts(recognitionBaseTranscriptRef.current, final);
+      const liveTranscript = joinSpeechTranscripts(confirmed, interim);
+      liveTranscriptRef.current = liveTranscript;
+      setFinalTranscript(confirmed);
       setInterimTranscript(interim);
     };
 
     rec.onend = () => {
       if (activeRecognitionItemIdRef.current !== itemIdRef.current) return;
-      if (usingFallbackRef.current) return;
       // Auto-restart if user didn't intentionally stop and we haven't exceeded retries
       if (!intentionalStopRef.current && autoRestartCountRef.current < MAX_AUTO_RESTARTS) {
         autoRestartCountRef.current += 1;
@@ -646,29 +651,24 @@ function ReadSpeakPractice({
           // Fall through to stop
         }
       }
-      setPhase((prev) => {
-        if (prev === 'listening') {
-          if (!hasRecognitionResultRef.current) {
-            setSttError('No speech was detected. Check the selected microphone and try again.');
-            return 'idle';
-          }
-          return 'result';
-        }
-        return prev;
-      });
+      if (!intentionalStopRef.current && !hasRecognitionResultRef.current) {
+        setSttError('Live word detection paused. Keep reading; final recognition will run when you stop.');
+      }
     };
 
     rec.onerror = (event: SpeechRecognitionErrorEvent) => {
       if (activeRecognitionItemIdRef.current !== itemIdRef.current) return;
       if (event.error === 'aborted' && intentionalStopRef.current) return;
 
-      intentionalStopRef.current = true;
-
       if (event.error === 'network') {
-        setSttError('Browser speech recognition is unavailable. Switching to server transcription...');
-        usingFallbackRef.current = true;
+        intentionalStopRef.current = true;
+        useNative.current = false;
+        setSttError('Live word detection is unavailable. Keep reading; final recognition will run when you stop.');
         setPhase('listening');
-        void fallbackStartRef.current();
+        return;
+      }
+
+      if (event.error === 'no-speech') {
         return;
       }
 
@@ -676,11 +676,10 @@ function ReadSpeakPractice({
         'not-allowed': 'Microphone access was denied. Allow microphone access in the browser and try again.',
         'service-not-allowed': 'Browser speech recognition is blocked. Check browser privacy settings and try again.',
         'audio-capture': 'No working microphone was found. Check the selected input device and try again.',
-        'no-speech': 'No speech was detected. Move closer to the microphone and try again.',
         'language-not-supported': 'English speech recognition is not supported by this browser.',
       };
+      intentionalStopRef.current = true;
       setSttError(messages[event.error] ?? `Speech recognition stopped: ${event.error}.`);
-      setPhase('idle');
     };
 
     recognitionRef.current = rec;
@@ -698,7 +697,7 @@ function ReadSpeakPractice({
     recognitionBaseTranscriptRef.current = '';
     currentSessionFinalRef.current = '';
     hasRecognitionResultRef.current = false;
-    usingFallbackRef.current = false;
+    liveTranscriptRef.current = '';
     startedAtRef.current = Date.now();
     activeRecognitionItemIdRef.current = item.id;
 
@@ -707,29 +706,24 @@ function ReadSpeakPractice({
       return;
     }
 
+    void fallbackSTT.startRecording();
+    setPhase('listening');
+
     if (useNative.current && recognitionRef.current) {
       intentionalStopRef.current = false;
       autoRestartCountRef.current = 0;
       try {
         recognitionRef.current.start();
-        setPhase('listening');
       } catch {
         try {
           recognitionRef.current.abort();
           setTimeout(() => {
             recognitionRef.current?.start();
-            setPhase('listening');
           }, 100);
         } catch {
-          // Native failed, try fallback
-          void fallbackSTT.startRecording();
-          setPhase('listening');
+          useNative.current = false;
         }
       }
-    } else {
-      // Use fallback STT (Tauri / unsupported browsers)
-      void fallbackSTT.startRecording();
-      setPhase('listening');
     }
   }, [fallbackSTT, item.id]);
 
@@ -742,20 +736,12 @@ function ReadSpeakPractice({
       return;
     }
 
-    if (usingFallbackRef.current) {
-      fallbackSTT.stopRecording();
-      setPhase('transcribing');
-      return;
-    }
-
     if (useNative.current && recognitionRef.current) {
       intentionalStopRef.current = true;
       recognitionRef.current.stop();
-      setPhase('result');
-    } else {
-      fallbackSTT.stopRecording();
-      setPhase('transcribing');
     }
+    fallbackSTT.stopRecording();
+    setPhase('transcribing');
   }, [fallbackSTT]);
 
   const handleListen = useCallback(() => {

--- a/src/components/shared/word-book-practice.tsx
+++ b/src/components/shared/word-book-practice.tsx
@@ -42,7 +42,13 @@ import {
   getIOSNativeQAVoiceTranscript,
   isIOSNativeQASpeakMockEnabled,
 } from '@/lib/ios-native-qa';
-import { buildSpeechWordFeedback, calculateSpeechMatch, joinSpeechTranscripts } from '@/lib/speech-feedback';
+import {
+  buildSpeechWordFeedback,
+  calculateSpeechMatch,
+  joinSpeechTranscripts,
+  resolveSpeechTranscript,
+  shouldShowSpeechFeedback,
+} from '@/lib/speech-feedback';
 import { IS_IOS_NATIVE_HOST, IS_TAURI, reportNativeQAState } from '@/lib/tauri';
 import { cn } from '@/lib/utils';
 import { getWordBook, loadWordBookItems } from '@/lib/wordbooks';
@@ -541,14 +547,16 @@ function ReadSpeakPractice({
   const activeRecognitionItemIdRef = useRef<string | null>(null);
   const MAX_AUTO_RESTARTS = 3;
 
-  const transcript = joinSpeechTranscripts(finalTranscript, interimTranscript);
+  const transcript = resolveSpeechTranscript(finalTranscript, interimTranscript, useNative.current);
 
   // Fallback STT for Tauri / browsers without SpeechRecognition
   const fallbackSTT = useFallbackSTT({
     lang: 'en',
+    interimIntervalMs: 1200,
     onTranscript: useCallback((text: string) => {
       if (activeRecognitionItemIdRef.current !== itemIdRef.current) return;
       usingFallbackRef.current = false;
+      setInterimTranscript('');
       setFinalTranscript(text);
       setPhase(text ? 'result' : 'idle');
     }, []),
@@ -798,8 +806,8 @@ function ReadSpeakPractice({
   }, [phase, item, matchResult, module, onCompleted, persistProgress, transcript]);
 
   const wordComparison = (() => {
-    if (!transcript) return null;
-    return buildSpeechWordFeedback(item.text, transcript, phase === 'listening');
+    if (!shouldShowSpeechFeedback(phase, transcript)) return null;
+    return buildSpeechWordFeedback(item.text, transcript, phase !== 'result');
   })();
 
   // Update phase when fallback STT is transcribing

--- a/src/components/shared/word-book-practice.tsx
+++ b/src/components/shared/word-book-practice.tsx
@@ -494,11 +494,10 @@ function WritePractice({
 type SpeakPhase = 'idle' | 'listening' | 'transcribing' | 'result';
 
 const hasNativeSpeechRecognition = () => {
-  if (typeof window === 'undefined') return false;
-  // In Tauri, skip native SpeechRecognition to avoid TCC crash (missing Info.plist in dev mode)
-  if (IS_TAURI && !IS_IOS_NATIVE_HOST) return false;
-  const w = window as BrowserSpeechRecognition;
-  return !!(w.SpeechRecognition || w.webkitSpeechRecognition);
+  // Browser SpeechRecognition depends on an external browser service and often
+  // returns no-speech/network errors behind proxies. The server STT path uses
+  // the configured provider fallback chain and is consistent across platforms.
+  return false;
 };
 
 const encourageByAccuracy = (accuracy: number, enc: typeof enWordBook.encourage): string => {

--- a/src/hooks/use-fallback-stt.ts
+++ b/src/hooks/use-fallback-stt.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { isCurrentSpeechSession } from '@/lib/speech-feedback';
 import { getApiBase } from '@/lib/tauri';
 import { useProviderStore } from '@/stores/provider-store';
 
@@ -49,7 +50,10 @@ export function useFallbackSTT(options: UseFallbackSTTOptions = {}): UseFallback
   const interimTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const stopFallbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const interimInFlightRef = useRef(false);
+  const interimAbortControllerRef = useRef<AbortController | null>(null);
+  const finalAbortControllerRef = useRef<AbortController | null>(null);
   const finalizingRef = useRef(false);
+  const sessionRef = useRef(0);
   const mimeTypeRef = useRef('audio/webm');
   const onTranscriptRef = useRef(onTranscript);
   const onInterimTranscriptRef = useRef(onInterimTranscript);
@@ -60,10 +64,9 @@ export function useFallbackSTT(options: UseFallbackSTTOptions = {}): UseFallback
   onErrorRef.current = onError;
 
   const sendForTranscription = useCallback(
-    async (audioBlob: Blob): Promise<string | null> => {
+    async (audioBlob: Blob, timeoutMs: number, controller: AbortController): Promise<string | null> => {
       const { activeProviderId, providers } = useProviderStore.getState();
-      const controller = new AbortController();
-      const timeoutId = window.setTimeout(() => controller.abort(), requestTimeoutMs);
+      const timeoutId = window.setTimeout(() => controller.abort(), timeoutMs);
       const formData = new FormData();
       formData.append('audio', audioBlob, 'recording.webm');
       formData.append('language', lang);
@@ -91,7 +94,7 @@ export function useFallbackSTT(options: UseFallbackSTTOptions = {}): UseFallback
         window.clearTimeout(timeoutId);
       }
     },
-    [lang, requestTimeoutMs],
+    [lang],
   );
 
   const clearInterimTimer = useCallback(() => {
@@ -116,10 +119,18 @@ export function useFallbackSTT(options: UseFallbackSTTOptions = {}): UseFallback
     const blob = new Blob(chunksRef.current, { type: mimeTypeRef.current });
     if (blob.size < 100) return;
 
+    const requestSession = sessionRef.current;
+    const controller = new AbortController();
+    interimAbortControllerRef.current = controller;
     interimInFlightRef.current = true;
-    sendForTranscription(blob)
+    sendForTranscription(blob, Math.min(requestTimeoutMs, 8000), controller)
       .then((text) => {
-        if (text != null) {
+        if (
+          text != null &&
+          !controller.signal.aborted &&
+          isCurrentSpeechSession(requestSession, sessionRef.current) &&
+          mediaRecorderRef.current?.state === 'recording'
+        ) {
           onInterimTranscriptRef.current?.(text);
         }
       })
@@ -127,14 +138,21 @@ export function useFallbackSTT(options: UseFallbackSTTOptions = {}): UseFallback
         // Interim failures are non-critical — silently ignore
       })
       .finally(() => {
-        interimInFlightRef.current = false;
+        if (interimAbortControllerRef.current === controller) {
+          interimAbortControllerRef.current = null;
+          interimInFlightRef.current = false;
+        }
       });
-  }, [sendForTranscription]);
+  }, [requestTimeoutMs, sendForTranscription]);
 
   const finalizeRecording = useCallback(async () => {
     if (finalizingRef.current) return;
     finalizingRef.current = true;
     clearStopFallbackTimer();
+    interimAbortControllerRef.current?.abort();
+    interimAbortControllerRef.current = null;
+    interimInFlightRef.current = false;
+    const requestSession = sessionRef.current;
 
     const stream = streamRef.current;
     stream?.getTracks().forEach((track) => track.stop());
@@ -154,27 +172,38 @@ export function useFallbackSTT(options: UseFallbackSTTOptions = {}): UseFallback
       setIsTranscribing(true);
     }
 
+    const controller = new AbortController();
+    finalAbortControllerRef.current = controller;
+
     try {
-      const text = await sendForTranscription(blob);
-      if (!disposedRef.current) {
+      const text = await sendForTranscription(blob, Math.max(requestTimeoutMs, 30000), controller);
+      if (!disposedRef.current && isCurrentSpeechSession(requestSession, sessionRef.current)) {
         onTranscriptRef.current?.(text ?? '');
       }
     } catch (error) {
-      if (!disposedRef.current) {
+      if (!disposedRef.current && isCurrentSpeechSession(requestSession, sessionRef.current)) {
         const message =
           error instanceof Error && error.message ? error.message : 'Failed to connect to speech recognition service.';
         onErrorRef.current?.(message);
       }
     } finally {
-      if (!disposedRef.current) {
-        setIsTranscribing(false);
+      if (finalAbortControllerRef.current === controller) {
+        finalAbortControllerRef.current = null;
       }
-      finalizingRef.current = false;
+      if (!disposedRef.current && isCurrentSpeechSession(requestSession, sessionRef.current)) {
+        setIsTranscribing(false);
+        finalizingRef.current = false;
+      }
     }
-  }, [clearStopFallbackTimer, sendForTranscription]);
+  }, [clearStopFallbackTimer, requestTimeoutMs, sendForTranscription]);
 
   const startRecording = useCallback(async () => {
     try {
+      sessionRef.current += 1;
+      interimAbortControllerRef.current?.abort();
+      finalAbortControllerRef.current?.abort();
+      interimAbortControllerRef.current = null;
+      finalAbortControllerRef.current = null;
       chunksRef.current = [];
       interimInFlightRef.current = false;
       finalizingRef.current = false;
@@ -227,6 +256,9 @@ export function useFallbackSTT(options: UseFallbackSTTOptions = {}): UseFallback
     disposedRef.current = false;
     return () => {
       disposedRef.current = true;
+      sessionRef.current += 1;
+      interimAbortControllerRef.current?.abort();
+      finalAbortControllerRef.current?.abort();
       clearInterimTimer();
       clearStopFallbackTimer();
       const recorder = mediaRecorderRef.current;

--- a/src/lib/speech-feedback.test.ts
+++ b/src/lib/speech-feedback.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { buildSpeechWordFeedback, calculateSpeechMatch, joinSpeechTranscripts } from './speech-feedback';
+import {
+  buildSpeechWordFeedback,
+  calculateSpeechMatch,
+  joinSpeechTranscripts,
+  resolveSpeechTranscript,
+  shouldShowSpeechFeedback,
+} from './speech-feedback';
 
 const sentence = 'I will send the meeting notes and action items to everyone by end of day.';
 
@@ -8,6 +14,16 @@ describe('speech feedback', () => {
     expect(joinSpeechTranscripts('I will send', 'the meeting notes and action items')).toBe(
       'I will send the meeting notes and action items',
     );
+  });
+
+  it('uses the latest accumulated server transcript without duplicating the final text', () => {
+    expect(resolveSpeechTranscript(sentence, sentence, false)).toBe(sentence);
+    expect(resolveSpeechTranscript(sentence, '', false)).toBe(sentence);
+  });
+
+  it('shows pending word feedback as soon as listening starts', () => {
+    expect(shouldShowSpeechFeedback('listening', '')).toBe(true);
+    expect(buildSpeechWordFeedback(sentence, '', true).every((result) => result.accuracy === 'pending')).toBe(true);
   });
 
   it('does not mark the unconfirmed suffix as wrong while listening', () => {

--- a/src/lib/speech-feedback.test.ts
+++ b/src/lib/speech-feedback.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   buildSpeechWordFeedback,
   calculateSpeechMatch,
+  isCurrentSpeechSession,
   joinSpeechTranscripts,
   resolveSpeechTranscript,
   shouldShowSpeechFeedback,
@@ -24,6 +25,11 @@ describe('speech feedback', () => {
   it('shows pending word feedback as soon as listening starts', () => {
     expect(shouldShowSpeechFeedback('listening', '')).toBe(true);
     expect(buildSpeechWordFeedback(sentence, '', true).every((result) => result.accuracy === 'pending')).toBe(true);
+  });
+
+  it('rejects transcription responses from an older recording session', () => {
+    expect(isCurrentSpeechSession(3, 4)).toBe(false);
+    expect(isCurrentSpeechSession(4, 4)).toBe(true);
   });
 
   it('does not mark the unconfirmed suffix as wrong while listening', () => {

--- a/src/lib/speech-feedback.ts
+++ b/src/lib/speech-feedback.ts
@@ -24,6 +24,10 @@ export function shouldShowSpeechFeedback(phase: string, transcript: string): boo
   return phase === 'listening' || phase === 'transcribing' || Boolean(transcript.trim());
 }
 
+export function isCurrentSpeechSession(requestSession: number, activeSession: number): boolean {
+  return requestSession === activeSession;
+}
+
 export function normalizeSpeechWords(text: string): string[] {
   return text
     .toLowerCase()

--- a/src/lib/speech-feedback.ts
+++ b/src/lib/speech-feedback.ts
@@ -13,6 +13,17 @@ export function joinSpeechTranscripts(...parts: string[]): string {
     .join(' ');
 }
 
+export function resolveSpeechTranscript(finalText: string, interimText: string, combinesSegments: boolean): string {
+  if (combinesSegments) {
+    return joinSpeechTranscripts(finalText, interimText);
+  }
+  return interimText.trim() || finalText.trim();
+}
+
+export function shouldShowSpeechFeedback(phase: string, transcript: string): boolean {
+  return phase === 'listening' || phase === 'transcribing' || Boolean(transcript.trim());
+}
+
 export function normalizeSpeechWords(text: string): string[] {
   return text
     .toLowerCase()


### PR DESCRIPTION
## Summary

- use browser `SpeechRecognition` for low-latency progressive word highlighting
- record the same session with `MediaRecorder` and use server STT for final scoring
- prevent stale interim/final requests from updating a newer recording session
- keep the live browser transcript when final server transcription times out
- show pending words immediately and avoid duplicate final/interim transcripts

## Root cause

Server-side Whisper transcription is batch-oriented. Polling accumulated audio could wait for pauses, return late, and allow an older request to overwrite a newer recording. Treating those responses as real-time recognition caused delayed updates, duplicated text, stale all-green states, and timeout/result combinations.

## Validation

- `pnpm test`: 97 files, 660 tests passed
- `pnpm typecheck`
- `pnpm lint`
- real hardware browser test with no mocked speech APIs or intercepted STT responses:
  - macOS `say` played the page sentence through MacBook speakers
  - Chrome captured it through the real MacBook microphone
  - live correct words progressed from 0 to 2 to 3 to 5 to 8 while speaking
  - unread words remained pending
  - final server STT returned 90% (9/10 words), with `Wang` correctly shown as the only mismatch
