### PR TITLE
Fix daily plan sync and listen controls

### DIFF
--- a/src/__tests__/daily-plan-progress.test.ts
+++ b/src/__tests__/daily-plan-progress.test.ts
@@ -147,6 +147,80 @@ describe('daily-plan-progress', () => {
       expect(synced[0].completed).toBe(true);
     });
 
+    it('requires the full new-words limit before completing a limited wordbook task', () => {
+      mockContents = Array.from({ length: 20 }, (_, index) =>
+        makeContent({ id: `word-${index + 1}`, category: 'cet4' }),
+      );
+      mockRecords = mockContents.slice(0, 19).map((content, index) =>
+        makeRecord({
+          id: `record-${index + 1}`,
+          contentId: content.id,
+          module: 'write',
+          lastPracticed: new Date('2026-03-12T09:00:00+08:00').getTime(),
+        }),
+      );
+
+      const tasks = [
+        {
+          id: 'task-1',
+          type: 'new-words' as const,
+          title: 'Learn 20 new words',
+          description: 'From CET-4',
+          module: 'write' as const,
+          bookId: 'cet4',
+          limit: 20,
+          completed: false,
+          skipped: false,
+        },
+      ];
+
+      const synced = syncPlanTasks(tasks, {
+        contents: mockContents,
+        records: mockRecords,
+        sessions: mockSessions,
+        dayKey: '2026-03-12',
+      });
+
+      expect(synced[0].completed).toBe(false);
+    });
+
+    it('marks Learn 20 new words complete after 20 same-day wordbook items are practiced', () => {
+      mockContents = Array.from({ length: 20 }, (_, index) =>
+        makeContent({ id: `word-${index + 1}`, category: 'cet4' }),
+      );
+      mockRecords = mockContents.map((content, index) =>
+        makeRecord({
+          id: `record-${index + 1}`,
+          contentId: content.id,
+          module: 'write',
+          lastPracticed: new Date('2026-03-12T09:00:00+08:00').getTime(),
+        }),
+      );
+
+      const tasks = [
+        {
+          id: 'task-1',
+          type: 'new-words' as const,
+          title: 'Learn 20 new words',
+          description: 'From CET-4',
+          module: 'write' as const,
+          bookId: 'cet4',
+          limit: 20,
+          completed: false,
+          skipped: false,
+        },
+      ];
+
+      const synced = syncPlanTasks(tasks, {
+        contents: mockContents,
+        records: mockRecords,
+        sessions: mockSessions,
+        dayKey: '2026-03-12',
+      });
+
+      expect(synced[0].completed).toBe(true);
+    });
+
     it('does not complete tasks from activity on a different day', () => {
       mockContents = [makeContent({ id: 'article-1', type: 'article', category: undefined })];
       mockSessions = [

--- a/src/components/read-aloud/read-aloud-floating-bar.test.tsx
+++ b/src/components/read-aloud/read-aloud-floating-bar.test.tsx
@@ -27,8 +27,17 @@ describe('ReadAloudFloatingBar', () => {
     expect(markup).toBe('');
   });
 
+  it('stays hidden before playback has started so inline controls remain the primary entry', () => {
+    useReadAloudStore.getState().activate('hello world');
+
+    const markup = renderToStaticMarkup(<ReadAloudFloatingBar {...defaultProps} />);
+
+    expect(markup).toBe('');
+  });
+
   it('can hide immersive mode for word-book practice pages', () => {
     useReadAloudStore.getState().activate('hello world');
+    useReadAloudStore.getState().setPlaying(true);
     const markup = renderToStaticMarkup(<ReadAloudFloatingBar {...defaultProps} showImmersive={false} />);
 
     expect(markup).not.toContain('Immersive mode');

--- a/src/components/read-aloud/read-aloud-floating-bar.tsx
+++ b/src/components/read-aloud/read-aloud-floating-bar.tsx
@@ -36,7 +36,8 @@ export function ReadAloudFloatingBar({
   const currentWordIndex = useReadAloudStore((s) => s.currentWordIndex);
   const { speed, setSpeed } = useTTSStore();
 
-  if (!isActive || immersiveMode) return null;
+  const hasStartedPlayback = isPlaying || currentWordIndex >= 0;
+  if (!isActive || immersiveMode || !hasStartedPlayback) return null;
 
   const progress = words.length > 0 && currentWordIndex >= 0 ? ((currentWordIndex + 1) / words.length) * 100 : 0;
 

--- a/src/lib/daily-plan-progress.ts
+++ b/src/lib/daily-plan-progress.ts
@@ -100,6 +100,13 @@ export async function savePracticeSession(
 
   await db.sessions.add(session);
 
+  if (options?.content) {
+    const existingContent = await db.contents.where('id').equals(session.contentId).first();
+    if (!existingContent) {
+      await db.contents.put(options.content);
+    }
+  }
+
   const existingRecords = await db.records.where('contentId').equals(session.contentId).toArray();
   const existingRecord = existingRecords.find((record) => record.module === session.module);
   const attempts = (existingRecord?.attempts ?? 0) + 1;


### PR DESCRIPTION
## Summary
- Add regression coverage for limited new-word daily plan tasks so Learn 20 only completes after 20 same-day wordbook items.
- Persist provided content snapshots when saving practice sessions so dashboard plan sync can match built-in wordbook practice.
- Hide the read-aloud floating bar until playback starts, leaving inline controls as the primary Listen entry point.

## Verification
- pnpm typecheck
- pnpm vitest run src/__tests__/daily-plan-progress.test.ts src/components/read-aloud/read-aloud-floating-bar.test.tsx
- pnpm playwright test e2e/listen.spec.ts -g "listen detail page has playback controls" --project=chromium