### PR TITLE
[codex] Add practice notebook journal flow

### DIFF
--- a/src/app/(app)/journal/[id]/page.tsx
+++ b/src/app/(app)/journal/[id]/page.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { useParams } from 'next/navigation';
+import { useEffect } from 'react';
+import { JournalDetail } from '@/components/journal/journal-detail';
+import { useJournalStore } from '@/stores/journal-store';
+
+export default function JournalDetailPage() {
+  const params = useParams<{ id: string }>();
+  const loadJournals = useJournalStore((s) => s.loadJournals);
+  const loaded = useJournalStore((s) => s.loaded);
+
+  useEffect(() => {
+    if (!loaded) void loadJournals();
+  }, [loaded, loadJournals]);
+
+  return <JournalDetail journalId={params.id} />;
+}

--- a/src/app/(app)/journal/page.tsx
+++ b/src/app/(app)/journal/page.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { useEffect } from 'react';
+import { JournalList } from '@/components/journal/journal-list';
+import { useJournalStore } from '@/stores/journal-store';
+
+export default function JournalPage() {
+  const loadJournals = useJournalStore((s) => s.loadJournals);
+  const loaded = useJournalStore((s) => s.loaded);
+
+  useEffect(() => {
+    if (!loaded) void loadJournals();
+  }, [loaded, loadJournals]);
+
+  return <JournalList />;
+}

--- a/src/app/(app)/speak/[scenarioId]/page.tsx
+++ b/src/app/(app)/speak/[scenarioId]/page.tsx
@@ -4,6 +4,7 @@ import { ArrowLeft, Send } from 'lucide-react';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { useEffect } from 'react';
+import { SaveToJournalButton } from '@/components/journal/save-to-journal-button';
 import { RecommendationPanel } from '@/components/shared/recommendation-panel';
 import { ConversationArea } from '@/components/speak/conversation-area';
 import { ScenarioGoals } from '@/components/speak/scenario-goals';
@@ -108,6 +109,14 @@ export default function ConversationPage() {
           <Badge variant="outline" className={`text-[10px] px-1.5 py-0 ${difficultyColors[scenario.difficulty]}`}>
             {scenario.difficulty}
           </Badge>
+          <SaveToJournalButton messages={messages} title={scenario.title} />
+          <TranslationBar module="speak" />
+        </div>
+      )}
+
+      {isIOSNativeHost && (
+        <div className="flex items-center justify-end gap-2 shrink-0">
+          <SaveToJournalButton messages={messages} title={scenario.title} />
           <TranslationBar module="speak" />
         </div>
       )}

--- a/src/app/api/journal/ocr/route.ts
+++ b/src/app/api/journal/ocr/route.ts
@@ -1,0 +1,95 @@
+import { generateText } from 'ai';
+import { type NextRequest, NextResponse } from 'next/server';
+import { resolveApiKey, resolveModel } from '@/lib/ai-model';
+import { JOURNAL_OCR_SYSTEM, normalizeTurns, type RawTurn } from '@/lib/journal-structure';
+import { parseAIJson } from '@/lib/parse-ai-json';
+import { enforcePlatformRateLimit } from '@/lib/platform-provider';
+import { ProviderResolutionError, resolveProviderForCapability } from '@/lib/provider-resolver';
+import { providerSupportsVision } from '@/lib/provider-vision';
+import type { ProviderConfig, ProviderId } from '@/lib/providers';
+
+export async function POST(req: NextRequest) {
+  try {
+    const {
+      imageDataUrl,
+      provider = 'groq',
+      providerConfigs = {},
+    }: {
+      imageDataUrl?: string;
+      provider?: ProviderId;
+      providerConfigs?: Partial<Record<ProviderId, Partial<ProviderConfig>>>;
+    } = await req.json();
+
+    if (!imageDataUrl || !imageDataUrl.startsWith('data:image/')) {
+      return NextResponse.json({ error: 'Missing or invalid image' }, { status: 400 });
+    }
+
+    const resolution = resolveProviderForCapability({
+      capability: 'generate',
+      requestedProviderId: provider as ProviderId,
+      availableProviderConfigs: providerConfigs,
+      headers: req.headers,
+    });
+
+    if (!providerSupportsVision(resolution.providerId)) {
+      return NextResponse.json(
+        {
+          error: `Screenshot import needs a vision-capable provider (OpenAI, Anthropic, or Google). "${resolution.providerId}" can't read images — switch provider in Settings, or paste the text instead.`,
+          code: 'vision_not_supported',
+        },
+        { status: 422 },
+      );
+    }
+
+    const apiKey = resolveApiKey(resolution.providerId, req.headers, providerConfigs[resolution.providerId]?.auth);
+    if (!apiKey) {
+      return NextResponse.json({ error: 'No API key configured. Add your key in Settings.' }, { status: 401 });
+    }
+
+    const rateLimit = await enforcePlatformRateLimit({ headers: req.headers, capability: 'generate', resolution });
+    if (!rateLimit.ok) {
+      return NextResponse.json(
+        { error: rateLimit.message, code: 'platform_rate_limited' },
+        { status: 429, headers: { 'Retry-After': String(rateLimit.retryAfterSeconds) } },
+      );
+    }
+
+    const model = resolveModel({
+      providerId: resolution.providerId,
+      modelId: resolution.modelId,
+      apiKey,
+      baseUrl: resolution.baseUrl,
+      apiPath: resolution.apiPath,
+    });
+
+    const { text: result } = await generateText({
+      model,
+      system: JOURNAL_OCR_SYSTEM,
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Transcribe and structure the English-learning content in this screenshot.' },
+            { type: 'image', image: imageDataUrl },
+          ],
+        },
+      ],
+    });
+
+    const parsed = parseAIJson<{ turns: RawTurn[] }>(result, 'turns');
+    const turns = normalizeTurns(parsed.data);
+
+    if (turns.length === 0) {
+      return NextResponse.json({ error: 'Could not read any usable lines from the image.' }, { status: 422 });
+    }
+
+    return NextResponse.json({ turns, providerId: resolution.providerId, fallbackApplied: resolution.fallbackApplied });
+  } catch (error) {
+    console.error('Journal OCR error:', error);
+    if (error instanceof ProviderResolutionError) {
+      return NextResponse.json({ error: error.message, code: error.code }, { status: 400 });
+    }
+    const msg = error instanceof Error ? error.message : 'Failed to read image';
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/app/api/journal/structure/route.ts
+++ b/src/app/api/journal/structure/route.ts
@@ -1,0 +1,76 @@
+import { generateText } from 'ai';
+import { type NextRequest, NextResponse } from 'next/server';
+import { resolveApiKey, resolveModel } from '@/lib/ai-model';
+import { JOURNAL_STRUCTURE_SYSTEM, normalizeTurns, type RawTurn } from '@/lib/journal-structure';
+import { parseAIJson } from '@/lib/parse-ai-json';
+import { enforcePlatformRateLimit } from '@/lib/platform-provider';
+import { ProviderResolutionError, resolveProviderForCapability } from '@/lib/provider-resolver';
+import type { ProviderConfig, ProviderId } from '@/lib/providers';
+
+export async function POST(req: NextRequest) {
+  try {
+    const {
+      text,
+      provider = 'groq',
+      providerConfigs = {},
+    }: {
+      text?: string;
+      provider?: ProviderId;
+      providerConfigs?: Partial<Record<ProviderId, Partial<ProviderConfig>>>;
+    } = await req.json();
+
+    if (!text || !text.trim()) {
+      return NextResponse.json({ error: 'Missing text' }, { status: 400 });
+    }
+
+    const resolution = resolveProviderForCapability({
+      capability: 'generate',
+      requestedProviderId: provider as ProviderId,
+      availableProviderConfigs: providerConfigs,
+      headers: req.headers,
+    });
+
+    const apiKey = resolveApiKey(resolution.providerId, req.headers, providerConfigs[resolution.providerId]?.auth);
+    if (!apiKey) {
+      return NextResponse.json({ error: 'No API key configured. Add your key in Settings.' }, { status: 401 });
+    }
+
+    const rateLimit = await enforcePlatformRateLimit({ headers: req.headers, capability: 'generate', resolution });
+    if (!rateLimit.ok) {
+      return NextResponse.json(
+        { error: rateLimit.message, code: 'platform_rate_limited' },
+        { status: 429, headers: { 'Retry-After': String(rateLimit.retryAfterSeconds) } },
+      );
+    }
+
+    const model = resolveModel({
+      providerId: resolution.providerId,
+      modelId: resolution.modelId,
+      apiKey,
+      baseUrl: resolution.baseUrl,
+      apiPath: resolution.apiPath,
+    });
+
+    const { text: result } = await generateText({
+      model,
+      system: JOURNAL_STRUCTURE_SYSTEM,
+      prompt: text,
+    });
+
+    const parsed = parseAIJson<{ turns: RawTurn[] }>(result, 'turns');
+    const turns = normalizeTurns(parsed.data);
+
+    if (turns.length === 0) {
+      return NextResponse.json({ error: 'Could not extract any usable lines from the text.' }, { status: 422 });
+    }
+
+    return NextResponse.json({ turns, providerId: resolution.providerId, fallbackApplied: resolution.fallbackApplied });
+  } catch (error) {
+    console.error('Journal structure error:', error);
+    if (error instanceof ProviderResolutionError) {
+      return NextResponse.json({ error: error.message, code: error.code }, { status: 400 });
+    }
+    const msg = error instanceof Error ? error.message : 'Failed to structure imported content';
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/components/journal/import-dialog.tsx
+++ b/src/components/journal/import-dialog.tsx
@@ -1,0 +1,310 @@
+'use client';
+
+import { FileText, ImageIcon, Loader2, Sparkles, Trash2, Upload } from 'lucide-react';
+import { nanoid } from 'nanoid';
+import { useRouter } from 'next/navigation';
+import { type ReactNode, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { providerSupportsVision } from '@/lib/provider-vision';
+import { PROVIDER_REGISTRY } from '@/lib/providers';
+import { cn } from '@/lib/utils';
+import { useJournalStore } from '@/stores/journal-store';
+import { useProviderStore } from '@/stores/provider-store';
+import type { DialogueTurn } from '@/types/journal';
+
+type Mode = 'text' | 'image';
+
+function readFileAsDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(new Error('Failed to read file'));
+    reader.readAsDataURL(file);
+  });
+}
+
+export function ImportDialog({ trigger }: { trigger: ReactNode }) {
+  const router = useRouter();
+  const addJournal = useJournalStore((s) => s.addJournal);
+
+  const activeProviderId = useProviderStore((s) => s.activeProviderId);
+  const providerConfigs = useProviderStore((s) => s.providers);
+  const activeApiKey = useProviderStore((s) => {
+    const config = s.providers[s.activeProviderId];
+    return config?.auth.apiKey || config?.auth.accessToken || '';
+  });
+
+  const [open, setOpen] = useState(false);
+  const [mode, setMode] = useState<Mode>('text');
+  const [title, setTitle] = useState('');
+  const [text, setText] = useState('');
+  const [imageDataUrl, setImageDataUrl] = useState<string | null>(null);
+  const [turns, setTurns] = useState<DialogueTurn[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const visionOk = providerSupportsVision(activeProviderId);
+
+  const reset = () => {
+    setMode('text');
+    setTitle('');
+    setText('');
+    setImageDataUrl(null);
+    setTurns(null);
+    setError('');
+    setLoading(false);
+  };
+
+  const callJournalApi = async (path: string, body: Record<string, unknown>) => {
+    const headerKey = PROVIDER_REGISTRY[activeProviderId]?.headerKey;
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (activeApiKey && headerKey) headers[headerKey] = activeApiKey;
+    const res = await fetch(path, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ ...body, provider: activeProviderId, providerConfigs }),
+    });
+    const json = await res.json();
+    if (!res.ok) throw new Error(json.error || 'Request failed');
+    return json as { turns: { speaker?: string; text: string; translation?: string }[] };
+  };
+
+  const handleDocFile = async (file: File) => {
+    setError('');
+    setLoading(true);
+    try {
+      const isPdf = file.type === 'application/pdf' || file.name.toLowerCase().endsWith('.pdf');
+      const formData = new FormData();
+      formData.append('file', file);
+      const res = await fetch(isPdf ? '/api/import/pdf' : '/api/import/extract-text', {
+        method: 'POST',
+        body: formData,
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error || 'Extraction failed');
+      setText((prev) => (prev ? `${prev}\n\n${json.text ?? ''}` : (json.text ?? '')));
+      if (!title && json.metadata?.title) setTitle(json.metadata.title);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Extraction failed');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleImageFile = async (file: File) => {
+    setError('');
+    try {
+      const dataUrl = await readFileAsDataUrl(file);
+      setImageDataUrl(dataUrl);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to read image');
+    }
+  };
+
+  const handleAnalyze = async () => {
+    setError('');
+    setLoading(true);
+    try {
+      const json =
+        mode === 'image' && imageDataUrl
+          ? await callJournalApi('/api/journal/ocr', { imageDataUrl })
+          : await callJournalApi('/api/journal/structure', { text });
+      setTurns(json.turns.map((t) => ({ id: nanoid(), speaker: t.speaker, text: t.text, translation: t.translation })));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Analysis failed');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSave = async () => {
+    if (!turns || turns.length === 0) return;
+    const id = await addJournal({
+      title: title.trim() || 'Imported notebook',
+      source: mode === 'image' ? 'uploaded' : 'ai-generated',
+      turns,
+    });
+    setOpen(false);
+    reset();
+    router.push(`/journal/${id}`);
+  };
+
+  const canAnalyze = mode === 'image' ? Boolean(imageDataUrl) && visionOk : Boolean(text.trim());
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(o) => {
+        setOpen(o);
+        if (!o) reset();
+      }}
+    >
+      <DialogTrigger asChild>{trigger}</DialogTrigger>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Import into notebook</DialogTitle>
+        </DialogHeader>
+
+        {!turns ? (
+          <div className="space-y-3">
+            <div className="flex gap-1.5">
+              <button
+                type="button"
+                onClick={() => setMode('text')}
+                className={cn(
+                  'inline-flex items-center gap-1.5 px-3 h-8 rounded-md text-sm font-medium transition-colors',
+                  mode === 'text' ? 'bg-indigo-600 text-white' : 'bg-slate-100 text-slate-600 hover:bg-slate-200',
+                )}
+              >
+                <FileText className="w-4 h-4" /> Text / document
+              </button>
+              <button
+                type="button"
+                onClick={() => setMode('image')}
+                className={cn(
+                  'inline-flex items-center gap-1.5 px-3 h-8 rounded-md text-sm font-medium transition-colors',
+                  mode === 'image' ? 'bg-indigo-600 text-white' : 'bg-slate-100 text-slate-600 hover:bg-slate-200',
+                )}
+              >
+                <ImageIcon className="w-4 h-4" /> Screenshot
+              </button>
+            </div>
+
+            <Input value={title} onChange={(e) => setTitle(e.target.value)} placeholder="Title (optional)" />
+
+            {mode === 'text' ? (
+              <>
+                <Textarea
+                  value={text}
+                  onChange={(e) => setText(e.target.value)}
+                  rows={6}
+                  placeholder="Paste phrases, dialogue, sentence pairs, or notes here…"
+                />
+                <label className="inline-flex items-center gap-1.5 text-sm text-indigo-600 hover:underline cursor-pointer">
+                  <Upload className="w-4 h-4" /> or upload .txt / .md / .pdf / .docx
+                  <input
+                    type="file"
+                    accept=".txt,.md,.pdf,.docx,.epub"
+                    className="hidden"
+                    onChange={(e) => {
+                      const f = e.target.files?.[0];
+                      if (f) void handleDocFile(f);
+                    }}
+                  />
+                </label>
+              </>
+            ) : (
+              <>
+                {!visionOk && (
+                  <p className="text-xs text-amber-600 bg-amber-50 rounded-md px-3 py-2">
+                    Your current provider ({activeProviderId}) can't read images. Switch to OpenAI, Anthropic, or Google
+                    in Settings, or use the Text tab.
+                  </p>
+                )}
+                <label
+                  className={cn(
+                    'flex flex-col items-center justify-center gap-2 border-2 border-dashed rounded-lg py-8 cursor-pointer transition-colors',
+                    visionOk ? 'border-slate-200 hover:border-indigo-300' : 'border-slate-200 opacity-60',
+                  )}
+                >
+                  {imageDataUrl ? (
+                    // biome-ignore lint/performance/noImgElement: local data URL preview only
+                    <img src={imageDataUrl} alt="preview" className="max-h-40 rounded-md" />
+                  ) : (
+                    <>
+                      <ImageIcon className="w-8 h-8 text-slate-300" />
+                      <span className="text-sm text-slate-500">Click to choose a screenshot</span>
+                    </>
+                  )}
+                  <input
+                    type="file"
+                    accept="image/*"
+                    className="hidden"
+                    disabled={!visionOk}
+                    onChange={(e) => {
+                      const f = e.target.files?.[0];
+                      if (f) void handleImageFile(f);
+                    }}
+                  />
+                </label>
+              </>
+            )}
+
+            {error && <p className="text-sm text-red-600">{error}</p>}
+
+            <DialogFooter>
+              <Button onClick={handleAnalyze} disabled={!canAnalyze || loading}>
+                {loading ? <Loader2 className="w-4 h-4 animate-spin" /> : <Sparkles className="w-4 h-4" />}
+                Analyze
+              </Button>
+            </DialogFooter>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            <p className="text-sm text-slate-500">{turns.length} entries detected. Review and edit before saving.</p>
+            <div className="max-h-72 overflow-y-auto space-y-2 pr-1">
+              {turns.map((turn, idx) => (
+                <div key={turn.id} className="rounded-lg border border-slate-200 p-2.5 space-y-2">
+                  <div className="flex items-start gap-1.5">
+                    <Input
+                      value={turn.speaker ?? ''}
+                      onChange={(e) =>
+                        setTurns((prev) =>
+                          prev!.map((t) =>
+                            t.id === turn.id ? { ...t, speaker: e.target.value.trim() || undefined } : t,
+                          ),
+                        )
+                      }
+                      placeholder="Label / speaker (optional)"
+                      className="h-8 w-44 shrink-0"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => setTurns((prev) => prev!.filter((t) => t.id !== turn.id))}
+                      className="ml-auto shrink-0 h-8 w-8 flex items-center justify-center rounded-md text-slate-400 hover:text-red-600 hover:bg-red-50"
+                      title={`Remove entry ${idx + 1}`}
+                    >
+                      <Trash2 className="w-4 h-4" />
+                    </button>
+                  </div>
+                  <Textarea
+                    value={turn.text}
+                    onChange={(e) =>
+                      setTurns((prev) => prev!.map((t) => (t.id === turn.id ? { ...t, text: e.target.value } : t)))
+                    }
+                    rows={2}
+                    className="min-h-16"
+                  />
+                  <Input
+                    value={turn.translation ?? ''}
+                    onChange={(e) =>
+                      setTurns((prev) =>
+                        prev!.map((t) =>
+                          t.id === turn.id ? { ...t, translation: e.target.value.trim() || undefined } : t,
+                        ),
+                      )
+                    }
+                    placeholder="Translation (optional)"
+                    className="h-8"
+                  />
+                </div>
+              ))}
+            </div>
+            {error && <p className="text-sm text-red-600">{error}</p>}
+            <DialogFooter className="gap-2">
+              <Button variant="ghost" onClick={() => setTurns(null)}>
+                Back
+              </Button>
+              <Button onClick={handleSave} disabled={turns.length === 0}>
+                Save notebook
+              </Button>
+            </DialogFooter>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/journal/journal-detail.tsx
+++ b/src/components/journal/journal-detail.tsx
@@ -1,0 +1,223 @@
+'use client';
+
+import { ArrowLeft, BookOpen, Headphones, Mic, PenTool, Plus, Star } from 'lucide-react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useEffect, useMemo, useState } from 'react';
+import { TurnRow } from '@/components/journal/turn-row';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { useTTS } from '@/hooks/use-tts';
+import { journalContentCategory, useJournalStore } from '@/stores/journal-store';
+
+interface JournalDetailProps {
+  journalId: string;
+}
+
+export function JournalDetail({ journalId }: JournalDetailProps) {
+  const router = useRouter();
+  const { speak } = useTTS();
+  const journal = useJournalStore((s) => s.journals.find((j) => j.id === journalId));
+  const loaded = useJournalStore((s) => s.loaded);
+  const { updateJournal, deleteJournal, addTurn, updateTurn, removeTurn, toggleHighlight, materializeForPractice } =
+    useJournalStore();
+
+  // Draft state for the "add turn" composer.
+  const [speaker, setSpeaker] = useState('');
+  const [text, setText] = useState('');
+  const [translation, setTranslation] = useState('');
+  const [tagInput, setTagInput] = useState('');
+
+  useEffect(() => {
+    if (journal) setTagInput(journal.tags.join(', '));
+  }, [journal]);
+
+  const highlightCount = useMemo(() => journal?.turns.filter((t) => t.highlighted).length ?? 0, [journal?.turns]);
+
+  if (!journal) {
+    return (
+      <div className="p-8 text-center text-slate-500">
+        {loaded ? 'Journal not found.' : 'Loading…'}
+        <div className="mt-4">
+          <Link href="/journal" className="text-indigo-600 hover:underline">
+            Back to Practice Notebook
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const handleAddTurn = async () => {
+    const trimmed = text.trim();
+    if (!trimmed) return;
+    await addTurn(journalId, {
+      speaker: speaker.trim() || undefined,
+      text: trimmed,
+      translation: translation.trim() || undefined,
+    });
+    setText('');
+    setTranslation('');
+    setSpeaker('');
+  };
+
+  const commitTags = () => {
+    const tags = tagInput
+      .split(',')
+      .map((t) => t.trim())
+      .filter(Boolean);
+    void updateJournal(journalId, { tags });
+  };
+
+  const startPractice = async (module: 'listen' | 'speak' | 'read' | 'write') => {
+    await materializeForPractice(journalId);
+    router.push(`/${module}/book/${encodeURIComponent(journalContentCategory(journalId))}`);
+  };
+
+  const handleDelete = async () => {
+    if (!confirm('Delete this notebook? Highlighted sentences will be removed from review.')) return;
+    await deleteJournal(journalId);
+    router.push('/journal');
+  };
+
+  return (
+    <div className="max-w-2xl mx-auto px-4 py-6 space-y-6">
+      {/* Header */}
+      <div className="space-y-3">
+        <Link href="/journal" className="inline-flex items-center gap-1 text-sm text-slate-500 hover:text-slate-800">
+          <ArrowLeft className="w-4 h-4" /> Practice Notebook
+        </Link>
+
+        <Input
+          value={journal.title}
+          onChange={(e) => updateJournal(journalId, { title: e.target.value })}
+          className="text-lg font-semibold border-transparent hover:border-slate-200 focus-visible:border-slate-300 px-2 -mx-2"
+          placeholder="Notebook title"
+        />
+
+        <div className="flex flex-wrap items-center gap-2 text-sm">
+          <Input
+            type="date"
+            value={journal.lessonDate}
+            onChange={(e) => updateJournal(journalId, { lessonDate: e.target.value })}
+            className="h-8 w-auto"
+          />
+          <Input
+            value={journal.topic ?? ''}
+            onChange={(e) => updateJournal(journalId, { topic: e.target.value || undefined })}
+            className="h-8 w-40"
+            placeholder="Topic"
+          />
+          <Input
+            value={tagInput}
+            onChange={(e) => setTagInput(e.target.value)}
+            onBlur={commitTags}
+            className="h-8 flex-1 min-w-40"
+            placeholder="Tags (comma separated)"
+          />
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          {journal.tags.map((tag) => (
+            <Badge key={tag} variant="secondary">
+              #{tag}
+            </Badge>
+          ))}
+          {highlightCount > 0 && (
+            <Badge className="bg-amber-100 text-amber-700 hover:bg-amber-100">
+              <Star className="w-3 h-3 fill-amber-400 text-amber-400" /> {highlightCount} in review
+            </Badge>
+          )}
+          <span className="ml-auto">
+            <Button variant="ghost" size="sm" className="text-red-500 hover:text-red-600" onClick={handleDelete}>
+              Delete
+            </Button>
+          </span>
+        </div>
+      </div>
+
+      {/* Turns */}
+      <div className="space-y-4">
+        {journal.turns.length === 0 ? (
+          <p className="text-sm text-slate-400 text-center py-8">
+            No entries yet. Add your first phrase, note, sentence, or dialogue line below.
+          </p>
+        ) : (
+          journal.turns.map((turn) => (
+            <TurnRow
+              key={turn.id}
+              turn={turn}
+              onPlay={(t) => void speak(t)}
+              onToggleHighlight={() => toggleHighlight(journalId, turn.id)}
+              onUpdate={(updates) => updateTurn(journalId, turn.id, updates)}
+              onRemove={() => removeTurn(journalId, turn.id)}
+            />
+          ))
+        )}
+      </div>
+
+      {/* Add-turn composer */}
+      <div className="rounded-xl border border-slate-200 bg-white p-3 space-y-2">
+        <Input
+          value={speaker}
+          onChange={(e) => setSpeaker(e.target.value)}
+          placeholder="Label / speaker (optional: A, B, Me, Teacher, Phrase...)"
+          className="h-8"
+        />
+        <Textarea
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          rows={2}
+          placeholder="Write a phrase, sentence, note, or dialogue line…"
+          onKeyDown={(e) => {
+            if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') void handleAddTurn();
+          }}
+        />
+        <Input
+          value={translation}
+          onChange={(e) => setTranslation(e.target.value)}
+          placeholder="Translation (optional)"
+          className="h-8"
+        />
+        <div className="flex justify-end">
+          <Button size="sm" onClick={handleAddTurn} disabled={!text.trim()}>
+            <Plus className="w-4 h-4" /> Add entry
+          </Button>
+        </div>
+      </div>
+
+      {/* Practice whole notebook */}
+      {journal.turns.length > 0 && (
+        <div className="space-y-2">
+          <h3 className="text-sm font-semibold text-slate-700">Practice these entries</h3>
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+            <Button variant="outline" size="sm" onClick={() => startPractice('listen')}>
+              <Headphones className="w-4 h-4" /> Listen
+            </Button>
+            <Button variant="outline" size="sm" onClick={() => startPractice('speak')}>
+              <Mic className="w-4 h-4" /> Speak
+            </Button>
+            <Button variant="outline" size="sm" onClick={() => startPractice('read')}>
+              <BookOpen className="w-4 h-4" /> Read
+            </Button>
+            <Button variant="outline" size="sm" onClick={() => startPractice('write')}>
+              <PenTool className="w-4 h-4" /> Write
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {/* Notes */}
+      <div className="space-y-2">
+        <h3 className="text-sm font-semibold text-slate-700">Notes</h3>
+        <Textarea
+          value={journal.notes ?? ''}
+          onChange={(e) => updateJournal(journalId, { notes: e.target.value || undefined })}
+          rows={3}
+          placeholder="Anything to remember about these phrases, lines, or notes…"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/journal/journal-list.tsx
+++ b/src/components/journal/journal-list.tsx
@@ -1,0 +1,174 @@
+'use client';
+
+import { MessageSquareText, Plus, Search, Star, Upload } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { useDeferredValue, useMemo, useState } from 'react';
+import { ImportDialog } from '@/components/journal/import-dialog';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { useJournalStore } from '@/stores/journal-store';
+import type { JournalEntry } from '@/types/journal';
+
+function todayDateKey(): string {
+  const now = new Date();
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
+}
+
+export function JournalList() {
+  const router = useRouter();
+  const journals = useJournalStore((s) => s.journals);
+  const loading = useJournalStore((s) => s.loading);
+  const addJournal = useJournalStore((s) => s.addJournal);
+
+  const [search, setSearch] = useState('');
+  const deferredSearch = useDeferredValue(search);
+
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [newTitle, setNewTitle] = useState('');
+  const [newTopic, setNewTopic] = useState('');
+  const [newDate, setNewDate] = useState(todayDateKey());
+
+  const filtered = useMemo(() => {
+    const q = deferredSearch.trim().toLowerCase();
+    if (!q) return journals;
+    return journals.filter((j) => {
+      const haystack = [j.title, j.topic, ...j.tags, ...j.turns.map((t) => t.text)].join(' ').toLowerCase();
+      return haystack.includes(q);
+    });
+  }, [journals, deferredSearch]);
+
+  // Group by lessonDate, newest first.
+  const groups = useMemo(() => {
+    const map = new Map<string, JournalEntry[]>();
+    for (const j of filtered) {
+      const list = map.get(j.lessonDate) ?? [];
+      list.push(j);
+      map.set(j.lessonDate, list);
+    }
+    return Array.from(map.entries()).sort((a, b) => b[0].localeCompare(a[0]));
+  }, [filtered]);
+
+  const handleCreate = async () => {
+    const id = await addJournal({
+      title: newTitle.trim() || 'Untitled notebook',
+      topic: newTopic.trim() || undefined,
+      lessonDate: newDate || todayDateKey(),
+    });
+    setDialogOpen(false);
+    setNewTitle('');
+    setNewTopic('');
+    setNewDate(todayDateKey());
+    router.push(`/journal/${id}`);
+  };
+
+  return (
+    <div className="max-w-2xl mx-auto px-4 py-6 space-y-5">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h1 className="text-xl font-bold text-slate-900">Practice Notebook</h1>
+          <p className="text-sm text-slate-500">
+            Save phrases, dialogues, notes, and sentence sets you want to practice again.
+          </p>
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          <ImportDialog
+            trigger={
+              <Button variant="outline">
+                <Upload className="w-4 h-4" /> Import
+              </Button>
+            }
+          />
+          <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+            <DialogTrigger asChild>
+              <Button>
+                <Plus className="w-4 h-4" /> New
+              </Button>
+            </DialogTrigger>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Create notebook</DialogTitle>
+              </DialogHeader>
+              <div className="space-y-3">
+                <Input
+                  value={newTitle}
+                  onChange={(e) => setNewTitle(e.target.value)}
+                  placeholder="Title (e.g. Self-introduction, Coffee phrases)"
+                  autoFocus
+                />
+                <Input
+                  value={newTopic}
+                  onChange={(e) => setNewTopic(e.target.value)}
+                  placeholder="Topic / label (optional)"
+                />
+                <Input type="date" value={newDate} onChange={(e) => setNewDate(e.target.value)} />
+              </div>
+              <DialogFooter>
+                <Button onClick={handleCreate}>Create</Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
+        </div>
+      </div>
+
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
+        <Input
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search notebooks, topics, tags, lines…"
+          className="pl-9"
+        />
+      </div>
+
+      {loading && journals.length === 0 ? (
+        <p className="text-sm text-slate-400 text-center py-10">Loading…</p>
+      ) : groups.length === 0 ? (
+        <div className="text-center py-16 text-slate-400">
+          <MessageSquareText className="w-10 h-10 mx-auto mb-3 opacity-40" />
+          <p className="text-sm">{search ? 'No matching notebooks.' : 'No notebooks yet. Create your first one.'}</p>
+        </div>
+      ) : (
+        <div className="space-y-6">
+          {groups.map(([date, entries]) => (
+            <div key={date} className="space-y-2">
+              <h2 className="text-xs font-semibold uppercase tracking-wide text-slate-400">{date}</h2>
+              <div className="space-y-2">
+                {entries.map((j) => {
+                  const highlights = j.turns.filter((t) => t.highlighted).length;
+                  return (
+                    <button
+                      key={j.id}
+                      type="button"
+                      onClick={() => router.push(`/journal/${j.id}`)}
+                      className="w-full text-left rounded-xl border border-slate-200 bg-white p-3.5 hover:border-indigo-300 hover:shadow-sm transition-all"
+                    >
+                      <div className="flex items-center justify-between gap-2">
+                        <span className="font-medium text-slate-900 truncate">{j.title}</span>
+                        <span className="text-xs text-slate-400 shrink-0">{j.turns.length} entries</span>
+                      </div>
+                      <div className="flex flex-wrap items-center gap-1.5 mt-1.5">
+                        {j.topic && <Badge variant="secondary">{j.topic}</Badge>}
+                        {j.tags.map((tag) => (
+                          <Badge key={tag} variant="outline" className="text-slate-500">
+                            #{tag}
+                          </Badge>
+                        ))}
+                        {highlights > 0 && (
+                          <Badge className="bg-amber-100 text-amber-700 hover:bg-amber-100">
+                            <Star className="w-3 h-3 fill-amber-400 text-amber-400" /> {highlights}
+                          </Badge>
+                        )}
+                      </div>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/journal/save-to-journal-button.test.tsx
+++ b/src/components/journal/save-to-journal-button.test.tsx
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import type { ConversationMessage } from '@/types/scenario';
+import { canSaveConversationToJournal } from './save-to-journal-button';
+
+function message(overrides: Partial<ConversationMessage>): ConversationMessage {
+  return {
+    id: 'msg-1',
+    role: 'assistant',
+    content: '',
+    timestamp: Date.now(),
+    ...overrides,
+  };
+}
+
+describe('canSaveConversationToJournal', () => {
+  it('returns false for an opening message without any user reply', () => {
+    expect(
+      canSaveConversationToJournal([
+        message({
+          role: 'assistant',
+          content: 'Hey there! Welcome to Sunrise Coffee. What can I get started for you today?',
+        }),
+      ]),
+    ).toBe(false);
+  });
+
+  it('returns true once the user has sent a real message', () => {
+    expect(
+      canSaveConversationToJournal([
+        message({
+          role: 'assistant',
+          content: 'Hey there! Welcome to Sunrise Coffee. What can I get started for you today?',
+        }),
+        message({
+          id: 'msg-2',
+          role: 'user',
+          content: 'I would like a latte, please.',
+        }),
+      ]),
+    ).toBe(true);
+  });
+});

--- a/src/components/journal/save-to-journal-button.tsx
+++ b/src/components/journal/save-to-journal-button.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { BookmarkPlus, Check } from 'lucide-react';
+import { nanoid } from 'nanoid';
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { useJournalStore } from '@/stores/journal-store';
+import type { DialogueTurn } from '@/types/journal';
+import type { ConversationMessage } from '@/types/scenario';
+
+interface SaveToJournalButtonProps {
+  messages: ConversationMessage[];
+  title: string;
+}
+
+export function canSaveConversationToJournal(messages: ConversationMessage[]): boolean {
+  return messages.some((message) => message.role === 'user' && message.content.trim());
+}
+
+export function SaveToJournalButton({ messages, title }: SaveToJournalButtonProps) {
+  const addJournal = useJournalStore((s) => s.addJournal);
+  const [saved, setSaved] = useState(false);
+
+  const usable = messages.filter((m) => m.role !== 'recording' && m.content.trim());
+  const hasRealConversation = canSaveConversationToJournal(usable);
+
+  const handleSave = async () => {
+    const turns: DialogueTurn[] = usable.map((m) => ({
+      id: nanoid(),
+      speaker: m.role === 'user' ? 'Me' : 'Teacher',
+      text: m.content,
+      translation: m.translation || undefined,
+    }));
+    if (turns.length === 0 || !hasRealConversation) return;
+    await addJournal({ title, source: 'from-speak', turns, tags: ['speak'] });
+    setSaved(true);
+  };
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={handleSave}
+      disabled={saved || usable.length === 0 || !hasRealConversation}
+      className="border-indigo-200 text-indigo-600 shrink-0"
+      title={
+        hasRealConversation
+          ? 'Save this conversation to your Practice Notebook'
+          : 'Start the conversation first, then save it to your Practice Notebook'
+      }
+    >
+      {saved ? (
+        <>
+          <Check className="w-4 h-4" /> Saved
+        </>
+      ) : (
+        <>
+          <BookmarkPlus className="w-4 h-4" /> Save
+        </>
+      )}
+    </Button>
+  );
+}

--- a/src/components/journal/turn-row.tsx
+++ b/src/components/journal/turn-row.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+import { Check, Languages, Pencil, Star, Trash2, Volume2, X } from 'lucide-react';
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { cn } from '@/lib/utils';
+import type { DialogueTurn } from '@/types/journal';
+
+interface TurnRowProps {
+  turn: DialogueTurn;
+  onPlay: (text: string) => void;
+  onToggleHighlight: () => void;
+  onUpdate: (updates: Partial<DialogueTurn>) => void;
+  onRemove: () => void;
+}
+
+export function TurnRow({ turn, onPlay, onToggleHighlight, onUpdate, onRemove }: TurnRowProps) {
+  const speakerLabel = turn.speaker?.trim() || '';
+  const isLabeled = speakerLabel.length > 0;
+  const [editing, setEditing] = useState(false);
+  const [draftSpeaker, setDraftSpeaker] = useState(speakerLabel);
+  const [draftText, setDraftText] = useState(turn.text);
+  const [draftTranslation, setDraftTranslation] = useState(turn.translation ?? '');
+  const [showTranslation, setShowTranslation] = useState(false);
+
+  const saveEdit = () => {
+    onUpdate({
+      speaker: draftSpeaker.trim() || undefined,
+      text: draftText.trim(),
+      translation: draftTranslation.trim() || undefined,
+    });
+    setEditing(false);
+  };
+
+  return (
+    <div className="flex gap-2.5">
+      <div className="max-w-[86%] flex flex-col">
+        {editing ? (
+          <div className="flex flex-col gap-2 w-72 max-w-full">
+            <Input
+              value={draftSpeaker}
+              onChange={(e) => setDraftSpeaker(e.target.value)}
+              placeholder="Label / speaker (optional)"
+              className="h-8"
+            />
+            <Textarea value={draftText} onChange={(e) => setDraftText(e.target.value)} rows={2} placeholder="English" />
+            <Textarea
+              value={draftTranslation}
+              onChange={(e) => setDraftTranslation(e.target.value)}
+              rows={1}
+              placeholder="Translation (optional)"
+            />
+            <div className="flex gap-1.5">
+              <Button size="xs" onClick={saveEdit}>
+                <Check className="w-3 h-3" /> Save
+              </Button>
+              <Button size="xs" variant="ghost" onClick={() => setEditing(false)}>
+                <X className="w-3 h-3" /> Cancel
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <>
+            {isLabeled && (
+              <p className="mb-1 px-1 text-xs font-medium uppercase tracking-wide text-slate-400">{speakerLabel}</p>
+            )}
+            <div
+              className={cn(
+                'rounded-2xl px-4 py-2.5 text-sm leading-relaxed relative',
+                isLabeled ? 'bg-indigo-50 text-indigo-900' : 'bg-slate-100 text-slate-900',
+                turn.highlighted && 'ring-2 ring-amber-400',
+              )}
+            >
+              <span className="whitespace-pre-wrap">{turn.text}</span>
+            </div>
+
+            <div className="ml-1 mt-1 flex items-center gap-0.5">
+              <button
+                type="button"
+                onClick={() => onPlay(turn.text)}
+                className="h-6 w-6 flex items-center justify-center rounded-md text-slate-400 hover:text-indigo-600 hover:bg-indigo-50 transition-colors cursor-pointer"
+                title="Play"
+              >
+                <Volume2 className="w-3.5 h-3.5" />
+              </button>
+              <button
+                type="button"
+                onClick={onToggleHighlight}
+                className={cn(
+                  'h-6 w-6 flex items-center justify-center rounded-md transition-colors cursor-pointer',
+                  turn.highlighted
+                    ? 'text-amber-500 bg-amber-50'
+                    : 'text-slate-400 hover:text-amber-500 hover:bg-amber-50',
+                )}
+                title={turn.highlighted ? 'Remove from review' : 'Mark golden sentence (add to review)'}
+              >
+                <Star className={cn('w-3.5 h-3.5', turn.highlighted && 'fill-amber-400')} />
+              </button>
+              {turn.translation && (
+                <button
+                  type="button"
+                  onClick={() => setShowTranslation((v) => !v)}
+                  className={cn(
+                    'h-6 w-6 flex items-center justify-center rounded-md transition-colors cursor-pointer',
+                    showTranslation
+                      ? 'text-indigo-600 bg-indigo-50'
+                      : 'text-slate-400 hover:text-indigo-600 hover:bg-indigo-50',
+                  )}
+                  title="Toggle translation"
+                >
+                  <Languages className="w-3.5 h-3.5" />
+                </button>
+              )}
+              <button
+                type="button"
+                onClick={() => {
+                  setDraftSpeaker(speakerLabel);
+                  setDraftText(turn.text);
+                  setDraftTranslation(turn.translation ?? '');
+                  setEditing(true);
+                }}
+                className="h-6 w-6 flex items-center justify-center rounded-md text-slate-400 hover:text-slate-700 hover:bg-slate-100 transition-colors cursor-pointer"
+                title="Edit"
+              >
+                <Pencil className="w-3.5 h-3.5" />
+              </button>
+              <button
+                type="button"
+                onClick={onRemove}
+                className="h-6 w-6 flex items-center justify-center rounded-md text-slate-400 hover:text-red-600 hover:bg-red-50 transition-colors cursor-pointer"
+                title="Delete"
+              >
+                <Trash2 className="w-3.5 h-3.5" />
+              </button>
+            </div>
+
+            {showTranslation && turn.translation && (
+              <p className="mt-0.5 px-2 text-sm text-slate-500">{turn.translation}</p>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -13,6 +13,7 @@ import {
   LayoutDashboard,
   Library,
   MessageCircle,
+  NotebookPen,
   PenTool,
   Radar,
   RotateCcw,
@@ -260,6 +261,7 @@ export function Sidebar({ open = false, onOpenChange }: SidebarProps = {}) {
       items: [
         { href: '/library', label: messages.items.library, icon: Library },
         { href: '/library/wordbooks', label: messages.items.wordBooks, icon: BookMarked },
+        { href: '/journal', label: messages.items.journal, icon: NotebookPen },
         { href: '/favorites', label: messages.items.favorites, icon: Heart },
       ],
     },

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -3,6 +3,7 @@ import type { WordTimestamp } from '@/lib/word-alignment';
 import type { Conversation } from '@/types/chat';
 import type { BookItem, CollectionItem, ContentItem, LearningRecord, TypingSession } from '@/types/content';
 import type { FavoriteFolder, FavoriteItem, LookupEntry } from '@/types/favorite';
+import type { JournalEntry } from '@/types/journal';
 import type { WeakSpot } from '@/types/weak-spot';
 
 export interface TranslationCacheEntry {
@@ -39,6 +40,7 @@ class EchoTypeDB extends Dexie {
   alignmentCache!: Table<AlignmentCacheEntry>;
   collections!: Table<CollectionItem>;
   weakSpots!: Table<WeakSpot>;
+  journals!: Table<JournalEntry>;
 
   constructor() {
     super('echotype');
@@ -218,6 +220,25 @@ class EchoTypeDB extends Dexie {
       collections: 'id, category, source, difficulty, createdAt, updatedAt, *tags',
     });
 
+    // Version 15: add journals table for dialogue notebook / learning journal
+    this.version(15).stores({
+      contents: 'id, type, category, source, difficulty, createdAt, updatedAt, *tags',
+      records: 'id, contentId, module, lastPracticed, nextReview, updatedAt',
+      sessions: 'id, contentId, module, startTime, completed',
+      books: 'id, title, source, createdAt',
+      conversations: 'id, updatedAt, createdAt',
+      favorites:
+        'id, normalizedText, type, folderId, sourceContentId, targetLang, nextReview, autoCollected, createdAt, updatedAt',
+      favoriteFolders: 'id, sortOrder, createdAt',
+      lookupHistory: 'text, count, lastLookedUp',
+      translationCache: 'key, createdAt',
+      mediaBlobs: 'contentId, createdAt',
+      alignmentCache: 'cacheKey, createdAt',
+      weakSpots: 'id, module, weakSpotType, normalizedText, lastSeenAt, resolved, [module+weakSpotType+normalizedText]',
+      collections: 'id, category, source, difficulty, createdAt, updatedAt, *tags',
+      journals: 'id, lessonDate, source, updatedAt, *tags',
+    });
+
     // Dexie hooks: auto-set updatedAt on create/update for contents and records
     this.contents.hook('creating', (_primKey, obj) => {
       const now = Date.now();
@@ -252,6 +273,19 @@ class EchoTypeDB extends Dexie {
     });
 
     this.favorites.hook('updating', (modifications) => {
+      if (!('updatedAt' in modifications)) {
+        return { ...modifications, updatedAt: Date.now() };
+      }
+      return undefined;
+    });
+
+    this.journals.hook('creating', (_primKey, obj) => {
+      const now = Date.now();
+      if (!obj.updatedAt) obj.updatedAt = now;
+      if (!obj.createdAt) obj.createdAt = now;
+    });
+
+    this.journals.hook('updating', (modifications) => {
       if (!('updatedAt' in modifications)) {
         return { ...modifications, updatedAt: Date.now() };
       }

--- a/src/lib/i18n/messages/sidebar/en.json
+++ b/src/lib/i18n/messages/sidebar/en.json
@@ -13,6 +13,7 @@
     "write": "Write",
     "library": "Library",
     "wordBooks": "Word Books",
+    "journal": "Practice Notebook",
     "favorites": "Favorites",
     "todayReview": "Today's Review",
     "weakSpots": "Weak Spots",

--- a/src/lib/i18n/messages/sidebar/zh.json
+++ b/src/lib/i18n/messages/sidebar/zh.json
@@ -13,6 +13,7 @@
     "write": "写作",
     "library": "资料库",
     "wordBooks": "词书",
+    "journal": "练习本",
     "favorites": "收藏",
     "todayReview": "今日复习",
     "weakSpots": "薄弱点",

--- a/src/lib/journal-structure.test.ts
+++ b/src/lib/journal-structure.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeTurns } from './journal-structure';
+
+describe('normalizeTurns', () => {
+  it('keeps free-form speaker labels and unlabeled lines', () => {
+    expect(
+      normalizeTurns({
+        turns: [
+          { speaker: ' A: ', text: ' Where is the nearest station? ', translation: '最近的车站在哪里？' },
+          { speaker: '', text: 'Could you say that again, please?' },
+          { speaker: 'Phrase', text: 'I am looking forward to it.', translation: '' },
+        ],
+      }),
+    ).toEqual([
+      { speaker: 'A', text: 'Where is the nearest station?', translation: '最近的车站在哪里？' },
+      { speaker: undefined, text: 'Could you say that again, please?', translation: undefined },
+      { speaker: 'Phrase', text: 'I am looking forward to it.', translation: undefined },
+    ]);
+  });
+
+  it('does not invent a speaker for unknown labels', () => {
+    expect(
+      normalizeTurns({
+        turns: [
+          { speaker: 'unknown', text: 'Single sentence material.' },
+          { speaker: 'n/a', text: 'Useful phrase.' },
+          { speaker: 'Teacher', text: 'Try this sentence.' },
+        ],
+      }),
+    ).toEqual([
+      { speaker: undefined, text: 'Single sentence material.', translation: undefined },
+      { speaker: undefined, text: 'Useful phrase.', translation: undefined },
+      { speaker: 'Teacher', text: 'Try this sentence.', translation: undefined },
+    ]);
+  });
+
+  it('drops empty or malformed turn items', () => {
+    expect(
+      normalizeTurns({
+        turns: [{ speaker: 'A', text: '  ' }, null, { text: 'Keep this line.' }],
+      }),
+    ).toEqual([{ speaker: undefined, text: 'Keep this line.', translation: undefined }]);
+  });
+});

--- a/src/lib/journal-structure.ts
+++ b/src/lib/journal-structure.ts
@@ -1,0 +1,58 @@
+export interface RawTurn {
+  speaker?: string;
+  text: string;
+  translation?: string;
+}
+
+export const JOURNAL_STRUCTURE_SYSTEM = `You are parsing imported English-learning material. It may be:
+- a teacher/student dialogue
+- an A/B dialogue
+- a list of useful phrases
+- standalone sentences or notes without speaker labels
+Split the text into clean line items and return ONLY valid JSON (no markdown, no commentary) of the shape:
+{ "turns": [ { "speaker": "<optional free-form label such as Teacher, Me, A, B, Phrase, Note, or empty string>", "text": "<the English line>", "translation": "<short translation in the learner's language, or empty string>" } ] }
+Rules:
+- Preserve clear speaker labels when present, but use short natural labels only.
+- If a line has no clear speaker, leave "speaker" empty instead of inventing one.
+- Keep each line's English text clean (strip duplicate speaker labels, timestamps, and bullet markers).
+- Do not invent content that is not in the source. Do not merge unrelated lines.
+- "translation" should be a concise Chinese (zh-CN) translation unless the source itself provides translations.`;
+
+export const JOURNAL_OCR_SYSTEM = `You are reading a screenshot of English-learning material.
+It may contain a chat, an A/B dialogue, phrase cards, or standalone lines.
+First transcribe the visible English text via OCR, then split it into clean line items.
+Return ONLY valid JSON (no markdown, no commentary) of the shape:
+{ "turns": [ { "speaker": "<optional free-form label such as Teacher, Me, A, B, Phrase, Note, or empty string>", "text": "<the English line>", "translation": "<short zh-CN translation, or empty string>" } ] }
+Rules:
+- Preserve visible speaker labels when clear. If a line has no clear label, leave "speaker" empty.
+- Only include legible English learning lines; ignore UI chrome, timestamps, names, and reactions.
+- Do not invent content that is not visible in the image.`;
+
+/** Coerce arbitrary AI JSON into clean RawTurn[]. */
+export function normalizeTurns(raw: unknown): RawTurn[] {
+  if (!raw || typeof raw !== 'object' || !Array.isArray((raw as { turns?: unknown }).turns)) return [];
+  const turns = (raw as { turns: unknown[] }).turns;
+  const result: RawTurn[] = [];
+  for (const t of turns) {
+    if (!t || typeof t !== 'object') continue;
+    const rec = t as Record<string, unknown>;
+    const text = typeof rec.text === 'string' ? rec.text.trim() : '';
+    if (!text) continue;
+    const speaker = normalizeSpeaker(rec.speaker);
+    const translation = typeof rec.translation === 'string' ? rec.translation.trim() : '';
+    result.push({ speaker, text, translation: translation || undefined });
+  }
+  return result;
+}
+
+function normalizeSpeaker(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const cleaned = value
+    .trim()
+    .replace(/^[\s:：\-–—]+|[\s:：\-–—]+$/g, '')
+    .replace(/\s+/g, ' ');
+  if (!cleaned) return undefined;
+  const lowered = cleaned.toLowerCase();
+  if (['none', 'unknown', 'n/a', 'na', 'unlabeled', 'no speaker'].includes(lowered)) return undefined;
+  return cleaned;
+}

--- a/src/lib/provider-vision.ts
+++ b/src/lib/provider-vision.ts
@@ -1,0 +1,11 @@
+import type { ProviderId } from './providers';
+
+/**
+ * Providers whose default chat models accept image input (multimodal).
+ * Used to gate the screenshot-OCR path — text/document import works on any provider.
+ */
+export const VISION_PROVIDER_IDS: ProviderId[] = ['openai', 'anthropic', 'google'];
+
+export function providerSupportsVision(providerId: ProviderId): boolean {
+  return VISION_PROVIDER_IDS.includes(providerId);
+}

--- a/src/lib/sync/engine.ts
+++ b/src/lib/sync/engine.ts
@@ -2,16 +2,19 @@ import type { SupabaseClient } from '@supabase/supabase-js';
 import { db } from '@/lib/db';
 import type { ContentItem, LearningRecord, TypingSession } from '@/types/content';
 import type { FavoriteFolder, FavoriteItem } from '@/types/favorite';
+import type { JournalEntry } from '@/types/journal';
 
 import {
   fromSupabaseContent,
   fromSupabaseFavorite,
   fromSupabaseFavoriteFolder,
+  fromSupabaseJournal,
   fromSupabaseRecord,
   fromSupabaseSession,
   toSupabaseContent,
   toSupabaseFavorite,
   toSupabaseFavoriteFolder,
+  toSupabaseJournal,
   toSupabaseRecord,
   toSupabaseSession,
 } from './mapper';
@@ -19,12 +22,26 @@ import {
 // ─── Types ──────────────────────────────────────────────────────────────────────
 
 export interface SyncResult {
-  pulled: { contents: number; records: number; sessions: number; favorites: number; favoriteFolders: number };
-  pushed: { contents: number; records: number; sessions: number; favorites: number; favoriteFolders: number };
+  pulled: {
+    contents: number;
+    records: number;
+    sessions: number;
+    favorites: number;
+    favoriteFolders: number;
+    journals: number;
+  };
+  pushed: {
+    contents: number;
+    records: number;
+    sessions: number;
+    favorites: number;
+    favoriteFolders: number;
+    journals: number;
+  };
   errors: string[];
 }
 
-type SyncableTable = 'contents' | 'records' | 'sessions' | 'favorites' | 'favoriteFolders';
+type SyncableTable = 'contents' | 'records' | 'sessions' | 'favorites' | 'favoriteFolders' | 'journals';
 
 // ─── Helpers ────────────────────────────────────────────────────────────────────
 
@@ -40,8 +57,8 @@ function setLastSyncedAt(userId: string, iso: string): void {
 
 function emptySyncResult(): SyncResult {
   return {
-    pulled: { contents: 0, records: 0, sessions: 0, favorites: 0, favoriteFolders: 0 },
-    pushed: { contents: 0, records: 0, sessions: 0, favorites: 0, favoriteFolders: 0 },
+    pulled: { contents: 0, records: 0, sessions: 0, favorites: 0, favoriteFolders: 0, journals: 0 },
+    pushed: { contents: 0, records: 0, sessions: 0, favorites: 0, favoriteFolders: 0, journals: 0 },
     errors: [],
   };
 }
@@ -90,6 +107,12 @@ export class SyncEngine {
     }
 
     try {
+      result.pulled.journals = await this.pullTable('journals');
+    } catch (e) {
+      result.errors.push(`Pull journals failed: ${(e as Error).message}`);
+    }
+
+    try {
       result.pushed.contents = await this.pushTable('contents');
     } catch (e) {
       result.errors.push(`Push contents failed: ${(e as Error).message}`);
@@ -119,6 +142,12 @@ export class SyncEngine {
       result.errors.push(`Push favoriteFolders failed: ${(e as Error).message}`);
     }
 
+    try {
+      result.pushed.journals = await this.pushTable('journals');
+    } catch (e) {
+      result.errors.push(`Push journals failed: ${(e as Error).message}`);
+    }
+
     setLastSyncedAt(this.userId, new Date().toISOString());
     return result;
   }
@@ -132,7 +161,7 @@ export class SyncEngine {
     // If there's no last sync timestamp, fall back to full sync
     if (!since) return this.fullSync();
 
-    const tables: SyncableTable[] = ['contents', 'records', 'sessions', 'favorites', 'favoriteFolders'];
+    const tables: SyncableTable[] = ['contents', 'records', 'sessions', 'favorites', 'favoriteFolders', 'journals'];
 
     for (const table of tables) {
       try {
@@ -212,6 +241,16 @@ export class SyncEngine {
           await db.favoriteFolders.put(mapped);
           upsertCount++;
         }
+      } else if (table === 'journals') {
+        const local = await db.journals.get(remoteRecord.id as string);
+        if (!local || local.updatedAt < remoteUpdatedAt) {
+          const mapped = fromSupabaseJournal(remoteRecord);
+          if (mapped.deletedAt) {
+            await this.cleanupJournalArtifacts(mapped.id);
+          }
+          await db.journals.put(mapped);
+          upsertCount++;
+        }
       }
     }
 
@@ -223,7 +262,9 @@ export class SyncEngine {
   private async pushTable(table: SyncableTable, since?: string): Promise<number> {
     const sinceTs = since ? new Date(since).getTime() : 0;
 
-    let localRecords: Array<ContentItem | LearningRecord | TypingSession | FavoriteItem | FavoriteFolder>;
+    let localRecords: Array<
+      ContentItem | LearningRecord | TypingSession | FavoriteItem | FavoriteFolder | JournalEntry
+    >;
 
     if (table === 'contents') {
       localRecords = since
@@ -241,6 +282,10 @@ export class SyncEngine {
       localRecords = since
         ? await db.favorites.where('updatedAt').above(sinceTs).toArray()
         : await db.favorites.toArray();
+    } else if (table === 'journals') {
+      localRecords = since
+        ? await db.journals.where('updatedAt').above(sinceTs).toArray()
+        : await db.journals.toArray();
     } else {
       localRecords = since
         ? await db.favoriteFolders.where('createdAt').above(sinceTs).toArray()
@@ -255,6 +300,7 @@ export class SyncEngine {
       if (table === 'records') return toSupabaseRecord(record as LearningRecord, this.userId);
       if (table === 'favorites') return toSupabaseFavorite(record as FavoriteItem, this.userId);
       if (table === 'favoriteFolders') return toSupabaseFavoriteFolder(record as FavoriteFolder, this.userId);
+      if (table === 'journals') return toSupabaseJournal(record as JournalEntry, this.userId);
       return toSupabaseSession(record as TypingSession, this.userId);
     });
 
@@ -269,9 +315,47 @@ export class SyncEngine {
       if (error) {
         throw new Error(error.message);
       }
+
+      if (table === 'journals') {
+        const deletedJournalIds = (localRecords as JournalEntry[])
+          .filter((journal) => journal.deletedAt)
+          .map((journal) => journal.id);
+        for (const journalId of deletedJournalIds) {
+          await this.cleanupRemoteJournalArtifacts(journalId);
+        }
+      }
       pushCount += batch.length;
     }
 
     return pushCount;
+  }
+
+  private async cleanupJournalArtifacts(journalId: string): Promise<void> {
+    await db.contents.where('category').equals(`journal:${journalId}`).delete();
+    const favorites = await db.favorites.where('sourceContentId').equals(journalId).toArray();
+    if (favorites.length > 0) {
+      await db.favorites.bulkDelete(favorites.map((favorite) => favorite.id));
+    }
+  }
+
+  private async cleanupRemoteJournalArtifacts(journalId: string): Promise<void> {
+    const { error: contentsError } = await this.supabase
+      .from('contents')
+      .delete()
+      .eq('user_id', this.userId)
+      .eq('category', `journal:${journalId}`);
+    if (contentsError) {
+      throw new Error(contentsError.message);
+    }
+
+    const { error: favoritesError } = await this.supabase
+      .from('favorites')
+      .delete()
+      .eq('user_id', this.userId)
+      .eq('source_module', 'journal')
+      .eq('source_content_id', journalId);
+    if (favoritesError) {
+      throw new Error(favoritesError.message);
+    }
   }
 }

--- a/src/lib/sync/mapper.ts
+++ b/src/lib/sync/mapper.ts
@@ -1,5 +1,6 @@
 import type { ContentItem, LearningRecord, TypingSession } from '@/types/content';
 import type { FavoriteFolder, FavoriteItem } from '@/types/favorite';
+import type { DialogueTurn, JournalEntry } from '@/types/journal';
 
 // ─── Content ────────────────────────────────────────────────────────────────────
 
@@ -181,5 +182,42 @@ export function fromSupabaseFavoriteFolder(row: Record<string, unknown>): Favori
     color: (row.color as string) ?? undefined,
     sortOrder: (row.sort_order as number) ?? 0,
     createdAt: new Date(row.created_at as string).getTime(),
+  };
+}
+
+// ─── Journal ────────────────────────────────────────────────────────────────────
+
+export function toSupabaseJournal(journal: JournalEntry, userId: string): Record<string, unknown> {
+  return {
+    id: journal.id,
+    user_id: userId,
+    title: journal.title,
+    topic: journal.topic ?? null,
+    tags: journal.tags,
+    lesson_date: journal.lessonDate,
+    source: journal.source,
+    turns: journal.turns,
+    notes: journal.notes ?? null,
+    content_ids: journal.contentIds ?? null,
+    deleted_at: journal.deletedAt != null ? new Date(journal.deletedAt).toISOString() : null,
+    created_at: new Date(journal.createdAt).toISOString(),
+    updated_at: new Date(journal.updatedAt).toISOString(),
+  };
+}
+
+export function fromSupabaseJournal(row: Record<string, unknown>): JournalEntry {
+  return {
+    id: row.id as string,
+    title: row.title as string,
+    topic: (row.topic as string) ?? undefined,
+    tags: (row.tags as string[]) ?? [],
+    lessonDate: row.lesson_date as string,
+    source: row.source as JournalEntry['source'],
+    turns: (row.turns as DialogueTurn[]) ?? [],
+    notes: (row.notes as string) ?? undefined,
+    contentIds: (row.content_ids as string[]) ?? undefined,
+    deletedAt: row.deleted_at != null ? new Date(row.deleted_at as string).getTime() : undefined,
+    createdAt: new Date(row.created_at as string).getTime(),
+    updatedAt: new Date(row.updated_at as string).getTime(),
   };
 }

--- a/src/stores/__tests__/journal-store.test.ts
+++ b/src/stores/__tests__/journal-store.test.ts
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// In-memory tables backing the mocked Dexie.
+const journals: any[] = [];
+const contents: any[] = [];
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    journals: {
+      orderBy: vi.fn(() => ({
+        reverse: vi.fn(() => ({
+          toArray: vi.fn(() => Promise.resolve([...journals])),
+        })),
+      })),
+      add: vi.fn((j: any) => {
+        journals.push(j);
+        return Promise.resolve(j.id);
+      }),
+      put: vi.fn((j: any) => {
+        const idx = journals.findIndex((x) => x.id === j.id);
+        if (idx >= 0) journals[idx] = j;
+        else journals.push(j);
+        return Promise.resolve(j.id);
+      }),
+      delete: vi.fn((id: string) => {
+        const idx = journals.findIndex((x) => x.id === id);
+        if (idx >= 0) journals.splice(idx, 1);
+        return Promise.resolve();
+      }),
+    },
+    contents: {
+      where: vi.fn((field: string) => ({
+        equals: vi.fn((value: string) => ({
+          delete: vi.fn(() => {
+            for (let i = contents.length - 1; i >= 0; i--) {
+              if (contents[i][field] === value) contents.splice(i, 1);
+            }
+            return Promise.resolve();
+          }),
+          toArray: vi.fn(() => Promise.resolve(contents.filter((c) => c[field] === value))),
+        })),
+      })),
+      bulkAdd: vi.fn((items: any[]) => {
+        contents.push(...items);
+        return Promise.resolve();
+      }),
+    },
+  },
+}));
+
+// Mock the favorite store so highlight toggling can be asserted in isolation.
+const addFavorite = vi.fn(() => Promise.resolve('fav-1'));
+const removeFavorite = vi.fn(() => Promise.resolve());
+vi.mock('../favorite-store', () => ({
+  useFavoriteStore: { getState: () => ({ addFavorite, removeFavorite }) },
+}));
+
+import { useJournalStore } from '../journal-store';
+
+function resetStore() {
+  journals.length = 0;
+  contents.length = 0;
+  addFavorite.mockClear();
+  removeFavorite.mockClear();
+  useJournalStore.setState({ journals: [], loading: false, loaded: false });
+}
+
+describe('journal-store', () => {
+  beforeEach(resetStore);
+
+  it('creates a journal with defaults', async () => {
+    const id = await useJournalStore.getState().addJournal({ title: 'Self-introduction' });
+    const journal = useJournalStore.getState().getJournalById(id);
+    expect(journal).toBeTruthy();
+    expect(journal?.title).toBe('Self-introduction');
+    expect(journal?.source).toBe('manual');
+    expect(journal?.turns).toEqual([]);
+    expect(journal?.lessonDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('adds, updates, and removes turns', async () => {
+    const id = await useJournalStore.getState().addJournal({ title: 'Lesson' });
+    await useJournalStore.getState().addTurn(id, { speaker: 'Teacher', text: 'Tell me about yourself.' });
+    let journal = useJournalStore.getState().getJournalById(id);
+    expect(journal?.turns).toHaveLength(1);
+    const turnId = journal!.turns[0].id;
+
+    await useJournalStore.getState().updateTurn(id, turnId, { translation: '介绍一下你自己。' });
+    journal = useJournalStore.getState().getJournalById(id);
+    expect(journal?.turns[0].translation).toBe('介绍一下你自己。');
+
+    await useJournalStore.getState().removeTurn(id, turnId);
+    journal = useJournalStore.getState().getJournalById(id);
+    expect(journal?.turns).toHaveLength(0);
+  });
+
+  it('supports a line without any speaker label', async () => {
+    const id = await useJournalStore.getState().addJournal({ title: 'Phrases' });
+    await useJournalStore.getState().addTurn(id, { text: 'Nice to meet you.' });
+    const turn = useJournalStore.getState().getJournalById(id)!.turns[0];
+    expect(turn.speaker).toBeUndefined();
+    expect(turn.text).toBe('Nice to meet you.');
+  });
+
+  it('toggles a highlight in and out of favorites', async () => {
+    const id = await useJournalStore.getState().addJournal({ title: 'Lesson' });
+    await useJournalStore.getState().addTurn(id, { speaker: 'Me', text: 'I specialize in backend systems.' });
+    const turnId = useJournalStore.getState().getJournalById(id)!.turns[0].id;
+
+    await useJournalStore.getState().toggleHighlight(id, turnId);
+    let turn = useJournalStore.getState().getJournalById(id)!.turns[0];
+    expect(addFavorite).toHaveBeenCalledTimes(1);
+    expect(turn.highlighted).toBe(true);
+    expect(turn.favoriteId).toBe('fav-1');
+
+    await useJournalStore.getState().toggleHighlight(id, turnId);
+    turn = useJournalStore.getState().getJournalById(id)!.turns[0];
+    expect(removeFavorite).toHaveBeenCalledWith('fav-1');
+    expect(turn.highlighted).toBe(false);
+    expect(turn.favoriteId).toBeUndefined();
+  });
+
+  it('materializes turns into practice contents under journal:{id}', async () => {
+    const id = await useJournalStore.getState().addJournal({ title: 'Lesson', tags: ['intro'] });
+    await useJournalStore.getState().addTurn(id, { speaker: 'A', text: 'How are you?' });
+    await useJournalStore.getState().addTurn(id, { speaker: 'B', text: 'I am great, thanks.' });
+
+    await useJournalStore.getState().materializeForPractice(id);
+
+    expect(contents).toHaveLength(2);
+    expect(contents.every((c) => c.category === `journal:${id}`)).toBe(true);
+    const journal = useJournalStore.getState().getJournalById(id);
+    expect(journal?.contentIds).toHaveLength(2);
+
+    // Re-materializing rebuilds (no duplicates).
+    await useJournalStore.getState().materializeForPractice(id);
+    expect(contents).toHaveLength(2);
+
+    // Deleting the journal cleans up its materialized contents.
+    await useJournalStore.getState().deleteJournal(id);
+    expect(contents).toHaveLength(0);
+  });
+
+  it('removes linked favorites when a journal is deleted', async () => {
+    const id = await useJournalStore.getState().addJournal({ title: 'Lesson' });
+    await useJournalStore.getState().addTurn(id, { speaker: 'Phrase', text: 'Nice to meet you.' });
+    const turnId = useJournalStore.getState().getJournalById(id)!.turns[0].id;
+    await useJournalStore.getState().toggleHighlight(id, turnId);
+
+    await useJournalStore.getState().deleteJournal(id);
+    expect(removeFavorite).toHaveBeenCalledWith('fav-1');
+    expect(useJournalStore.getState().getJournalById(id)).toBeUndefined();
+    expect(journals.find((journal) => journal.id === id)?.deletedAt).toBeTypeOf('number');
+  });
+});

--- a/src/stores/journal-store.ts
+++ b/src/stores/journal-store.ts
@@ -1,0 +1,214 @@
+import { nanoid } from 'nanoid';
+import { create } from 'zustand';
+import { db } from '@/lib/db';
+import type { ContentItem } from '@/types/content';
+import type { FavoriteType } from '@/types/favorite';
+import type { DialogueTurn, JournalEntry } from '@/types/journal';
+import { useFavoriteStore } from './favorite-store';
+
+/** Dexie `contents.category` value used for a journal's materialized practice items. */
+export function journalContentCategory(journalId: string): string {
+  return `journal:${journalId}`;
+}
+
+/** Local YYYY-MM-DD for "today", used as the default notebook date. */
+function todayDateKey(): string {
+  const now = new Date();
+  const y = now.getFullYear();
+  const m = String(now.getMonth() + 1).padStart(2, '0');
+  const d = String(now.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+/** Rough heuristic to bucket a highlighted turn into a favorite type. */
+function classifyFavoriteType(text: string): FavoriteType {
+  const trimmed = text.trim();
+  const wordCount = trimmed.split(/\s+/).filter(Boolean).length;
+  if (wordCount <= 1) return 'word';
+  if (wordCount >= 6 || /[.!?]$/.test(trimmed)) return 'sentence';
+  return 'phrase';
+}
+
+interface JournalStore {
+  journals: JournalEntry[];
+  loading: boolean;
+  loaded: boolean;
+
+  loadJournals: (force?: boolean) => Promise<void>;
+  getJournalById: (id: string) => JournalEntry | undefined;
+  addJournal: (input: Partial<Omit<JournalEntry, 'id' | 'createdAt' | 'updatedAt'>>) => Promise<string>;
+  updateJournal: (id: string, updates: Partial<JournalEntry>) => Promise<void>;
+  deleteJournal: (id: string) => Promise<void>;
+
+  addTurn: (journalId: string, turn: { speaker?: string; text: string; translation?: string }) => Promise<void>;
+  updateTurn: (journalId: string, turnId: string, updates: Partial<DialogueTurn>) => Promise<void>;
+  removeTurn: (journalId: string, turnId: string) => Promise<void>;
+  toggleHighlight: (journalId: string, turnId: string) => Promise<void>;
+
+  /** Materialize the journal's lines into practice ContentItems (idempotent). */
+  materializeForPractice: (journalId: string) => Promise<void>;
+}
+
+/** Persist a mutated journal to Dexie and patch it into store state. */
+async function persistJournal(set: (fn: (s: JournalStore) => Partial<JournalStore>) => void, journal: JournalEntry) {
+  const next = { ...journal, updatedAt: Date.now() };
+  await db.journals.put(next);
+  set((state) => ({ journals: state.journals.map((j) => (j.id === next.id ? next : j)) }));
+}
+
+async function cleanupJournalArtifacts(journal: JournalEntry | undefined, journalId: string) {
+  if (journal) {
+    const { removeFavorite } = useFavoriteStore.getState();
+    await Promise.all(journal.turns.filter((t) => t.favoriteId).map((t) => removeFavorite(t.favoriteId as string)));
+  } else {
+    const linkedFavorites = await db.favorites.where('sourceContentId').equals(journalId).toArray();
+    const { removeFavorite } = useFavoriteStore.getState();
+    await Promise.all(linkedFavorites.map((favorite) => removeFavorite(favorite.id)));
+  }
+
+  await db.contents.where('category').equals(journalContentCategory(journalId)).delete();
+}
+
+export const useJournalStore = create<JournalStore>((set, get) => ({
+  journals: [],
+  loading: false,
+  loaded: false,
+
+  loadJournals: async (force?: boolean) => {
+    if (!force && get().loaded) return;
+    set({ loading: true });
+    try {
+      const journals = (await db.journals.orderBy('updatedAt').reverse().toArray()).filter(
+        (journal) => !journal.deletedAt,
+      );
+      set({ journals, loaded: true });
+    } finally {
+      set({ loading: false });
+    }
+  },
+
+  getJournalById: (id) => get().journals.find((j) => j.id === id),
+
+  addJournal: async (input) => {
+    const now = Date.now();
+    const journal: JournalEntry = {
+      id: nanoid(),
+      title: input.title?.trim() || 'Untitled notebook',
+      topic: input.topic,
+      tags: input.tags ?? [],
+      lessonDate: input.lessonDate || todayDateKey(),
+      source: input.source ?? 'manual',
+      turns: input.turns ?? [],
+      notes: input.notes,
+      contentIds: input.contentIds,
+      createdAt: now,
+      updatedAt: now,
+    };
+    await db.journals.add(journal);
+    set((state) => ({ journals: [journal, ...state.journals], loaded: true }));
+    return journal.id;
+  },
+
+  updateJournal: async (id, updates) => {
+    const journal = get().journals.find((j) => j.id === id);
+    if (!journal) return;
+    await persistJournal(set, { ...journal, ...updates });
+  },
+
+  deleteJournal: async (id) => {
+    const journal = get().journals.find((j) => j.id === id);
+    await cleanupJournalArtifacts(journal, id);
+    if (journal) {
+      await db.journals.put({ ...journal, deletedAt: Date.now(), turns: [], contentIds: [] });
+    } else {
+      await db.journals.delete(id);
+    }
+    set((state) => ({ journals: state.journals.filter((j) => j.id !== id) }));
+  },
+
+  addTurn: async (journalId, turn) => {
+    const journal = get().journals.find((j) => j.id === journalId);
+    if (!journal) return;
+    const newTurn: DialogueTurn = {
+      id: nanoid(),
+      speaker: turn.speaker?.trim() || undefined,
+      text: turn.text,
+      translation: turn.translation,
+    };
+    await persistJournal(set, { ...journal, turns: [...journal.turns, newTurn] });
+  },
+
+  updateTurn: async (journalId, turnId, updates) => {
+    const journal = get().journals.find((j) => j.id === journalId);
+    if (!journal) return;
+    const turns = journal.turns.map((t) => (t.id === turnId ? { ...t, ...updates } : t));
+    await persistJournal(set, { ...journal, turns });
+  },
+
+  removeTurn: async (journalId, turnId) => {
+    const journal = get().journals.find((j) => j.id === journalId);
+    if (!journal) return;
+    const turn = journal.turns.find((t) => t.id === turnId);
+    if (turn?.favoriteId) {
+      await useFavoriteStore.getState().removeFavorite(turn.favoriteId);
+    }
+    await persistJournal(set, { ...journal, turns: journal.turns.filter((t) => t.id !== turnId) });
+  },
+
+  toggleHighlight: async (journalId, turnId) => {
+    const journal = get().journals.find((j) => j.id === journalId);
+    if (!journal) return;
+    const turn = journal.turns.find((t) => t.id === turnId);
+    if (!turn) return;
+
+    const favoriteStore = useFavoriteStore.getState();
+
+    if (turn.highlighted && turn.favoriteId) {
+      // Un-highlight: drop the favorite.
+      await favoriteStore.removeFavorite(turn.favoriteId);
+      const turns = journal.turns.map((t) =>
+        t.id === turnId ? { ...t, highlighted: false, favoriteId: undefined } : t,
+      );
+      await persistJournal(set, { ...journal, turns });
+      return;
+    }
+
+    // Highlight: push into Favorites so it enters the FSRS review queue.
+    const favoriteId = await favoriteStore.addFavorite({
+      text: turn.text,
+      translation: turn.translation ?? '',
+      type: classifyFavoriteType(turn.text),
+      folderId: 'default',
+      sourceModule: 'journal',
+      sourceContentId: journalId,
+      context: journal.title,
+      targetLang: 'zh-CN',
+    });
+    const turns = journal.turns.map((t) => (t.id === turnId ? { ...t, highlighted: true, favoriteId } : t));
+    await persistJournal(set, { ...journal, turns });
+  },
+
+  materializeForPractice: async (journalId) => {
+    const journal = get().journals.find((j) => j.id === journalId);
+    if (!journal) return;
+    const category = journalContentCategory(journalId);
+    // Rebuild from scratch so edited/removed lines are reflected.
+    await db.contents.where('category').equals(category).delete();
+    const now = Date.now();
+    const items: ContentItem[] = journal.turns
+      .filter((t) => t.text.trim())
+      .map((t) => ({
+        id: nanoid(),
+        title: t.text,
+        text: t.text,
+        type: classifyFavoriteType(t.text),
+        category,
+        tags: journal.tags,
+        source: 'imported' as const,
+        createdAt: now,
+        updatedAt: now,
+      }));
+    if (items.length > 0) await db.contents.bulkAdd(items);
+    await persistJournal(set, { ...journal, contentIds: items.map((i) => i.id) });
+  },
+}));

--- a/src/types/favorite.ts
+++ b/src/types/favorite.ts
@@ -8,7 +8,7 @@ export interface RelatedData {
 }
 
 export type FavoriteType = 'word' | 'phrase' | 'sentence';
-export type FavoriteSourceModule = 'listen' | 'read' | 'write' | 'speak' | 'library' | 'chat';
+export type FavoriteSourceModule = 'listen' | 'read' | 'write' | 'speak' | 'library' | 'chat' | 'journal';
 
 export interface FavoriteItem {
   id: string;

--- a/src/types/journal.ts
+++ b/src/types/journal.ts
@@ -1,0 +1,33 @@
+export type JournalSource = 'manual' | 'uploaded' | 'from-speak' | 'ai-generated';
+
+export interface DialogueTurn {
+  id: string;
+  /** Optional free-form label: A, B, Me, Teacher, Phrase, etc. */
+  speaker?: string;
+  text: string;
+  translation?: string;
+  /** ⭐ Marks a golden sentence / fixed collocation worth reviewing. */
+  highlighted?: boolean;
+  /** Set after the turn has been pushed into Favorites, so we can toggle it back off. */
+  favoriteId?: string;
+}
+
+export interface JournalEntry {
+  id: string;
+  title: string;
+  /** Topic label, e.g. "Self-introduction", "Ordering food", "Useful phrases". */
+  topic?: string;
+  tags: string[];
+  /** Notebook date in YYYY-MM-DD format. */
+  lessonDate: string;
+  source: JournalSource;
+  turns: DialogueTurn[];
+  /** Free-form notes for this notebook. */
+  notes?: string;
+  /** ContentItem ids materialized for whole-group practice (Phase 3). */
+  contentIds?: string[];
+  /** Tombstone timestamp for cross-device delete sync. */
+  deletedAt?: number;
+  createdAt: number;
+  updatedAt: number;
+}

--- a/supabase/migrations/20260617_journals.sql
+++ b/supabase/migrations/20260617_journals.sql
@@ -1,0 +1,32 @@
+-- ============================================
+-- EchoType - Practice Notebook (journals) sync table
+-- ============================================
+
+CREATE TABLE public.journals (
+  id TEXT PRIMARY KEY,
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  title TEXT NOT NULL,
+  topic TEXT,
+  tags TEXT[] DEFAULT '{}',
+  lesson_date TEXT NOT NULL,
+  source TEXT NOT NULL DEFAULT 'manual',
+  turns JSONB NOT NULL DEFAULT '[]',
+  notes TEXT,
+  content_ids TEXT[],
+  deleted_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX idx_journals_user ON public.journals(user_id);
+CREATE INDEX idx_journals_updated ON public.journals(updated_at);
+CREATE INDEX idx_journals_deleted ON public.journals(deleted_at);
+
+ALTER TABLE public.journals ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users own their journals"
+  ON public.journals FOR ALL USING (auth.uid() = user_id);
+
+CREATE TRIGGER update_journals_updated_at
+  BEFORE UPDATE ON public.journals
+  FOR EACH ROW EXECUTE FUNCTION public.update_updated_at();


### PR DESCRIPTION
## What changed

- Adds the `/journal` Practice Notebook flow with list/detail pages, manual creation, import dialog, editable entry rows, highlighting, and whole-notebook practice materialization.
- Broadens journal entries beyond fixed dialogue roles: `speaker` is now optional free text, so entries can be unlabeled phrases, A/B dialogue lines, Speak exports, or any custom label.
- Adds AI structure/OCR endpoints and shared normalization prompts for mixed English-learning material instead of teacher/me-only conversations.
- Adds Speak integration via `SaveToJournalButton`, including iOS native-host visibility and a guard that requires a real user message before saving.
- Wires journals into Dexie and Supabase sync with tombstone deletes, plus a migration for the remote table/RLS.

## Why

The original notebook design assumed every saved item was a strict dialogue turn. Real learning material can be single phrases, unlabeled sentences, A/B scripts, lesson notes, or conversations exported from Speak. This PR makes the notebook model match those actual use cases while keeping Speak -> Save compatible.

## Validation

- `pnpm typecheck`
- `pnpm test src/lib/journal-structure.test.ts src/components/journal/save-to-journal-button.test.tsx src/stores/__tests__/journal-store.test.ts`
- `pnpm exec biome check src/lib/journal-structure.test.ts src/lib/journal-structure.ts src/components/journal/import-dialog.tsx src/components/journal/journal-detail.tsx src/components/journal/journal-list.tsx src/components/journal/turn-row.tsx src/stores/journal-store.ts src/types/journal.ts`
- `pnpm build`

## Browser QA

Verified with `agent-browser` against the local app:

- Created `Useful Phrase Set` from `/journal` via the real `New` dialog.
- Added real entries with no speaker, `A`, `B`, and `Phrase` labels.
- Confirmed `/journal` list shows `Useful Phrase Set 4 entries` and search matches the unlabeled line.
- Opened `/speak`, entered `Ordering Coffee`, sent a user message, confirmed `Save` becomes enabled, saved, and confirmed `/journal` shows `Ordering Coffee 3 entries #speak`.
- Tested Import flow with a browser network mock for `/api/journal/structure`: `Analyze -> editable free-label preview -> Save notebook -> detail page`.
