### PR TITLE
Fix dashboard plan sync and unify inline playback controls

### DIFF
--- a/e2e/listen.spec.ts
+++ b/e2e/listen.spec.ts
@@ -219,6 +219,7 @@ test.describe('Listen Module', () => {
   test('listen detail page has playback controls', async ({ page }) => {
     await navigateToContentDetail(page, 'listen');
 
+    await expect(page.getByTestId('read-aloud-inline-controls')).toBeVisible();
     // Should have Play button
     await expect(page.getByRole('button', { name: 'Play' })).toBeVisible();
     // Should have speed controls

--- a/e2e/read.spec.ts
+++ b/e2e/read.spec.ts
@@ -32,6 +32,7 @@ test.describe('Read Module', () => {
 
     await expect(page.getByText('Reference Text')).toBeVisible();
     await expect(page.getByRole('button', { name: 'Listen' })).toBeVisible();
+    await expect(page.getByTestId('read-aloud-inline-controls')).toBeVisible();
     await expect(page.getByText('Reset')).toBeVisible();
     await expect(page.getByText('Read Aloud Mode')).toBeVisible();
     await expect(page.getByRole('heading', { name: 'Your Speech' })).toHaveCount(0);

--- a/e2e/wordbook-practice.spec.ts
+++ b/e2e/wordbook-practice.spec.ts
@@ -135,6 +135,7 @@ test.describe('WordBook Practice – Listen', () => {
     await page.goto(`/listen/book/${BOOK_ID}`);
     await waitForPracticeCard(page);
 
+    await expect(page.getByTestId('read-aloud-inline-controls')).toBeVisible();
     await expect(page.getByRole('button', { name: 'Play', exact: true })).toBeVisible();
     await expect(page.getByText('0.5x')).toBeVisible();
     await expect(page.getByText('1x')).toBeVisible();
@@ -284,6 +285,24 @@ test.describe('WordBook Practice – Write', () => {
     await input.press('Enter');
 
     await expect(page.getByText('Not quite right')).toBeVisible({ timeout: 3000 });
+  });
+
+  test('requires completing the current prompt before finish and records the completed count', async ({ page }) => {
+    await page.goto(`/write/book/${BOOK_ID}?limit=1`);
+    await waitForPracticeCard(page);
+
+    const finishButton = page.getByRole('button', { name: 'Finish' });
+    await expect(finishButton).toBeDisabled();
+
+    const textContent = await page.locator('.bg-indigo-50\\/50 p').textContent();
+    expect(textContent).toBeTruthy();
+
+    const input = page.getByPlaceholder('Type the text above...');
+    await input.fill(textContent!);
+    await page.getByRole('button', { name: 'Check' }).click();
+
+    await expect(page.getByText('Session Complete!')).toBeVisible({ timeout: 3000 });
+    await expect(page.getByText('1', { exact: true })).toBeVisible();
   });
 });
 

--- a/src/__tests__/daily-plan-progress.test.ts
+++ b/src/__tests__/daily-plan-progress.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { toLocalDateKey } from '@/lib/date-key';
 import type { ContentItem, LearningRecord, TypingSession } from '@/types/content';
 
 let mockContents: ContentItem[] = [];
@@ -18,6 +19,14 @@ vi.mock('@/lib/db', () => {
       contents: {
         toArray: async () => mockContents,
         where: (field: string) => createWhereChain(() => mockContents, field),
+        put: async (content: ContentItem) => {
+          const index = mockContents.findIndex((item) => item.id === content.id);
+          if (index >= 0) {
+            mockContents[index] = content;
+          } else {
+            mockContents.push(content);
+          }
+        },
       },
       records: {
         toArray: async () => mockRecords,
@@ -219,6 +228,51 @@ describe('daily-plan-progress', () => {
 
       expect(mockRecords).toHaveLength(1);
       expect(mockRecords[0].attempts).toBe(3);
+    });
+
+    it('stores provided content snapshots so book-based tasks can sync from built-in wordbook practice', async () => {
+      const builtInWord = makeContent({
+        id: 'daily-vocab-1',
+        category: 'daily-vocab',
+        source: 'builtin',
+      });
+      const practicedAt = Date.now();
+
+      await savePracticeSession(
+        makeSession({
+          id: 'session-daily-vocab-1',
+          contentId: 'daily-vocab-1',
+          module: 'write',
+          startTime: practicedAt - 60_000,
+          endTime: practicedAt,
+        }),
+        { content: builtInWord },
+      );
+
+      const synced = syncPlanTasks(
+        [
+          {
+            id: 'task-daily-vocab',
+            type: 'new-words',
+            title: 'Learn 1 new word',
+            description: 'From Daily Essentials',
+            module: 'write',
+            bookId: 'daily-vocab',
+            limit: 1,
+            completed: false,
+            skipped: false,
+          },
+        ],
+        {
+          contents: mockContents,
+          records: mockRecords,
+          sessions: mockSessions,
+          dayKey: toLocalDateKey(practicedAt),
+        },
+      );
+
+      expect(mockContents).toEqual(expect.arrayContaining([expect.objectContaining({ id: 'daily-vocab-1' })]));
+      expect(synced[0].completed).toBe(true);
     });
   });
 });

--- a/src/app/(app)/listen/[id]/page.tsx
+++ b/src/app/(app)/listen/[id]/page.tsx
@@ -9,7 +9,7 @@ import {
   ImmersiveReaderOverlay,
   IOSReadAloudControls,
   ReadAloudContent,
-  ReadAloudFloatingBar,
+  ReadAloudInlineControls,
 } from '@/components/read-aloud';
 import { CrossModuleNav } from '@/components/shared/cross-module-nav';
 import { IOS_LIST_CARD_CLASS, IOS_SECTION_CARD_CLASS } from '@/components/shared/ios-native-ui';
@@ -827,7 +827,7 @@ export default function ListenDetailPage() {
     t.dictation.weakSpotReason,
   ]);
 
-  const handleFloatingNext = useCallback(() => {
+  const handleReadAloudNext = useCallback(() => {
     if (!content) return;
     const state = useReadAloudStore.getState();
     const { sentences, currentSentenceIndex } = state;
@@ -838,7 +838,7 @@ export default function ListenDetailPage() {
     playSentenceSegment(nextSentence.text, nextSentence.startWordIndex);
   }, [content, playSentenceSegment]);
 
-  const handleFloatingPrev = useCallback(() => {
+  const handleReadAloudPrev = useCallback(() => {
     if (!content) return;
     const state = useReadAloudStore.getState();
     const { sentences, currentSentenceIndex, currentWordIndex } = state;
@@ -906,7 +906,7 @@ export default function ListenDetailPage() {
   }
 
   return (
-    <div className={cn('max-w-4xl mx-auto space-y-5', isIOSNativeHost ? 'pb-6' : 'pr-16')}>
+    <div className={cn('max-w-4xl mx-auto space-y-5', isIOSNativeHost ? 'pb-6' : '')}>
       {/* Header */}
       {isIOSNativeHost && (
         <Card className={cn(IOS_SECTION_CARD_CLASS, 'overflow-hidden')}>
@@ -1241,16 +1241,17 @@ export default function ListenDetailPage() {
           accentClassName="text-indigo-600"
           onPlay={handlePlay}
           onPause={handlePause}
-          onNext={handleFloatingNext}
-          onPrev={handleFloatingPrev}
+          onNext={handleReadAloudNext}
+          onPrev={handleReadAloudPrev}
           onRestart={handleRestart}
         />
       ) : (
-        <ReadAloudFloatingBar
+        <ReadAloudInlineControls
+          label="Listen controls"
           onPlay={handlePlay}
           onPause={handlePause}
-          onNext={handleFloatingNext}
-          onPrev={handleFloatingPrev}
+          onNext={handleReadAloudNext}
+          onPrev={handleReadAloudPrev}
           onRestart={handleRestart}
         />
       )}
@@ -1259,8 +1260,8 @@ export default function ListenDetailPage() {
         text={content.text}
         onPlay={handlePlay}
         onPause={handlePause}
-        onNext={handleFloatingNext}
-        onPrev={handleFloatingPrev}
+        onNext={handleReadAloudNext}
+        onPrev={handleReadAloudPrev}
         onWordClick={handleWordClick}
       />
 

--- a/src/app/(app)/read/[id]/page.tsx
+++ b/src/app/(app)/read/[id]/page.tsx
@@ -12,7 +12,7 @@ import {
   ImmersiveReaderOverlay,
   IOSReadAloudControls,
   ReadAloudContent,
-  ReadAloudFloatingBar,
+  ReadAloudInlineControls,
 } from '@/components/read-aloud';
 import { CrossModuleNav } from '@/components/shared/cross-module-nav';
 import { FormattedContentText } from '@/components/shared/formatted-content-text';
@@ -1125,7 +1125,9 @@ export default function ReadDetailPage() {
               onPrev={handleReadAloudPrev}
             />
           ) : (
-            <ReadAloudFloatingBar
+            <ReadAloudInlineControls
+              label="Read controls"
+              accentClassName="text-orange-500"
               onPlay={handlePlayTTS}
               onPause={handleReadAloudPause}
               onNext={handleReadAloudNext}

--- a/src/components/read-aloud/index.ts
+++ b/src/components/read-aloud/index.ts
@@ -2,3 +2,4 @@ export { ImmersiveReaderOverlay } from './immersive-reader-overlay';
 export { IOSReadAloudControls } from './ios-read-aloud-controls';
 export { ReadAloudContent } from './read-aloud-content';
 export { ReadAloudFloatingBar } from './read-aloud-floating-bar';
+export { ReadAloudInlineControls } from './read-aloud-inline-controls';

--- a/src/components/read-aloud/read-aloud-inline-controls.tsx
+++ b/src/components/read-aloud/read-aloud-inline-controls.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import { Maximize2, Pause, Play, RotateCcw, SkipBack, SkipForward } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import enPracticeUi from '@/lib/i18n/messages/practice-ui/en.json';
+import zhPracticeUi from '@/lib/i18n/messages/practice-ui/zh.json';
+import { cn } from '@/lib/utils';
+import { useLanguageStore } from '@/stores/language-store';
+import { useReadAloudStore } from '@/stores/read-aloud-store';
+import { useTTSStore } from '@/stores/tts-store';
+
+const PRACTICE_UI_LOCALES = { en: enPracticeUi, zh: zhPracticeUi } as const;
+const SPEED_STEPS = [0.5, 0.75, 1, 1.25, 1.5, 2];
+
+interface ReadAloudInlineControlsProps {
+  accentClassName?: string;
+  className?: string;
+  label: string;
+  onPlay: () => void;
+  onPause: () => void;
+  onPrev: () => void;
+  onNext: () => void;
+  onRestart?: () => void;
+  showImmersive?: boolean;
+}
+
+export function ReadAloudInlineControls({
+  accentClassName = 'text-indigo-600',
+  className,
+  label,
+  onPlay,
+  onPause,
+  onPrev,
+  onNext,
+  onRestart,
+  showImmersive = true,
+}: ReadAloudInlineControlsProps) {
+  const raT = PRACTICE_UI_LOCALES[useLanguageStore((s) => s.interfaceLanguage)].readAloud;
+  const isPlaying = useReadAloudStore((s) => s.isPlaying);
+  const immersiveMode = useReadAloudStore((s) => s.immersiveMode);
+  const toggleImmersiveMode = useReadAloudStore((s) => s.toggleImmersiveMode);
+  const words = useReadAloudStore((s) => s.words);
+  const currentWordIndex = useReadAloudStore((s) => s.currentWordIndex);
+  const { speed, setSpeed } = useTTSStore();
+
+  const progress = words.length > 0 && currentWordIndex >= 0 ? ((currentWordIndex + 1) / words.length) * 100 : 0;
+
+  return (
+    <div
+      data-testid="read-aloud-inline-controls"
+      className={cn('rounded-2xl border border-slate-200 bg-slate-50/90 p-4 shadow-sm', className)}
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">{label}</p>
+          <p className="mt-1 text-sm text-slate-500">
+            {Math.round(progress)}% {raT.progress.toLowerCase()}
+          </p>
+        </div>
+        <div className="rounded-full bg-white px-3 py-1.5 text-sm font-semibold text-slate-700 shadow-sm tabular-nums">
+          {speed}x
+        </div>
+      </div>
+
+      <div className="mt-3 h-2 overflow-hidden rounded-full bg-white">
+        <div
+          className={cn(
+            'h-full rounded-full bg-[linear-gradient(90deg,rgba(79,70,229,0.96)_0%,rgba(129,140,248,0.92)_100%)] transition-all duration-300',
+            accentClassName.includes('orange') &&
+              'bg-[linear-gradient(90deg,rgba(249,115,22,0.94)_0%,rgba(251,146,60,0.9)_100%)]',
+          )}
+          style={{ width: `${Math.max(progress, 4)}%` }}
+        />
+      </div>
+
+      <div className="mt-4 flex flex-wrap items-center justify-center gap-2">
+        <Button type="button" variant="outline" size="icon" onClick={onPrev} aria-label={raT.previousSentence}>
+          <SkipBack className="h-4 w-4" />
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="icon"
+          onClick={onRestart ?? onPrev}
+          aria-label="Restart"
+          disabled={!onRestart}
+        >
+          <RotateCcw className="h-4 w-4" />
+        </Button>
+        <Button
+          type="button"
+          onClick={isPlaying ? onPause : onPlay}
+          className={cn(
+            'min-w-28 gap-2 shadow-sm',
+            accentClassName.includes('orange')
+              ? 'bg-orange-500 hover:bg-orange-600 text-white'
+              : 'bg-indigo-600 hover:bg-indigo-700 text-white',
+          )}
+          aria-label={isPlaying ? raT.pause : raT.play}
+        >
+          {isPlaying ? <Pause className="h-4 w-4" /> : <Play className="ml-0.5 h-4 w-4" />}
+          {isPlaying ? raT.pause : raT.play}
+        </Button>
+        <Button type="button" variant="outline" size="icon" onClick={onNext} aria-label={raT.nextSentence}>
+          <SkipForward className="h-4 w-4" />
+        </Button>
+        {showImmersive ? (
+          <Button
+            type="button"
+            variant="outline"
+            size="icon"
+            onClick={toggleImmersiveMode}
+            aria-label={immersiveMode ? raT.exitImmersive : raT.immersiveMode}
+          >
+            <Maximize2 className="h-4 w-4" />
+          </Button>
+        ) : null}
+      </div>
+
+      <div className="mt-4 flex flex-wrap items-center justify-center gap-2">
+        {SPEED_STEPS.map((step) => (
+          <button
+            key={step}
+            type="button"
+            onClick={() => setSpeed(step)}
+            className={cn(
+              'rounded-full px-3 py-1.5 text-xs font-semibold transition-colors',
+              speed === step ? 'bg-indigo-600 text-white' : 'bg-white text-slate-600 hover:bg-slate-100',
+            )}
+          >
+            {step}x
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/shared/word-book-practice.tsx
+++ b/src/components/shared/word-book-practice.tsx
@@ -10,9 +10,7 @@ import {
   MessageCircle,
   Mic,
   MicOff,
-  Pause,
   PenTool,
-  Play,
   RotateCcw,
   Trophy,
   Volume2,
@@ -21,7 +19,7 @@ import { nanoid } from 'nanoid';
 import Link from 'next/link';
 import { useParams, useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { ReadAloudFloatingBar } from '@/components/read-aloud';
+import { ReadAloudInlineControls } from '@/components/read-aloud';
 import { PageSpinner } from '@/components/shared/page-spinner';
 import { fireConfetti } from '@/components/shared/practice-complete-banner';
 import { WordDictionaryInfo } from '@/components/shared/word-dictionary-info';
@@ -71,7 +69,6 @@ interface WordBookPracticeProps {
 interface SingleItemPracticeProps {
   item: ContentItem;
   module: PracticeModule;
-  persistProgress?: boolean;
   onCompleted?: () => void;
 }
 
@@ -106,6 +103,7 @@ const WORDBOOK_PROGRESS_STORAGE_KEY = 'echotype_wordbook_progress';
 interface WordBookPracticeProgress {
   currentIndex: number;
   completedCount: number;
+  completedItemIds?: string[];
   finished: boolean;
   updatedAt: number;
 }
@@ -229,19 +227,16 @@ function SentenceTranslation({
 function WordBookPlaybackControls({
   item,
   module,
-  persistProgress,
   onCompleted,
   onPrev,
   onNext,
 }: {
   item: ContentItem;
   module: 'listen' | 'read';
-  persistProgress: boolean;
   onCompleted?: () => void;
   onPrev: () => void;
   onNext: () => void;
 }) {
-  const t = WB_LOCALES[useLanguageStore((s) => s.interfaceLanguage)];
   const { createUtterance, boundaryPlaybackNotice } = useTTS();
   const speed = useTTSStore((s) => s.speed);
   const isPlaying = useReadAloudStore((s) => s.isPlaying);
@@ -277,21 +272,24 @@ function WordBookPlaybackControls({
     };
     utterance.onend = () => {
       setPlaying(false);
-      if (module === 'listen' && persistProgress) {
-        void savePracticeSession({
-          id: nanoid(),
-          contentId: item.id,
-          module: 'listen',
-          startTime: startedAtRef.current,
-          endTime: Date.now(),
-          totalChars: item.text.length,
-          correctChars: 0,
-          wrongChars: 0,
-          totalWords: item.text.split(/\s+/).filter(Boolean).length,
-          wpm: 0,
-          accuracy: 0,
-          completed: true,
-        });
+      if (module === 'listen') {
+        void savePracticeSession(
+          {
+            id: nanoid(),
+            contentId: item.id,
+            module: 'listen',
+            startTime: startedAtRef.current,
+            endTime: Date.now(),
+            totalChars: item.text.length,
+            correctChars: 0,
+            wrongChars: 0,
+            totalWords: item.text.split(/\s+/).filter(Boolean).length,
+            wpm: 0,
+            accuracy: 0,
+            completed: true,
+          },
+          { content: item },
+        );
         onCompleted?.();
       }
     };
@@ -300,7 +298,7 @@ function WordBookPlaybackControls({
     };
     window.speechSynthesis.speak(utterance);
     setPlaying(true);
-  }, [createUtterance, item, module, onCompleted, persistProgress, setCurrentWordIndex, setPlaying, speed]);
+  }, [createUtterance, item, module, onCompleted, setCurrentWordIndex, setPlaying, speed]);
 
   const handlePrev = useCallback(() => {
     handlePause();
@@ -319,42 +317,14 @@ function WordBookPlaybackControls({
           {boundaryPlaybackNotice}
         </div>
       )}
-      <div className="flex items-center justify-center gap-3 md:hidden">
-        <Button
-          onClick={isPlaying ? handlePause : handlePlay}
-          className={cn(
-            'cursor-pointer font-medium px-6',
-            isPlaying ? 'bg-slate-700 hover:bg-slate-800' : 'bg-indigo-600 hover:bg-indigo-700',
-          )}
-        >
-          {isPlaying ? <Pause className="w-4 h-4 mr-2" /> : <Play className="w-4 h-4 mr-2" />}
-          {isPlaying ? t.listen.pause : t.listen.play}
-        </Button>
-        <div className="flex gap-1">
-          {[0.5, 0.75, 1, 1.25, 1.5].map((s) => (
-            <button
-              key={s}
-              type="button"
-              onClick={() => useTTSStore.getState().setSpeed(s)}
-              className={cn(
-                'px-2 py-1 rounded text-xs font-medium transition-colors cursor-pointer',
-                speed === s ? 'bg-indigo-600 text-white' : 'text-indigo-400 hover:bg-indigo-50',
-              )}
-            >
-              {s}x
-            </button>
-          ))}
-        </div>
-      </div>
-      <div className="hidden md:block">
-        <ReadAloudFloatingBar
-          onPlay={handlePlay}
-          onPause={handlePause}
-          onPrev={handlePrev}
-          onNext={handleNext}
-          showImmersive={false}
-        />
-      </div>
+      <ReadAloudInlineControls
+        label={module === 'listen' ? 'Listen controls' : 'Read aloud controls'}
+        onPlay={handlePlay}
+        onPause={handlePause}
+        onPrev={handlePrev}
+        onNext={handleNext}
+        showImmersive={false}
+      />
     </div>
   );
 }
@@ -364,12 +334,10 @@ function WordBookPlaybackControls({
 function WritePractice({
   item,
   onCorrect,
-  persistProgress,
   onCompleted,
 }: {
   item: ContentItem;
   onCorrect?: () => void;
-  persistProgress: boolean;
   onCompleted?: () => void;
 }) {
   const t = WB_LOCALES[useLanguageStore((s) => s.interfaceLanguage)];
@@ -391,8 +359,8 @@ function WritePractice({
     const expected = item.text.trim().toLowerCase();
     if (normalized === expected) {
       setResult('correct');
-      if (persistProgress) {
-        void savePracticeSession({
+      void savePracticeSession(
+        {
           id: nanoid(),
           contentId: item.id,
           module: 'write',
@@ -405,8 +373,9 @@ function WritePractice({
           wpm: 0,
           accuracy: 100,
           completed: true,
-        });
-      }
+        },
+        { content: item },
+      );
       setTimeout(() => {
         onCompleted?.();
         onCorrect?.();
@@ -517,12 +486,10 @@ const encourageByAccuracy = (accuracy: number, enc: typeof enWordBook.encourage)
 function ReadSpeakPractice({
   item,
   module,
-  persistProgress,
   onCompleted,
 }: {
   item: ContentItem;
   module: 'speak' | 'read';
-  persistProgress: boolean;
   onCompleted?: () => void;
 }) {
   const t = WB_LOCALES[useLanguageStore((s) => s.interfaceLanguage)];
@@ -770,26 +737,29 @@ function ReadSpeakPractice({
 
   // Save progress when result phase is reached
   useEffect(() => {
-    if (phase !== 'result' || !transcript || !matchResult || !persistProgress) return;
+    if (phase !== 'result' || !transcript || !matchResult) return;
     if (lastSavedTranscriptRef.current === transcript) return;
 
     lastSavedTranscriptRef.current = transcript;
-    void savePracticeSession({
-      id: nanoid(),
-      contentId: item.id,
-      module,
-      startTime: startedAtRef.current,
-      endTime: Date.now(),
-      totalChars: item.text.length,
-      correctChars: matchResult.correct,
-      wrongChars: Math.max(matchResult.total - matchResult.correct, 0),
-      totalWords: matchResult.total,
-      wpm: 0,
-      accuracy: matchResult.accuracy,
-      completed: true,
-    });
+    void savePracticeSession(
+      {
+        id: nanoid(),
+        contentId: item.id,
+        module,
+        startTime: startedAtRef.current,
+        endTime: Date.now(),
+        totalChars: item.text.length,
+        correctChars: matchResult.correct,
+        wrongChars: Math.max(matchResult.total - matchResult.correct, 0),
+        totalWords: matchResult.total,
+        wpm: 0,
+        accuracy: matchResult.accuracy,
+        completed: true,
+      },
+      { content: item },
+    );
     onCompleted?.();
-  }, [phase, item, matchResult, module, onCompleted, persistProgress, transcript]);
+  }, [phase, item, matchResult, module, onCompleted, transcript]);
 
   const wordComparison = (() => {
     if (!shouldShowSpeechFeedback(phase, transcript)) return null;
@@ -1051,12 +1021,11 @@ export function WordBookPractice({ module }: WordBookPracticeProps) {
   const [book, setBook] = useState<WordBook | null>(null);
   const [bookInfo, setBookInfo] = useState<BookInfo | null>(null);
   const [items, setItems] = useState<ContentItem[]>([]);
-  const [persistProgress, setPersistProgress] = useState(false);
   const [currentIndex, setCurrentIndex] = useState(0);
   const [loading, setLoading] = useState(true);
   const [slideClass, setSlideClass] = useState('');
   const [finished, setFinished] = useState(false);
-  const [completedCount, setCompletedCount] = useState(0);
+  const [completedItemIds, setCompletedItemIds] = useState<Set<string>>(new Set());
   // Translation & TTS
   const targetLang = useTTSStore((s) => s.targetLang);
   const { speak } = useTTS();
@@ -1089,7 +1058,6 @@ export function WordBookPractice({ module }: WordBookPracticeProps) {
       const dbItems = await db.contents.where('category').equals(bookId).toArray();
       if (dbItems.length > 0) {
         setItems(limit > 0 ? dbItems.slice(0, limit) : dbItems);
-        setPersistProgress(true);
       } else if (wb) {
         // Not imported yet — load directly from wordbook data for practice
         const wordItems = await loadWordBookItems(bookId);
@@ -1100,7 +1068,6 @@ export function WordBookPractice({ module }: WordBookPracticeProps) {
           updatedAt: Date.now(),
         }));
         setItems(limit > 0 ? practiceItems.slice(0, limit) : practiceItems);
-        setPersistProgress(false);
       }
       setLoading(false);
     }
@@ -1115,11 +1082,17 @@ export function WordBookPractice({ module }: WordBookPracticeProps) {
 
     const safeIndex = Math.min(Math.max(saved.currentIndex, 0), Math.max(items.length - 1, 0));
     const safeCompletedCount = Math.min(Math.max(saved.completedCount, 0), items.length);
+    const restoredCompletedIds = Array.isArray(saved.completedItemIds)
+      ? saved.completedItemIds.filter((id) => items.some((item) => item.id === id)).slice(0, items.length)
+      : [];
+    const fallbackCompletedIds = items.slice(0, safeCompletedCount).map((item) => item.id);
 
     setCurrentIndex(safeIndex);
-    setCompletedCount(safeCompletedCount);
+    setCompletedItemIds(new Set(restoredCompletedIds.length > 0 ? restoredCompletedIds : fallbackCompletedIds));
     setFinished(saved.finished && safeCompletedCount >= items.length && items.length > 0);
   }, [items.length, loading, progressKey]);
+
+  const completedCount = completedItemIds.size;
 
   useEffect(() => {
     if (loading || items.length === 0) return;
@@ -1127,10 +1100,11 @@ export function WordBookPractice({ module }: WordBookPracticeProps) {
     saveWordBookProgress(progressKey, {
       currentIndex,
       completedCount,
+      completedItemIds: Array.from(completedItemIds),
       finished,
       updatedAt: Date.now(),
     });
-  }, [completedCount, currentIndex, finished, items.length, loading, progressKey]);
+  }, [completedCount, completedItemIds, currentIndex, finished, items.length, loading, progressKey]);
 
   const total = items.length;
 
@@ -1149,25 +1123,37 @@ export function WordBookPractice({ module }: WordBookPracticeProps) {
   }, [book, bookId, bookInfo, completedCount, currentIndex, finished, loading, module, total]);
 
   const currentItem = items[currentIndex];
+  const currentItemCompleted = currentItem ? completedItemIds.has(currentItem.id) : false;
+  const canAdvance = module !== 'write' || currentItemCompleted;
 
   // Navigation with slide animation
-  const goToNext = useCallback(() => {
-    if (currentIndex >= total - 1) {
-      // Last item — show completion screen
-      setFinished(true);
-      return;
-    }
-    setSlideClass('animate-slide-out-left');
-    setTimeout(() => {
-      setCurrentIndex((i) => i + 1);
-      setSlideClass('animate-slide-in-right');
-      setTimeout(() => setSlideClass(''), 200);
-    }, 150);
-  }, [currentIndex, total]);
+  const goToNext = useCallback(
+    (options?: { force?: boolean }) => {
+      if (module === 'write' && !options?.force && !currentItemCompleted) return;
+      if (currentIndex >= total - 1) {
+        // Last item — show completion screen
+        setFinished(true);
+        return;
+      }
+      setSlideClass('animate-slide-out-left');
+      setTimeout(() => {
+        setCurrentIndex((i) => i + 1);
+        setSlideClass('animate-slide-in-right');
+        setTimeout(() => setSlideClass(''), 200);
+      }, 150);
+    },
+    [currentIndex, currentItemCompleted, module, total],
+  );
 
   const handleItemCompleted = useCallback(() => {
-    setCompletedCount((count) => Math.min(count + 1, total));
-  }, []);
+    if (!currentItem) return;
+    setCompletedItemIds((existing) => {
+      if (existing.has(currentItem.id)) return existing;
+      const next = new Set(existing);
+      next.add(currentItem.id);
+      return next;
+    });
+  }, [currentItem]);
 
   const goToPrev = useCallback(() => {
     if (currentIndex <= 0) return;
@@ -1238,7 +1224,7 @@ export function WordBookPractice({ module }: WordBookPracticeProps) {
           clearWordBookProgress(progressKey);
           setFinished(false);
           setCurrentIndex(0);
-          setCompletedCount(0);
+          setCompletedItemIds(new Set());
         }}
       />
     );
@@ -1340,7 +1326,6 @@ export function WordBookPractice({ module }: WordBookPracticeProps) {
                     key={currentItem.id}
                     item={currentItem}
                     module={module}
-                    persistProgress={persistProgress}
                     onCompleted={handleItemCompleted}
                     onPrev={goToPrev}
                     onNext={goToNext}
@@ -1350,8 +1335,7 @@ export function WordBookPractice({ module }: WordBookPracticeProps) {
                   <WritePractice
                     key={currentItem.id}
                     item={currentItem}
-                    onCorrect={goToNext}
-                    persistProgress={persistProgress}
+                    onCorrect={() => goToNext({ force: true })}
                     onCompleted={handleItemCompleted}
                   />
                 )}
@@ -1360,7 +1344,6 @@ export function WordBookPractice({ module }: WordBookPracticeProps) {
                     key={currentItem.id}
                     item={currentItem}
                     module={module}
-                    persistProgress={persistProgress}
                     onCompleted={handleItemCompleted}
                   />
                 )}
@@ -1399,10 +1382,17 @@ export function WordBookPractice({ module }: WordBookPracticeProps) {
               <button
                 key={dotIndex}
                 type="button"
-                onClick={() => setCurrentIndex(dotIndex)}
+                onClick={() => {
+                  if (module === 'write' && dotIndex > currentIndex && !canAdvance) return;
+                  setCurrentIndex(dotIndex);
+                }}
+                disabled={module === 'write' && dotIndex > currentIndex && !canAdvance}
                 className={cn(
-                  'w-2 h-2 rounded-full transition-all cursor-pointer',
+                  'w-2 h-2 rounded-full transition-all',
                   dotIndex === currentIndex ? 'bg-indigo-600 w-4' : 'bg-indigo-200 hover:bg-indigo-300',
+                  module === 'write' && dotIndex > currentIndex && !canAdvance
+                    ? 'cursor-not-allowed opacity-40 hover:bg-indigo-200'
+                    : 'cursor-pointer',
                 )}
               />
             );
@@ -1412,8 +1402,8 @@ export function WordBookPractice({ module }: WordBookPracticeProps) {
         <Button
           variant="outline"
           size="sm"
-          onClick={currentIndex === total - 1 ? () => setFinished(true) : goToNext}
-          disabled={false}
+          onClick={currentIndex === total - 1 ? () => setFinished(true) : () => goToNext()}
+          disabled={!canAdvance}
           className={cn(
             'cursor-pointer',
             currentIndex === total - 1
@@ -1428,7 +1418,7 @@ export function WordBookPractice({ module }: WordBookPracticeProps) {
   );
 }
 
-export function SingleItemPractice({ item, module, persistProgress = true, onCompleted }: SingleItemPracticeProps) {
+export function SingleItemPractice({ item, module, onCompleted }: SingleItemPracticeProps) {
   const t = WB_LOCALES[useLanguageStore((s) => s.interfaceLanguage)];
   const targetLang = useTTSStore((s) => s.targetLang);
   const { speak } = useTTS();
@@ -1490,22 +1480,14 @@ export function SingleItemPractice({ item, module, persistProgress = true, onCom
             <WordBookPlaybackControls
               item={item}
               module={module}
-              persistProgress={persistProgress}
               onCompleted={onCompleted}
               onPrev={() => {}}
               onNext={() => {}}
             />
           )}
-          {module === 'write' && (
-            <WritePractice item={item} persistProgress={persistProgress} onCompleted={onCompleted} />
-          )}
+          {module === 'write' && <WritePractice item={item} onCompleted={onCompleted} />}
           {(module === 'read' || module === 'speak') && (
-            <ReadSpeakPractice
-              item={item}
-              module={module}
-              persistProgress={persistProgress}
-              onCompleted={onCompleted}
-            />
+            <ReadSpeakPractice item={item} module={module} onCompleted={onCompleted} />
           )}
         </CardContent>
       </Card>

--- a/src/lib/daily-plan-progress.ts
+++ b/src/lib/daily-plan-progress.ts
@@ -89,8 +89,15 @@ export async function syncPlanTasksWithActivity(tasks: PlanTask[]): Promise<Plan
 
 export async function savePracticeSession(
   session: TypingSession,
-  options?: { mistakes?: LearningRecord['mistakes'] },
+  options?: { mistakes?: LearningRecord['mistakes']; content?: ContentItem },
 ): Promise<void> {
+  if (options?.content) {
+    const existingContent = await db.contents.where('id').equals(options.content.id).first();
+    if (!existingContent) {
+      await db.contents.put(options.content);
+    }
+  }
+
   await db.sessions.add(session);
 
   const existingRecords = await db.records.where('contentId').equals(session.contentId).toArray();


### PR DESCRIPTION
## Summary
- persist content snapshots when saving built-in wordbook practice so book-based Today's Plan tasks can sync completion correctly
- unify desktop Web playback UI so `listen/[id]`, `read/[id]`, and wordbook practice use inline read-aloud controls while iOS native keeps native controls
- add regression coverage for Today's Plan sync and inline playback controls

## Verification
- `pnpm vitest run src/__tests__/daily-plan-progress.test.ts`
- `pnpm playwright test e2e/listen.spec.ts --grep "listen detail page has playback controls"`
- `pnpm playwright test e2e/read.spec.ts --grep "read detail page shows stable practice controls without transcript card"`
- `agent-browser` manual QA:
  - completed `write/book/daily-vocab?limit=3` and confirmed dashboard `Today's Plan` changed to `1/4 completed`
  - verified `listen/listen-1` shows `LISTEN CONTROLS` inline under content
  - verified `read/article-1` shows `READ CONTROLS` inline under content