### PR TITLE
Improve daily plan wordbook selection

### DIFF
--- a/src/__tests__/daily-plan.test.ts
+++ b/src/__tests__/daily-plan.test.ts
@@ -16,6 +16,7 @@ vi.mock('@/lib/wordbooks', () => ({
       filterTag: 'cet4',
       tags: [],
       description: '',
+      itemCount: 4500,
     },
     {
       id: 'travel-en',
@@ -29,6 +30,18 @@ vi.mock('@/lib/wordbooks', () => ({
       description: '',
     },
     {
+      id: 'tem4',
+      name: 'TEM-4',
+      nameEn: 'TEM-4 Vocabulary',
+      kind: 'vocabulary',
+      emoji: '',
+      difficulty: 'intermediate',
+      filterTag: 'tem4',
+      tags: [],
+      description: '',
+      itemCount: 4200,
+    },
+    {
       id: 'ielts',
       name: 'IELTS',
       nameEn: 'IELTS Vocabulary',
@@ -38,6 +51,7 @@ vi.mock('@/lib/wordbooks', () => ({
       filterTag: 'ielts',
       tags: [],
       description: '',
+      itemCount: 6000,
     },
     {
       id: 'business-en',
@@ -185,9 +199,11 @@ describe('generateDailyPlan', () => {
   // ── Empty state ───────────────────────────────────────────────────────────
 
   describe('empty state (new user)', () => {
-    it('returns empty array when no data', async () => {
+    it('still creates a built-in new-words task when no imported data exists', async () => {
       const tasks = await generateDailyPlan(defaultGoal);
-      expect(tasks).toEqual([]);
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0]?.type).toBe('new-words');
+      expect(tasks[0]?.title).toContain('20');
     });
 
     it('builds a signature from current content availability', async () => {
@@ -238,9 +254,8 @@ describe('generateDailyPlan', () => {
       const tasks = await generateDailyPlan(defaultGoal);
       const newWordsTask = tasks.find((t) => t.type === 'new-words');
       expect(newWordsTask).toBeDefined();
-      expect(newWordsTask!.title).toContain('3'); // 3 unpracticed
-      expect(newWordsTask!.description).toContain('CET-4');
-      expect(newWordsTask!.bookId).toBe('cet4');
+      expect(newWordsTask!.title).toContain('20');
+      expect(['cet4', 'tem4']).toContain(newWordsTask!.bookId ?? '');
       expect(newWordsTask!.module).toBe('write');
     });
 
@@ -265,15 +280,16 @@ describe('generateDailyPlan', () => {
       ];
 
       const tasks = await generateDailyPlan(defaultGoal);
-      expect(tasks.find((t) => t.type === 'new-words')).toBeUndefined();
+      expect(tasks.find((t) => t.type === 'new-words')?.bookId).not.toBe('cet4');
     });
 
-    it('skips wordbook with no imported content', async () => {
-      // cet4 has 0 imported contents
+    it('uses built-in vocabulary books even when no wordbook content was imported yet', async () => {
       mockContents = [];
 
       const tasks = await generateDailyPlan(defaultGoal);
-      expect(tasks.find((t) => t.type === 'new-words')).toBeUndefined();
+      const newWordsTask = tasks.find((t) => t.type === 'new-words');
+      expect(newWordsTask).toBeDefined();
+      expect(newWordsTask?.title).toContain('20');
     });
 
     it('prefers vocabulary difficulty close to the assessment level', async () => {
@@ -285,6 +301,20 @@ describe('generateDailyPlan', () => {
       const tasks = await generateDailyPlan(defaultGoal, { currentLevel: 'C1' });
       const newWordsTask = tasks.find((task) => task.type === 'new-words');
       expect(newWordsTask?.bookId).toBe('ielts');
+    });
+
+    it('rotates across comparable vocabulary books instead of always picking CET', async () => {
+      const firstDayTasks = await generateDailyPlan(
+        { wordsPerDay: 20, sessionsPerDay: 1 },
+        { currentLevel: 'B2', dateKey: '2026-03-12' },
+      );
+      const secondDayTasks = await generateDailyPlan(
+        { wordsPerDay: 20, sessionsPerDay: 1 },
+        { currentLevel: 'B2', dateKey: '2026-03-13' },
+      );
+
+      expect(firstDayTasks.find((task) => task.type === 'new-words')?.bookId).toBe('cet4');
+      expect(secondDayTasks.find((task) => task.type === 'new-words')?.bookId).toBe('tem4');
     });
   });
 
@@ -349,10 +379,10 @@ describe('generateDailyPlan', () => {
       ];
 
       vi.setSystemTime(new Date('2026-03-13T08:00:00+08:00'));
-      const firstDayTasks = await generateDailyPlan({ wordsPerDay: 20, sessionsPerDay: 1 }, { currentLevel: 'B2' });
+      const firstDayTasks = await generateDailyPlan({ wordsPerDay: 20, sessionsPerDay: 2 }, { currentLevel: 'B2' });
 
       vi.setSystemTime(new Date('2026-03-14T08:00:00+08:00'));
-      const secondDayTasks = await generateDailyPlan({ wordsPerDay: 20, sessionsPerDay: 1 }, { currentLevel: 'B2' });
+      const secondDayTasks = await generateDailyPlan({ wordsPerDay: 20, sessionsPerDay: 2 }, { currentLevel: 'B2' });
 
       expect(firstDayTasks.find((task) => task.type === 'article')?.contentId).not.toBe(
         secondDayTasks.find((task) => task.type === 'article')?.contentId,

--- a/src/__tests__/wordbook-practice-progress.test.ts
+++ b/src/__tests__/wordbook-practice-progress.test.ts
@@ -25,7 +25,7 @@ describe('wordbook-practice-progress', () => {
       dayKey: '2026-06-16',
     });
 
-    expect(resolved.items.map((item) => item.id)).toEqual(['word-4', 'word-5']);
+    expect(resolved.items.map((item) => item.id).sort()).toEqual(['word-4', 'word-5']);
     expect(resolved.restoredCompletedItemIds).toEqual([]);
   });
 
@@ -73,7 +73,7 @@ describe('wordbook-practice-progress', () => {
       dayKey: '2026-06-16',
     });
 
-    expect(resolved.items.map((item) => item.id)).toEqual(['word-4', 'word-5']);
+    expect(resolved.items.map((item) => item.id).sort()).toEqual(['word-4', 'word-5']);
     expect(resolved.restoredCompletedItemIds).toEqual([]);
   });
 });

--- a/src/lib/daily-plan.ts
+++ b/src/lib/daily-plan.ts
@@ -6,6 +6,7 @@ import { ALL_WORDBOOKS } from '@/lib/wordbooks';
 import type { CEFRLevel } from '@/stores/assessment-store';
 import type { DailyGoal, PlanTask } from '@/stores/daily-plan-store';
 import type { ContentItem, Difficulty, LearningRecord, TypingSession } from '@/types/content';
+import { getWordBookItemCount } from '@/types/wordbook';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const MODULE_ORDER: PlanTask['module'][] = ['write', 'read', 'speak', 'listen'];
@@ -210,21 +211,25 @@ async function buildNewWordsTask(
   modulePriority: number,
   dateKey: string,
 ): Promise<PlannedCandidate | null> {
+  const records = await db.records.toArray();
+  const practicedCountByCategory = new Map<string, number>();
+  const practicedContentIds = new Set(records.map((record) => record.contentId));
+
+  for (const content of await db.contents.toArray()) {
+    if (!content.category || !practicedContentIds.has(content.id)) continue;
+    practicedCountByCategory.set(content.category, (practicedCountByCategory.get(content.category) ?? 0) + 1);
+  }
+
   const candidates: PlannedCandidate[] = [];
 
   for (const book of ALL_WORDBOOKS) {
     if (book.kind !== 'vocabulary') continue;
 
-    const bookContents = await db.contents.where('category').equals(book.id).toArray();
-    if (bookContents.length === 0) continue;
+    const totalWordCount = Math.max(getWordBookItemCount(book), 0);
+    if (totalWordCount <= 0) continue;
 
-    const practicedIds = new Set<string>();
-    for (const content of bookContents) {
-      const record = await db.records.where('contentId').equals(content.id).first();
-      if (record) practicedIds.add(content.id);
-    }
-
-    const unpracticedCount = bookContents.length - practicedIds.size;
+    const practicedCount = practicedCountByCategory.get(book.id) ?? 0;
+    const unpracticedCount = totalWordCount - practicedCount;
     if (unpracticedCount <= 0) continue;
 
     const wordCount = Math.min(unpracticedCount, goal.wordsPerDay);

--- a/src/lib/wordbook-practice-progress.ts
+++ b/src/lib/wordbook-practice-progress.ts
@@ -55,13 +55,30 @@ export function resolveWordBookPracticeItems<T extends PracticeItem>({
       practicedIds && practicedIds.size > 0
         ? availableItems.filter((item) => !practicedIds.has(item.id))
         : availableItems;
-    items = filteredItems.slice(0, limit);
+    items = pickStableDailyItems(filteredItems, limit, dayKey);
   }
 
   return {
     items,
     restoredCompletedItemIds: restoreCompletedItemIds(items, restoreProgress),
   };
+}
+
+function pickStableDailyItems<T extends PracticeItem>(items: T[], limit: number, dayKey: string): T[] {
+  if (limit <= 0 || items.length <= limit) {
+    return items.slice(0, limit > 0 ? limit : items.length);
+  }
+
+  return [...items].sort((a, b) => hashString(`${dayKey}:${a.id}`) - hashString(`${dayKey}:${b.id}`)).slice(0, limit);
+}
+
+function hashString(value: string): number {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash >>> 0;
 }
 
 function restoreCompletedItemIds<T extends PracticeItem>(


### PR DESCRIPTION
## Summary
- let daily plan new-word tasks consider built-in vocabulary books instead of only imported DB entries
- rotate comparable vocabulary books across days instead of repeatedly sticking to CET
- shuffle limited wordbook sessions with a stable per-day order so the 20 words are not always the first 20

## Verification
- pnpm test src/__tests__/daily-plan.test.ts src/__tests__/wordbook-practice-progress.test.ts src/__tests__/daily-plan-progress.test.ts
- pnpm lint
- pnpm typecheck