### PR TITLE
Fix daily plan word rotation

### DIFF
--- a/src/__tests__/wordbook-practice-progress.test.ts
+++ b/src/__tests__/wordbook-practice-progress.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import {
+  resolveWordBookPracticeItems,
+  type WordBookPracticeProgressSnapshot,
+} from '@/lib/wordbook-practice-progress';
+
+interface TestItem {
+  id: string;
+}
+
+function makeItems(count: number): TestItem[] {
+  return Array.from({ length: count }, (_, index) => ({ id: `word-${index + 1}` }));
+}
+
+describe('wordbook-practice-progress', () => {
+  it('excludes already practiced items when building a limited daily-plan set', () => {
+    const items = makeItems(6);
+    const practicedIds = new Set(['word-1', 'word-2', 'word-3']);
+
+    const resolved = resolveWordBookPracticeItems({
+      availableItems: items,
+      limit: 2,
+      savedProgress: null,
+      practicedIds,
+      dayKey: '2026-06-16',
+    });
+
+    expect(resolved.items.map((item) => item.id)).toEqual(['word-4', 'word-5']);
+    expect(resolved.restoredCompletedItemIds).toEqual([]);
+  });
+
+  it('restores the same frozen item set for the same day', () => {
+    const items = makeItems(6);
+    const savedProgress: WordBookPracticeProgressSnapshot = {
+      currentIndex: 1,
+      completedCount: 1,
+      completedItemIds: ['word-5'],
+      itemIds: ['word-5', 'word-6'],
+      dayKey: '2026-06-16',
+      finished: false,
+      updatedAt: Date.now(),
+    };
+
+    const resolved = resolveWordBookPracticeItems({
+      availableItems: items,
+      limit: 2,
+      savedProgress,
+      practicedIds: new Set(['word-1', 'word-2', 'word-3', 'word-4']),
+      dayKey: '2026-06-16',
+    });
+
+    expect(resolved.items.map((item) => item.id)).toEqual(['word-5', 'word-6']);
+    expect(resolved.restoredCompletedItemIds).toEqual(['word-5']);
+  });
+
+  it('builds a fresh limited set on a new day instead of reusing yesterday item ids', () => {
+    const items = makeItems(6);
+    const savedProgress: WordBookPracticeProgressSnapshot = {
+      currentIndex: 1,
+      completedCount: 2,
+      completedItemIds: ['word-1', 'word-2'],
+      itemIds: ['word-1', 'word-2'],
+      dayKey: '2026-06-15',
+      finished: true,
+      updatedAt: Date.now(),
+    };
+
+    const resolved = resolveWordBookPracticeItems({
+      availableItems: items,
+      limit: 2,
+      savedProgress,
+      practicedIds: new Set(['word-1', 'word-2', 'word-3']),
+      dayKey: '2026-06-16',
+    });
+
+    expect(resolved.items.map((item) => item.id)).toEqual(['word-4', 'word-5']);
+    expect(resolved.restoredCompletedItemIds).toEqual([]);
+  });
+});

--- a/src/components/shared/word-book-practice.tsx
+++ b/src/components/shared/word-book-practice.tsx
@@ -31,6 +31,7 @@ import { Input } from '@/components/ui/input';
 import { useFallbackSTT } from '@/hooks/use-fallback-stt';
 import { useTTS } from '@/hooks/use-tts';
 import { savePracticeSession } from '@/lib/daily-plan-progress';
+import { toLocalDateKey } from '@/lib/date-key';
 import { db } from '@/lib/db';
 import enWordBook from '@/lib/i18n/messages/word-book-practice/en.json';
 import zhWordBook from '@/lib/i18n/messages/word-book-practice/zh.json';
@@ -49,6 +50,7 @@ import {
 } from '@/lib/speech-feedback';
 import { IS_IOS_NATIVE_HOST, IS_TAURI, reportNativeQAState } from '@/lib/tauri';
 import { cn } from '@/lib/utils';
+import { resolveWordBookPracticeItems, type WordBookPracticeProgressSnapshot } from '@/lib/wordbook-practice-progress';
 import { getWordBook, loadWordBookItems } from '@/lib/wordbooks';
 import { useLanguageStore } from '@/stores/language-store';
 import { usePracticeTranslationStore } from '@/stores/practice-translation-store';
@@ -104,6 +106,8 @@ interface WordBookPracticeProgress {
   currentIndex: number;
   completedCount: number;
   completedItemIds?: string[];
+  itemIds?: string[];
+  dayKey?: string;
   finished: boolean;
   updatedAt: number;
 }
@@ -1017,6 +1021,8 @@ export function WordBookPractice({ module }: WordBookPracticeProps) {
   const bookId = params.bookId as string;
   const limit = searchParams.get('limit') ? Number(searchParams.get('limit')) : 0;
   const progressKey = buildWordBookProgressKey(module, bookId, limit);
+  const progressScopeByDay = limit > 0;
+  const progressDayKey = toLocalDateKey();
 
   const [book, setBook] = useState<WordBook | null>(null);
   const [bookInfo, setBookInfo] = useState<BookInfo | null>(null);
@@ -1054,10 +1060,21 @@ export function WordBookPractice({ module }: WordBookPracticeProps) {
         }
       }
 
+      const savedProgress = loadWordBookProgress(progressKey);
+
       // First try loading from DB (already imported items)
       const dbItems = await db.contents.where('category').equals(bookId).toArray();
       if (dbItems.length > 0) {
-        setItems(limit > 0 ? dbItems.slice(0, limit) : dbItems);
+        const practicedIds =
+          limit > 0 ? new Set((await db.records.toArray()).map((record) => record.contentId)) : undefined;
+        const resolved = resolveWordBookPracticeItems({
+          availableItems: dbItems,
+          limit,
+          savedProgress,
+          practicedIds,
+          dayKey: progressDayKey,
+        });
+        setItems(resolved.items);
       } else if (wb) {
         // Not imported yet — load directly from wordbook data for practice
         const wordItems = await loadWordBookItems(bookId);
@@ -1067,12 +1084,18 @@ export function WordBookPractice({ module }: WordBookPracticeProps) {
           createdAt: Date.now(),
           updatedAt: Date.now(),
         }));
-        setItems(limit > 0 ? practiceItems.slice(0, limit) : practiceItems);
+        const resolved = resolveWordBookPracticeItems({
+          availableItems: practiceItems,
+          limit,
+          savedProgress,
+          dayKey: progressDayKey,
+        });
+        setItems(resolved.items);
       }
       setLoading(false);
     }
     load();
-  }, [bookId, limit]);
+  }, [bookId, limit, progressDayKey, progressKey]);
 
   useEffect(() => {
     if (loading || items.length === 0) return;
@@ -1080,17 +1103,32 @@ export function WordBookPractice({ module }: WordBookPracticeProps) {
     const saved = loadWordBookProgress(progressKey);
     if (!saved) return;
 
-    const safeIndex = Math.min(Math.max(saved.currentIndex, 0), Math.max(items.length - 1, 0));
-    const safeCompletedCount = Math.min(Math.max(saved.completedCount, 0), items.length);
-    const restoredCompletedIds = Array.isArray(saved.completedItemIds)
-      ? saved.completedItemIds.filter((id) => items.some((item) => item.id === id)).slice(0, items.length)
+    const scopedSaved =
+      progressScopeByDay && saved.dayKey && saved.dayKey !== progressDayKey
+        ? ({
+            ...saved,
+            currentIndex: 0,
+            completedCount: 0,
+            completedItemIds: [],
+            finished: false,
+          } satisfies WordBookPracticeProgressSnapshot)
+        : saved;
+
+    const safeIndex = Math.min(Math.max(scopedSaved.currentIndex, 0), Math.max(items.length - 1, 0));
+    const itemIds = new Set(items.map((item) => item.id));
+    const restoredCompletedIds = Array.isArray(scopedSaved.completedItemIds)
+      ? scopedSaved.completedItemIds.filter((id) => itemIds.has(id)).slice(0, items.length)
       : [];
+    const safeCompletedCount = Math.min(
+      Math.max(restoredCompletedIds.length > 0 ? restoredCompletedIds.length : scopedSaved.completedCount, 0),
+      items.length,
+    );
     const fallbackCompletedIds = items.slice(0, safeCompletedCount).map((item) => item.id);
 
     setCurrentIndex(safeIndex);
     setCompletedItemIds(new Set(restoredCompletedIds.length > 0 ? restoredCompletedIds : fallbackCompletedIds));
-    setFinished(saved.finished && safeCompletedCount >= items.length && items.length > 0);
-  }, [items.length, loading, progressKey]);
+    setFinished(scopedSaved.finished && safeCompletedCount >= items.length && items.length > 0);
+  }, [items, loading, progressDayKey, progressKey, progressScopeByDay]);
 
   const completedCount = completedItemIds.size;
 
@@ -1101,10 +1139,22 @@ export function WordBookPractice({ module }: WordBookPracticeProps) {
       currentIndex,
       completedCount,
       completedItemIds: Array.from(completedItemIds),
+      itemIds: items.map((item) => item.id),
+      dayKey: progressScopeByDay ? progressDayKey : undefined,
       finished,
       updatedAt: Date.now(),
     });
-  }, [completedCount, completedItemIds, currentIndex, finished, items.length, loading, progressKey]);
+  }, [
+    completedCount,
+    completedItemIds,
+    currentIndex,
+    finished,
+    items,
+    loading,
+    progressDayKey,
+    progressKey,
+    progressScopeByDay,
+  ]);
 
   const total = items.length;
 

--- a/src/lib/daily-plan-progress.ts
+++ b/src/lib/daily-plan-progress.ts
@@ -92,20 +92,13 @@ export async function savePracticeSession(
   options?: { mistakes?: LearningRecord['mistakes']; content?: ContentItem },
 ): Promise<void> {
   if (options?.content) {
-    const existingContent = await db.contents.where('id').equals(options.content.id).first();
+    const existingContent = await db.contents.where('id').equals(session.contentId).first();
     if (!existingContent) {
       await db.contents.put(options.content);
     }
   }
 
   await db.sessions.add(session);
-
-  if (options?.content) {
-    const existingContent = await db.contents.where('id').equals(session.contentId).first();
-    if (!existingContent) {
-      await db.contents.put(options.content);
-    }
-  }
 
   const existingRecords = await db.records.where('contentId').equals(session.contentId).toArray();
   const existingRecord = existingRecords.find((record) => record.module === session.module);

--- a/src/lib/wordbook-practice-progress.ts
+++ b/src/lib/wordbook-practice-progress.ts
@@ -1,0 +1,86 @@
+import { toLocalDateKey } from '@/lib/date-key';
+
+export interface WordBookPracticeProgressSnapshot {
+  currentIndex: number;
+  completedCount: number;
+  completedItemIds?: string[];
+  itemIds?: string[];
+  dayKey?: string;
+  finished: boolean;
+  updatedAt: number;
+}
+
+interface PracticeItem {
+  id: string;
+}
+
+interface ResolveWordBookPracticeItemsOptions<T extends PracticeItem> {
+  availableItems: T[];
+  limit: number;
+  savedProgress: WordBookPracticeProgressSnapshot | null;
+  practicedIds?: ReadonlySet<string>;
+  dayKey?: string;
+}
+
+interface ResolveWordBookPracticeItemsResult<T extends PracticeItem> {
+  items: T[];
+  restoredCompletedItemIds: string[];
+}
+
+export function resolveWordBookPracticeItems<T extends PracticeItem>({
+  availableItems,
+  limit,
+  savedProgress,
+  practicedIds,
+  dayKey = toLocalDateKey(),
+}: ResolveWordBookPracticeItemsOptions<T>): ResolveWordBookPracticeItemsResult<T> {
+  if (limit <= 0) {
+    const items = availableItems;
+    return {
+      items,
+      restoredCompletedItemIds: restoreCompletedItemIds(items, savedProgress),
+    };
+  }
+
+  const itemMap = new Map(availableItems.map((item) => [item.id, item]));
+  const savedItemIds = Array.isArray(savedProgress?.itemIds) ? savedProgress.itemIds : [];
+  const canRestoreSavedItems = savedProgress?.dayKey === dayKey && savedItemIds.length > 0;
+  const restoreProgress = canRestoreSavedItems ? savedProgress : null;
+
+  let items: T[];
+  if (canRestoreSavedItems) {
+    items = savedItemIds.map((id) => itemMap.get(id)).filter((item): item is T => Boolean(item));
+  } else {
+    const filteredItems =
+      practicedIds && practicedIds.size > 0
+        ? availableItems.filter((item) => !practicedIds.has(item.id))
+        : availableItems;
+    items = filteredItems.slice(0, limit);
+  }
+
+  return {
+    items,
+    restoredCompletedItemIds: restoreCompletedItemIds(items, restoreProgress),
+  };
+}
+
+function restoreCompletedItemIds<T extends PracticeItem>(
+  items: T[],
+  savedProgress: WordBookPracticeProgressSnapshot | null,
+): string[] {
+  if (!savedProgress || items.length === 0) {
+    return [];
+  }
+
+  const itemIds = new Set(items.map((item) => item.id));
+  const restoredCompletedIds = Array.isArray(savedProgress.completedItemIds)
+    ? savedProgress.completedItemIds.filter((id) => itemIds.has(id)).slice(0, items.length)
+    : [];
+
+  if (restoredCompletedIds.length > 0) {
+    return restoredCompletedIds;
+  }
+
+  const safeCompletedCount = Math.min(Math.max(savedProgress.completedCount, 0), items.length);
+  return items.slice(0, safeCompletedCount).map((item) => item.id);
+}


### PR DESCRIPTION
## Summary
- freeze limited daily-plan wordbook item sets per day and restore them by item id
- exclude already practiced words when generating the next limited practice set
- add regression tests for same-day restore and next-day rotation

## Verification
- pnpm lint
- pnpm typecheck
- pnpm test src/__tests__/wordbook-practice-progress.test.ts src/__tests__/daily-plan-progress.test.ts