### PR TITLE
Fix favorites popup folder state and partial selections

### DIFF
--- a/e2e/listen.spec.ts
+++ b/e2e/listen.spec.ts
@@ -285,7 +285,7 @@ test.describe('Listen Module', () => {
     await expect(page.getByText('行动')).toHaveCount(0);
   });
 
-  test('listen popup shows sanitized translation, favorite success, and speech comparison', async ({ page }) => {
+  test('listen popup keeps partial selections scoped and favorite interactions stay in sync', async ({ page }) => {
     await setupSelectionTranslationMocks(page);
     await page.goto('/listen/book/junior-high');
     await expect(page.getByText('Listen Mode')).toBeVisible({ timeout: 15000 });
@@ -296,6 +296,7 @@ test.describe('Listen Module', () => {
 
     const popup = page.getByRole('dialog', { name: 'Translation popup' });
     await expect(popup).toBeVisible({ timeout: 10000 });
+    await expect(popup.locator('span.text-sm.font-medium.text-slate-900')).toHaveText('action');
     await expect(popup.getByText('行动', { exact: true })).toBeVisible();
     await expect(popup.locator('p.text-xs.leading-relaxed.text-slate-500')).toContainText(
       'The government must take action now to stop the rise in violent crime.',
@@ -303,14 +304,25 @@ test.describe('Listen Module', () => {
     await expect(popup).not.toContainText('=');
 
     await popup.getByRole('button', { name: '♡ 收藏' }).click();
-    await expect(popup.getByRole('button', { name: '✓ 已收藏' })).toBeVisible();
+    await expect(popup.getByRole('button', { name: '取消收藏' })).toBeVisible();
+
+    await popup.getByLabel('选择收藏夹').selectOption('auto');
+    await expect(popup.getByRole('button', { name: '移动到此收藏夹' })).toBeVisible();
+    await popup.getByRole('button', { name: '移动到此收藏夹' }).click();
+    await expect(popup.getByRole('button', { name: '取消收藏' })).toBeVisible();
 
     await popup.getByRole('button', { name: 'Speak' }).click();
     const spokenTexts = await page.evaluate(() => (window as any).__spokenTexts as string[]);
-    expect(spokenTexts[0]).toBe('The government must take action now to stop the rise in violent crime.');
+    expect(spokenTexts[0]).toBe('action');
     expect(spokenTexts[0]).not.toContain('=');
 
     await popup.getByRole('button', { name: 'Record speech' }).click();
     await expect(popup.getByText('action ✓')).toBeVisible({ timeout: 3000 });
+
+    await page.goto('/favorites');
+    await expect(page.getByRole('heading', { level: 1, name: 'Favorites' })).toBeVisible();
+    await page.getByRole('button', { name: '🤖 智能收藏' }).click();
+    await expect(page.getByText('action', { exact: true })).toBeVisible();
+    await expect(page.getByText('行动', { exact: true })).toBeVisible();
   });
 });

--- a/src/app/api/translate/route.test.ts
+++ b/src/app/api/translate/route.test.ts
@@ -79,4 +79,59 @@ describe('POST /api/translate', () => {
       pronunciation: 'træʃ',
     });
   });
+
+  it('extracts structured translation JSON surrounded by model commentary', async () => {
+    generateTextMock.mockResolvedValue({
+      text: `Here is the translation:
+      {
+        "itemTranslation": "绝对美味",
+        "exampleSentence": "The food was absolutely delicious.",
+        "exampleTranslation": "食物非常美味。"
+      }
+      Hope this helps!`,
+    });
+
+    const response = await POST(
+      makeRequest({
+        text: 'absolutely delicious',
+        context: 'The food was absolutely delicious.',
+        targetLang: 'zh-CN',
+        selectionType: 'phrase',
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      translation: '绝对美味',
+      itemTranslation: '绝对美味',
+      exampleSentence: 'The food was absolutely delicious.',
+      exampleTranslation: '食物非常美味。',
+    });
+  });
+
+  it('does not expose the raw JSON response when itemTranslation is empty', async () => {
+    generateTextMock.mockResolvedValue({
+      text: JSON.stringify({
+        itemTranslation: '',
+        exampleSentence: 'The food was absolutely delicious.',
+        exampleTranslation: '',
+        related: { relatedPhrases: ['extremely tasty'] },
+      }),
+    });
+
+    const response = await POST(
+      makeRequest({
+        text: 'absolutely delicious',
+        context: 'The food was absolutely delicious.',
+        targetLang: 'zh-CN',
+        selectionType: 'phrase',
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.translation).toBe('');
+    expect(payload.itemTranslation).toBe('');
+    expect(payload.translation).not.toContain('itemTranslation');
+  });
 });

--- a/src/app/api/translate/route.ts
+++ b/src/app/api/translate/route.ts
@@ -1,6 +1,7 @@
 import { generateText } from 'ai';
 import { NextRequest, NextResponse } from 'next/server';
 import { resolveApiKey, resolveModel } from '@/lib/ai-model';
+import { parseAIJson } from '@/lib/parse-ai-json';
 import { enforcePlatformRateLimit } from '@/lib/platform-provider';
 import { ProviderResolutionError, resolveProviderForCapability } from '@/lib/provider-resolver';
 import { type ProviderConfig, type ProviderId } from '@/lib/providers';
@@ -146,13 +147,10 @@ export async function POST(req: NextRequest) {
       const prompt = context ? `${text ?? ''}\n\nContext: ${context}` : (text ?? '');
       const { text: result } = await generateText({ model, system, prompt });
 
-      try {
-        const cleaned = result
-          .trim()
-          .replace(/^```json?\s*/, '')
-          .replace(/\s*```$/, '');
-        const parsed = JSON.parse(cleaned) as Partial<SelectionTranslateResponse> & { translation?: string };
-        const itemTranslation = parsed.itemTranslation || parsed.translation || result;
+      const parsedResult = parseAIJson<Partial<SelectionTranslateResponse> & { translation?: string }>(result);
+      if (parsedResult.data) {
+        const parsed = parsedResult.data;
+        const itemTranslation = parsed.itemTranslation?.trim() || parsed.translation?.trim() || '';
         return NextResponse.json({
           translation: itemTranslation,
           itemTranslation,
@@ -165,17 +163,18 @@ export async function POST(req: NextRequest) {
           fallbackApplied: resolution.fallbackApplied,
           fallbackReason: resolution.fallbackReason,
         });
-      } catch {
-        // Fallback: return raw text as translation
-        return NextResponse.json({
-          translation: result,
-          itemTranslation: result,
-          providerId: resolution.providerId,
-          credentialSource: resolution.credentialSource,
-          fallbackApplied: resolution.fallbackApplied,
-          fallbackReason: resolution.fallbackReason,
-        });
       }
+
+      // Some providers ignore the JSON instruction and return a plain translation.
+      const plainTranslation = result.trim();
+      return NextResponse.json({
+        translation: plainTranslation,
+        itemTranslation: plainTranslation,
+        providerId: resolution.providerId,
+        credentialSource: resolution.credentialSource,
+        fallbackApplied: resolution.fallbackApplied,
+        fallbackReason: resolution.fallbackReason,
+      });
     }
 
     // Single text fallback (original behavior)

--- a/src/components/favorites/favorite-item-row.test.tsx
+++ b/src/components/favorites/favorite-item-row.test.tsx
@@ -1,0 +1,45 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/tauri', () => ({
+  detectIOSNativeHost: () => false,
+}));
+
+vi.mock('@/stores/favorite-store', () => ({
+  useFavoriteStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      removeFavorite: vi.fn(),
+    }),
+}));
+
+import { FavoriteItemRow } from './favorite-item-row';
+
+describe('FavoriteItemRow', () => {
+  it('renders the review status as a filled metadata pill inside the content area', () => {
+    const markup = renderToStaticMarkup(
+      <FavoriteItemRow
+        item={{
+          id: 'favorite-1',
+          text: 'We are running short on time',
+          normalizedText: 'we are running short on time',
+          translation: '我们时间不太充裕了',
+          type: 'sentence',
+          folderId: 'default',
+          targetLang: 'zh-CN',
+          autoCollected: false,
+          createdAt: 1,
+          updatedAt: 1,
+        }}
+        isExpanded={false}
+        onToggle={vi.fn()}
+      />,
+    );
+
+    const statusIndex = markup.indexOf('data-testid="favorite-status-favorite-1"');
+    const playIndex = markup.indexOf('aria-label="Play favorite');
+
+    expect(statusIndex).toBeGreaterThan(-1);
+    expect(markup).toContain('bg-slate-100');
+    expect(statusIndex).toBeLessThan(playIndex);
+  });
+});

--- a/src/components/favorites/favorite-item-row.tsx
+++ b/src/components/favorites/favorite-item-row.tsx
@@ -21,12 +21,12 @@ const TYPE_BADGE = {
 } as const;
 
 function getReviewStatus(item: FavoriteItem): { label: string; color: string } {
-  if (!item.fsrsCard) return { label: 'New', color: 'text-slate-500' };
+  if (!item.fsrsCard) return { label: 'New', color: 'bg-slate-100 text-slate-500' };
   const state = item.fsrsCard.state;
-  if (state === 0) return { label: 'New', color: 'text-slate-500' };
-  if (state === 1 || state === 3) return { label: 'Learning', color: 'text-amber-600' };
-  if (state === 2) return { label: 'Mastered', color: 'text-emerald-600' };
-  return { label: 'Due', color: 'text-amber-600' };
+  if (state === 0) return { label: 'New', color: 'bg-slate-100 text-slate-500' };
+  if (state === 1 || state === 3) return { label: 'Learning', color: 'bg-amber-50 text-amber-600' };
+  if (state === 2) return { label: 'Mastered', color: 'bg-emerald-50 text-emerald-600' };
+  return { label: 'Due', color: 'bg-amber-50 text-amber-600' };
 }
 
 export function FavoriteItemRow({ item, isExpanded, onToggle }: Props) {
@@ -97,38 +97,31 @@ export function FavoriteItemRow({ item, isExpanded, onToggle }: Props) {
         <p className={cn('truncate text-slate-500', isIOSNativeHost ? 'mt-0.5 text-[13px]' : 'text-xs')}>
           {item.translation}
         </p>
-        {isIOSNativeHost ? (
-          <div className="mt-2 flex flex-wrap items-center gap-2">
-            <span className={cn(IOS_PILL_CLASS, 'px-2.5 py-1 text-[10px] font-medium')}>{reviewStatus.label}</span>
-            {item.autoCollected ? (
-              <span className={cn(IOS_PILL_CLASS, 'px-2.5 py-1 text-[10px] font-medium')}>AI saved</span>
-            ) : null}
-          </div>
-        ) : null}
+        <div className={cn('flex flex-wrap items-center gap-2', isIOSNativeHost ? 'mt-2' : 'mt-1')}>
+          <span
+            data-testid={`favorite-status-${item.id}`}
+            className={cn(
+              'rounded-full font-medium',
+              isIOSNativeHost ? cn(IOS_PILL_CLASS, 'px-2.5 py-1 text-[10px]') : 'px-2 py-0.5 text-[10px]',
+              reviewStatus.color,
+            )}
+          >
+            {reviewStatus.label}
+          </span>
+          {item.autoCollected ? (
+            <span
+              className={cn(
+                'rounded-full font-medium',
+                isIOSNativeHost
+                  ? cn(IOS_PILL_CLASS, 'px-2.5 py-1 text-[10px]')
+                  : 'bg-slate-100 px-2 py-0.5 text-[10px] text-slate-500',
+              )}
+            >
+              {isIOSNativeHost ? 'AI saved' : 'AI'}
+            </span>
+          ) : null}
+        </div>
       </div>
-
-      {!isIOSNativeHost && item.autoCollected && (
-        <span
-          className={cn(
-            'shrink-0 rounded-full bg-slate-100 text-slate-500',
-            isIOSNativeHost ? 'px-2 py-1 text-[10px]' : 'px-1.5 py-0.5 text-[10px]',
-          )}
-        >
-          AI
-        </span>
-      )}
-
-      {!isIOSNativeHost ? (
-        <span
-          className={cn(
-            'shrink-0 rounded-full border border-slate-200 bg-white text-[10px]',
-            isIOSNativeHost ? 'px-2.5 py-1 font-medium' : 'px-0 py-0',
-            reviewStatus.color,
-          )}
-        >
-          {reviewStatus.label}
-        </span>
-      ) : null}
 
       <div
         className={cn(

--- a/src/components/favorites/folder-chips.test.tsx
+++ b/src/components/favorites/folder-chips.test.tsx
@@ -1,0 +1,33 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/tauri', () => ({
+  detectIOSNativeHost: () => false,
+}));
+
+vi.mock('@/stores/favorite-store', () => ({
+  useFavoriteStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      folders: [
+        { id: 'default', name: '默认收藏', emoji: '⭐', sortOrder: 0, createdAt: 1 },
+        { id: 'empty-folder', name: '单词收藏', emoji: '📚', sortOrder: 1, createdAt: 2 },
+      ],
+      favorites: [],
+      activeFolderId: null,
+      setActiveFolderId: vi.fn(),
+    }),
+}));
+
+vi.mock('./folder-manage-dialog', () => ({
+  FolderManageDialog: () => null,
+}));
+
+import { FolderChips } from './folder-chips';
+
+describe('FolderChips', () => {
+  it('shows newly created folders even when they do not contain favorites yet', () => {
+    const markup = renderToStaticMarkup(<FolderChips />);
+
+    expect(markup).toContain('📚 单词收藏');
+  });
+});

--- a/src/components/favorites/folder-chips.tsx
+++ b/src/components/favorites/folder-chips.tsx
@@ -10,14 +10,9 @@ import { FolderManageDialog } from './folder-manage-dialog';
 export function FolderChips() {
   const isIOSNativeHost = detectIOSNativeHost();
   const folders = useFavoriteStore((s) => s.folders);
-  const favorites = useFavoriteStore((s) => s.favorites);
   const activeFolderId = useFavoriteStore((s) => s.activeFolderId);
   const setActiveFolderId = useFavoriteStore((s) => s.setActiveFolderId);
   const [showManage, setShowManage] = useState(false);
-  const visibleFolders = folders.filter((folder) => {
-    if (folder.id === activeFolderId) return true;
-    return favorites.some((favorite) => favorite.folderId === folder.id);
-  });
   const getFolderLabel = (folder: (typeof folders)[number]) => {
     if (!isIOSNativeHost) return folder.name;
     if (folder.id === 'default') return 'Default';
@@ -55,7 +50,7 @@ export function FolderChips() {
           All
         </button>
 
-        {visibleFolders.map((f) => (
+        {folders.map((f) => (
           <button
             key={f.id}
             type="button"

--- a/src/components/selection-translation/selection-translation-popup.tsx
+++ b/src/components/selection-translation/selection-translation-popup.tsx
@@ -5,6 +5,7 @@ import { forwardRef, useCallback, useEffect, useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { Button } from '@/components/ui/button';
 import { useTTS } from '@/hooks/use-tts';
+import { getFavoriteSelectionAction } from '@/lib/favorite-selection-action';
 import { IS_IOS_NATIVE_HOST, IS_TAURI } from '@/lib/tauri';
 import { normalizeText } from '@/lib/text-normalize';
 import { cn } from '@/lib/utils';
@@ -54,7 +55,7 @@ export const SelectionTranslationPopup = forwardRef<HTMLDivElement, Props>(
     const favorites = useFavoriteStore((s) => s.favorites);
     const addFavorite = useFavoriteStore((s) => s.addFavorite);
     const removeFavorite = useFavoriteStore((s) => s.removeFavorite);
-    const getFavoriteByText = useFavoriteStore((s) => s.getFavoriteByText);
+    const updateFavorite = useFavoriteStore((s) => s.updateFavorite);
     const loadFavorites = useFavoriteStore((s) => s.loadFavorites);
     const isFavoritesLoaded = useFavoriteStore((s) => s.isLoaded);
     const folders = useFavoriteStore((s) => s.folders);
@@ -63,10 +64,11 @@ export const SelectionTranslationPopup = forwardRef<HTMLDivElement, Props>(
     const { speak: speakSelection } = useTTS();
     const [selectedFolderId, setSelectedFolderId] = useState(activeFolderId || 'default');
 
-    const alreadyFavorited = useMemo(() => {
+    const existingFavorite = useMemo(() => {
       const normalized = normalizeText(selection.favoriteText);
-      return favorites.some((f) => f.normalizedText === normalized);
+      return favorites.find((f) => f.normalizedText === normalized);
     }, [favorites, selection.favoriteText]);
+    const favoriteAction = getFavoriteSelectionAction(existingFavorite, selectedFolderId);
 
     const spokenMatchesFavorite = useMemo(() => {
       if (spokenText === null) return false;
@@ -182,14 +184,20 @@ export const SelectionTranslationPopup = forwardRef<HTMLDivElement, Props>(
       async (e: React.MouseEvent) => {
         e.stopPropagation();
         setFavoriteError(null);
-        if (alreadyFavorited) {
-          const existing = getFavoriteByText(selection.favoriteText);
-          if (existing) {
-            try {
-              await removeFavorite(existing.id);
-            } catch (err) {
-              setFavoriteError(err instanceof Error ? err.message : 'Failed to remove favorite');
-            }
+        if (favoriteAction === 'remove' && existingFavorite) {
+          try {
+            await removeFavorite(existingFavorite.id);
+          } catch (err) {
+            setFavoriteError(err instanceof Error ? err.message : 'Failed to remove favorite');
+          }
+        } else if (favoriteAction === 'move' && existingFavorite) {
+          try {
+            await updateFavorite(existingFavorite.id, {
+              folderId: selectedFolderId,
+              autoCollected: false,
+            });
+          } catch (err) {
+            setFavoriteError(err instanceof Error ? err.message : 'Failed to move favorite');
           }
         } else if (result) {
           const translatedText = result.itemTranslation || result.translation;
@@ -212,14 +220,15 @@ export const SelectionTranslationPopup = forwardRef<HTMLDivElement, Props>(
         }
       },
       [
-        alreadyFavorited,
+        favoriteAction,
+        existingFavorite,
         selection,
         result,
         selectedFolderId,
         targetLang,
         addFavorite,
         removeFavorite,
-        getFavoriteByText,
+        updateFavorite,
       ],
     );
 
@@ -334,31 +343,32 @@ export const SelectionTranslationPopup = forwardRef<HTMLDivElement, Props>(
           {result?.translation && (
             <div className="border-t border-slate-100 bg-slate-50/30 px-3 py-2">
               <div className="flex items-end gap-2">
-                {!alreadyFavorited && (
-                  <label className="min-w-0 flex-1 text-[10px] font-medium text-slate-500">
-                    收藏到
-                    <select
-                      aria-label="选择收藏夹"
-                      value={selectedFolderId}
-                      onChange={(e) => setSelectedFolderId(e.target.value)}
-                      className="mt-1 h-8 w-full rounded-md border border-slate-200 bg-white px-2 text-xs text-slate-700"
-                    >
-                      {folders.length === 0 ? <option value="default">⭐ 默认收藏</option> : null}
-                      {folders.map((f) => (
-                        <option key={f.id} value={f.id}>
-                          {f.emoji} {f.name}
-                        </option>
-                      ))}
-                    </select>
-                  </label>
-                )}
+                <label className="min-w-0 flex-1 text-[10px] font-medium text-slate-500">
+                  收藏到
+                  <select
+                    aria-label="选择收藏夹"
+                    value={selectedFolderId}
+                    onChange={(e) => setSelectedFolderId(e.target.value)}
+                    className="mt-1 h-8 w-full rounded-md border border-slate-200 bg-white px-2 text-xs text-slate-700"
+                  >
+                    {folders.length === 0 ? <option value="default">⭐ 默认收藏</option> : null}
+                    {folders.map((f) => (
+                      <option key={f.id} value={f.id}>
+                        {f.emoji} {f.name}
+                      </option>
+                    ))}
+                  </select>
+                </label>
                 <Button
-                  variant={alreadyFavorited ? 'default' : 'outline'}
+                  variant={favoriteAction === 'remove' ? 'default' : 'outline'}
                   size="sm"
-                  className={cn('h-8 text-xs', alreadyFavorited ? 'bg-green-500 hover:bg-green-600' : 'shrink-0')}
+                  className={cn(
+                    'h-8 shrink-0 text-xs',
+                    favoriteAction === 'remove' && 'bg-green-500 hover:bg-green-600',
+                  )}
                   onClick={handleFavorite}
                 >
-                  {alreadyFavorited ? '✓ 已收藏' : '♡ 收藏'}
+                  {favoriteAction === 'remove' ? '取消收藏' : favoriteAction === 'move' ? '移动到此收藏夹' : '♡ 收藏'}
                 </Button>
               </div>
               {favoriteError && <p className="mt-1 text-[11px] leading-4 text-red-500">{favoriteError}</p>}

--- a/src/components/selection-translation/selection-translation-popup.tsx
+++ b/src/components/selection-translation/selection-translation-popup.tsx
@@ -55,10 +55,13 @@ export const SelectionTranslationPopup = forwardRef<HTMLDivElement, Props>(
     const addFavorite = useFavoriteStore((s) => s.addFavorite);
     const removeFavorite = useFavoriteStore((s) => s.removeFavorite);
     const getFavoriteByText = useFavoriteStore((s) => s.getFavoriteByText);
+    const loadFavorites = useFavoriteStore((s) => s.loadFavorites);
+    const isFavoritesLoaded = useFavoriteStore((s) => s.isLoaded);
     const folders = useFavoriteStore((s) => s.folders);
+    const activeFolderId = useFavoriteStore((s) => s.activeFolderId);
     const targetLang = useTTSStore((s) => s.targetLang);
     const { speak: speakSelection } = useTTS();
-    const [selectedFolderId, setSelectedFolderId] = useState('default');
+    const [selectedFolderId, setSelectedFolderId] = useState(activeFolderId || 'default');
 
     const alreadyFavorited = useMemo(() => {
       const normalized = normalizeText(selection.favoriteText);
@@ -74,7 +77,23 @@ export const SelectionTranslationPopup = forwardRef<HTMLDivElement, Props>(
       setFavoriteError(null);
       setCopied(false);
       setSpokenText(null);
-    }, []);
+      setSelectedFolderId(activeFolderId || 'default');
+    }, [activeFolderId, selection.selectionId]);
+
+    useEffect(() => {
+      if (!isFavoritesLoaded) {
+        void loadFavorites();
+      }
+    }, [isFavoritesLoaded, loadFavorites]);
+
+    useEffect(() => {
+      if (folders.length === 0) return;
+      if (!folders.some((folder) => folder.id === selectedFolderId)) {
+        const preferredFolderId =
+          activeFolderId && folders.some((folder) => folder.id === activeFolderId) ? activeFolderId : folders[0]!.id;
+        setSelectedFolderId(preferredFolderId);
+      }
+    }, [activeFolderId, folders, selectedFolderId]);
 
     const position = useMemo(() => {
       const { rect } = selection;
@@ -314,28 +333,33 @@ export const SelectionTranslationPopup = forwardRef<HTMLDivElement, Props>(
           {/* Footer */}
           {result?.translation && (
             <div className="border-t border-slate-100 bg-slate-50/30 px-3 py-2">
-              <div className="flex items-center gap-2">
+              <div className="flex items-end gap-2">
+                {!alreadyFavorited && (
+                  <label className="min-w-0 flex-1 text-[10px] font-medium text-slate-500">
+                    收藏到
+                    <select
+                      aria-label="选择收藏夹"
+                      value={selectedFolderId}
+                      onChange={(e) => setSelectedFolderId(e.target.value)}
+                      className="mt-1 h-8 w-full rounded-md border border-slate-200 bg-white px-2 text-xs text-slate-700"
+                    >
+                      {folders.length === 0 ? <option value="default">⭐ 默认收藏</option> : null}
+                      {folders.map((f) => (
+                        <option key={f.id} value={f.id}>
+                          {f.emoji} {f.name}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                )}
                 <Button
                   variant={alreadyFavorited ? 'default' : 'outline'}
                   size="sm"
-                  className={cn('h-7 text-xs', alreadyFavorited && 'bg-green-500 hover:bg-green-600')}
+                  className={cn('h-8 text-xs', alreadyFavorited ? 'bg-green-500 hover:bg-green-600' : 'shrink-0')}
                   onClick={handleFavorite}
                 >
                   {alreadyFavorited ? '✓ 已收藏' : '♡ 收藏'}
                 </Button>
-                {!alreadyFavorited && (
-                  <select
-                    value={selectedFolderId}
-                    onChange={(e) => setSelectedFolderId(e.target.value)}
-                    className="h-7 text-xs border rounded px-1.5 bg-white text-slate-600"
-                  >
-                    {folders.map((f) => (
-                      <option key={f.id} value={f.id}>
-                        {f.emoji} {f.name}
-                      </option>
-                    ))}
-                  </select>
-                )}
               </div>
               {favoriteError && <p className="mt-1 text-[11px] leading-4 text-red-500">{favoriteError}</p>}
             </div>

--- a/src/lib/__tests__/favorite-selection-action.test.ts
+++ b/src/lib/__tests__/favorite-selection-action.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { getFavoriteSelectionAction } from '@/lib/favorite-selection-action';
+
+describe('getFavoriteSelectionAction', () => {
+  it('adds a new favorite to the selected folder', () => {
+    expect(getFavoriteSelectionAction(undefined, 'folder-a')).toBe('add');
+  });
+
+  it('moves an existing favorite when another folder is selected', () => {
+    expect(getFavoriteSelectionAction({ folderId: 'auto' }, 'folder-a')).toBe('move');
+  });
+
+  it('removes an existing favorite when its current folder remains selected', () => {
+    expect(getFavoriteSelectionAction({ folderId: 'folder-a' }, 'folder-a')).toBe('remove');
+  });
+});

--- a/src/lib/__tests__/selection-translation-text.test.ts
+++ b/src/lib/__tests__/selection-translation-text.test.ts
@@ -14,8 +14,8 @@ describe('buildSelectionTextPayload', () => {
       'trash',
     );
 
-    expect(payload.displayText).toBe('Will someone take out the trash?');
-    expect(payload.speechText).toBe('Will someone take out the trash?');
+    expect(payload.displayText).toBe('trash');
+    expect(payload.speechText).toBe('trash');
     expect(payload.speechText).not.toContain('=');
     expect(payload.favoriteText).toBe('trash');
   });
@@ -24,11 +24,16 @@ describe('buildSelectionTextPayload', () => {
     expect(sanitizeSelectionSentence('A = B is true.')).toBe('A = B is true.');
   });
 
-  it('uses sanitized sentence text for translation and history lookups', () => {
-    const payload = buildSelectionTextPayload('Will someone take out the trash (= take it outside the house)?', 'trash');
+  it('keeps a partial sentence selection for display, translation, history, and favorites', () => {
+    const payload = buildSelectionTextPayload(
+      'We are running short on time, so we need to decide now.',
+      'running short on time',
+    );
 
-    expect(getSelectionTranslationText(payload, 'sentence')).toBe('Will someone take out the trash?');
-    expect(getSelectionHistoryText(payload, 'sentence')).toBe('Will someone take out the trash?');
+    expect(payload.displayText).toBe('running short on time');
+    expect(getSelectionTranslationText(payload, 'sentence')).toBe('running short on time');
+    expect(getSelectionHistoryText(payload, 'sentence')).toBe('running short on time');
+    expect(getSelectionFavoriteText(payload, 'sentence')).toBe('running short on time');
   });
 
   it('keeps word and phrase lookups anchored to the selected term', () => {
@@ -38,10 +43,10 @@ describe('buildSelectionTextPayload', () => {
     expect(getSelectionHistoryText(payload, 'phrase')).toBe('trash');
   });
 
-  it('uses sanitized sentence text for sentence favorites', () => {
+  it('sanitizes inline explanations when the full selected sentence contains them', () => {
     const payload = buildSelectionTextPayload('Will someone take out the trash (= take it outside the house)?', 'Will someone take out the trash (= take it outside the house)?');
 
     expect(getSelectionFavoriteText(payload, 'sentence')).toBe('Will someone take out the trash?');
-    expect(getSelectionFavoriteText(payload, 'word')).toBe('Will someone take out the trash (= take it outside the house)?');
+    expect(getSelectionFavoriteText(payload, 'word')).toBe('Will someone take out the trash?');
   });
 });

--- a/src/lib/favorite-selection-action.ts
+++ b/src/lib/favorite-selection-action.ts
@@ -1,0 +1,9 @@
+export type FavoriteSelectionAction = 'add' | 'move' | 'remove';
+
+export function getFavoriteSelectionAction(
+  existingFavorite: { folderId: string } | undefined,
+  selectedFolderId: string,
+): FavoriteSelectionAction {
+  if (!existingFavorite) return 'add';
+  return existingFavorite.folderId === selectedFolderId ? 'remove' : 'move';
+}

--- a/src/lib/selection-translation-text.ts
+++ b/src/lib/selection-translation-text.ts
@@ -47,13 +47,12 @@ export function sanitizeSelectionSentence(rawText: string): string {
 
 export function buildSelectionTextPayload(contextText: string | undefined, selectedText: string): SelectionTextPayload {
   const fallbackText = normalizeWhitespace(selectedText);
-  const sourceText = contextText?.trim() ? contextText : fallbackText;
-  const displayText = sanitizeSelectionSentence(sourceText);
+  const selectedDisplayText = sanitizeSelectionSentence(fallbackText);
 
   return {
-    displayText,
-    speechText: displayText,
-    favoriteText: fallbackText || displayText,
+    displayText: selectedDisplayText,
+    speechText: selectedDisplayText,
+    favoriteText: selectedDisplayText,
   };
 }
 
@@ -61,13 +60,13 @@ export function getSelectionTranslationText(
   payload: SelectionTextPayload,
   type: 'word' | 'phrase' | 'sentence',
 ): string {
-  return type === 'sentence' ? payload.displayText : payload.favoriteText;
+  return payload.favoriteText;
 }
 
 export function getSelectionHistoryText(payload: SelectionTextPayload, type: 'word' | 'phrase' | 'sentence'): string {
-  return type === 'sentence' ? payload.displayText : payload.favoriteText;
+  return payload.favoriteText;
 }
 
 export function getSelectionFavoriteText(payload: SelectionTextPayload, type: 'word' | 'phrase' | 'sentence'): string {
-  return type === 'sentence' ? payload.displayText : payload.favoriteText;
+  return payload.favoriteText;
 }


### PR DESCRIPTION
## Summary
- keep selection translation payloads anchored to the actual highlighted text instead of expanding partial selections
- align favorites popup actions with current folder semantics, including move/remove states and related API coverage
- update the listen e2e flow to verify the current popup UI, speech text, folder move interaction, and favorites page result

## Verification
- pnpm exec playwright test e2e/listen.spec.ts --grep "listen popup keeps partial selections scoped and favorite interactions stay in sync" --project=chromium
- pnpm vitest run src/lib/__tests__/selection-translation-text.test.ts src/lib/__tests__/favorite-selection-action.test.ts
- pre-commit hook: biome check --write --no-errors-on-unmatched
- pre-commit hook: tsc --noEmit