### PR TITLE
[codex] Fix daily plan completion and read controls

### DIFF
--- a/src/__tests__/daily-plan-store.test.ts
+++ b/src/__tests__/daily-plan-store.test.ts
@@ -173,6 +173,68 @@ describe('daily-plan-store', () => {
       expect(parsed.tasks).toHaveLength(2);
       expect(parsed.dateKey).toBe(todayKey());
     });
+
+    it('keeps completed state when the same content task is regenerated with a new id', () => {
+      useDailyPlanStore.getState().setTasks([
+        {
+          id: 'old-task',
+          type: 'article',
+          title: 'Practice an article',
+          description: 'Digital Communication',
+          module: 'read',
+          contentId: 'article-1',
+          completed: true,
+          skipped: false,
+        },
+      ]);
+
+      useDailyPlanStore.getState().setTasks([
+        {
+          id: 'new-task',
+          type: 'article',
+          title: 'Practice an article',
+          description: 'Digital Communication',
+          module: 'read',
+          contentId: 'article-1',
+          completed: false,
+          skipped: false,
+        },
+      ]);
+
+      expect(useDailyPlanStore.getState().tasks[0]).toMatchObject({ id: 'new-task', completed: true });
+    });
+
+    it('keeps skipped state when the same book task is regenerated with a new id', () => {
+      useDailyPlanStore.getState().setTasks([
+        {
+          id: 'old-task',
+          type: 'speak',
+          title: 'Practice 4 scenario lines',
+          description: 'Office & Meetings',
+          module: 'speak',
+          bookId: 'office-meetings',
+          limit: 4,
+          completed: false,
+          skipped: true,
+        },
+      ]);
+
+      useDailyPlanStore.getState().setTasks([
+        {
+          id: 'new-task',
+          type: 'speak',
+          title: 'Practice 4 scenario lines',
+          description: 'Office & Meetings',
+          module: 'speak',
+          bookId: 'office-meetings',
+          limit: 4,
+          completed: false,
+          skipped: false,
+        },
+      ]);
+
+      expect(useDailyPlanStore.getState().tasks[0]).toMatchObject({ id: 'new-task', skipped: true });
+    });
   });
 
   // ── completeTask ──────────────────────────────────────────────────────────
@@ -275,6 +337,19 @@ describe('daily-plan-store', () => {
       useDailyPlanStore.setState({ streak: 10, lastActiveDate: twoDaysAgoStr });
       useDailyPlanStore.getState().updateStreak();
       expect(useDailyPlanStore.getState().streak).toBe(1);
+    });
+
+    it('keeps stale streak data unchanged until the next activity update', () => {
+      const twoDaysAgo = new Date();
+      twoDaysAgo.setDate(twoDaysAgo.getDate() - 2);
+      const twoDaysAgoStr = `${twoDaysAgo.getFullYear()}-${String(twoDaysAgo.getMonth() + 1).padStart(2, '0')}-${String(
+        twoDaysAgo.getDate(),
+      ).padStart(2, '0')}`;
+
+      useDailyPlanStore.setState({ streak: 10, lastActiveDate: twoDaysAgoStr });
+
+      expect(useDailyPlanStore.getState().streak).toBe(10);
+      expect(useDailyPlanStore.getState().lastActiveDate).toBe(twoDaysAgoStr);
     });
 
     it('is idempotent within the same day', () => {

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -50,6 +50,8 @@ function getNativeHostSearchParam(): string | null {
   return new URLSearchParams(window.location.search).get('nativeHost');
 }
 
+const PRIMARY_APP_ROUTES = ['/dashboard', '/listen', '/speak', '/read', '/write', '/review/today', '/journal'];
+
 export default function AppLayout({ children }: { children: React.ReactNode }) {
   const [seeded, setSeeded] = useState(false);
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
@@ -114,6 +116,18 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
     nextParams.set('nativeHost', 'ios');
     router.replace(`${pathname}?${nextParams.toString()}`);
   }, [isIOSNativeHost, pathname, router]);
+
+  useEffect(() => {
+    const cancelPrefetch = scheduleBackgroundTask(() => {
+      for (const route of PRIMARY_APP_ROUTES) {
+        if (route !== pathname) {
+          router.prefetch(route);
+        }
+      }
+    });
+
+    return cancelPrefetch;
+  }, [pathname, router]);
 
   useEffect(() => {
     document.documentElement.dataset.nativeHost = isIOSNativeHost ? 'ios' : 'web';

--- a/src/app/(app)/read/[id]/page.tsx
+++ b/src/app/(app)/read/[id]/page.tsx
@@ -963,7 +963,7 @@ export default function ReadDetailPage() {
   }
 
   return (
-    <div className="max-w-4xl mx-auto flex flex-col gap-4 pb-6">
+    <div className="max-w-4xl mx-auto flex flex-col gap-4 pb-28">
       {isIOSNativeHost && (
         <Card className={cn(IOS_SECTION_CARD_CLASS, 'shrink-0 overflow-hidden')}>
           <CardContent className="space-y-4 p-5">
@@ -1051,10 +1051,7 @@ export default function ReadDetailPage() {
             </div>
           </div>
           <div
-            className={cn(
-              'min-h-[18rem] max-h-[24rem] overflow-y-auto pr-2 scrollbar-thin scrollbar-thumb-indigo-200 scrollbar-track-transparent md:min-h-[22rem] md:max-h-[30rem]',
-              isIOSNativeHost && `${IOS_LIST_CARD_CLASS} px-4 py-4`,
-            )}
+            className={cn('min-h-[18rem] pr-2 md:min-h-[22rem]', isIOSNativeHost && `${IOS_LIST_CARD_CLASS} px-4 py-4`)}
           >
             {raIsActive ? (
               <ReadAloudContent
@@ -1113,9 +1110,14 @@ export default function ReadDetailPage() {
         </CardContent>
       </Card>
 
-      {raIsActive && (
-        <>
-          {isIOSNativeHost ? (
+      <div
+        className={cn(
+          'sticky bottom-3 z-20 rounded-2xl bg-white/95 shadow-[0_18px_46px_rgba(15,23,42,0.14)] backdrop-blur-xl',
+          isIOSNativeHost ? 'border border-white/80 p-2' : 'border border-slate-200 p-3',
+        )}
+      >
+        {raIsActive &&
+          (isIOSNativeHost ? (
             <IOSReadAloudControls
               label="Read controls"
               accentClassName="text-orange-500"
@@ -1128,21 +1130,78 @@ export default function ReadDetailPage() {
             <ReadAloudInlineControls
               label="Read controls"
               accentClassName="text-orange-500"
+              className="border-0 bg-transparent p-0 shadow-none"
               onPlay={handlePlayTTS}
               onPause={handleReadAloudPause}
               onNext={handleReadAloudNext}
               onPrev={handleReadAloudPrev}
             />
+          ))}
+
+        <div
+          className={cn(
+            'flex flex-col items-center gap-2',
+            raIsActive &&
+              (isIOSNativeHost ? 'mt-3 border-t border-slate-100 pt-3' : 'mt-4 border-t border-slate-100 pt-3'),
           )}
-          <ImmersiveReaderOverlay
-            text={content.text}
-            onPlay={handlePlayTTS}
-            onPause={handleReadAloudPause}
-            onNext={handleReadAloudNext}
-            onPrev={handleReadAloudPrev}
-            onWordClick={handleReadAloudWordClick}
-          />
-        </>
+        >
+          <div className="flex items-center justify-center gap-4">
+            <motion.div
+              animate={isListening ? { scale: [1, 1.08, 1] } : {}}
+              transition={isListening ? { repeat: Infinity, duration: 1.5 } : {}}
+            >
+              <Button
+                onClick={isListening ? stopListening : startListening}
+                disabled={isFallbackTranscribing}
+                aria-label={
+                  isFallbackTranscribing
+                    ? t.a11y.processingSpeech
+                    : isListening
+                      ? t.a11y.stopRecording
+                      : t.a11y.startRecording
+                }
+                className={`h-14 w-14 rounded-full cursor-pointer transition-colors duration-200 md:h-16 md:w-16 ${
+                  isFallbackTranscribing
+                    ? 'bg-amber-500 shadow-lg shadow-amber-200'
+                    : isListening
+                      ? 'bg-red-500 hover:bg-red-600'
+                      : 'bg-green-500 hover:bg-green-600'
+                }`}
+              >
+                {isFallbackTranscribing ? (
+                  <Loader2 className="h-6 w-6 animate-spin md:h-7 md:w-7" />
+                ) : isListening ? (
+                  <MicOff className="h-6 w-6 md:h-7 md:w-7" />
+                ) : (
+                  <Mic className="h-6 w-6 md:h-7 md:w-7" />
+                )}
+              </Button>
+            </motion.div>
+            <Button
+              ref={resetButtonRef}
+              variant="outline"
+              onClick={handleReset}
+              className="border-indigo-200 text-indigo-600 cursor-pointer"
+            >
+              <RotateCcw className="w-4 h-4 mr-2" /> {t.recording.reset}
+            </Button>
+          </div>
+          {speechError && <p className="text-xs text-red-500 text-center max-w-md">{speechError}</p>}
+          {phase === 'processing' && (
+            <p className="text-xs text-amber-600 font-medium">{t.recording.processingSpeech}</p>
+          )}
+        </div>
+      </div>
+
+      {raIsActive && (
+        <ImmersiveReaderOverlay
+          text={content.text}
+          onPlay={handlePlayTTS}
+          onPause={handleReadAloudPause}
+          onNext={handleReadAloudNext}
+          onPrev={handleReadAloudPrev}
+          onWordClick={handleReadAloudWordClick}
+        />
       )}
 
       {ttsError && (
@@ -1150,52 +1209,6 @@ export default function ReadDetailPage() {
           {ttsError}
         </div>
       )}
-
-      <div className="flex flex-col items-center gap-2 py-2 shrink-0">
-        <div className="flex items-center justify-center gap-4">
-          <motion.div
-            animate={isListening ? { scale: [1, 1.08, 1] } : {}}
-            transition={isListening ? { repeat: Infinity, duration: 1.5 } : {}}
-          >
-            <Button
-              onClick={isListening ? stopListening : startListening}
-              disabled={isFallbackTranscribing}
-              aria-label={
-                isFallbackTranscribing
-                  ? t.a11y.processingSpeech
-                  : isListening
-                    ? t.a11y.stopRecording
-                    : t.a11y.startRecording
-              }
-              className={`w-16 h-16 rounded-full cursor-pointer transition-colors duration-200 ${
-                isFallbackTranscribing
-                  ? 'bg-amber-500 shadow-lg shadow-amber-200'
-                  : isListening
-                    ? 'bg-red-500 hover:bg-red-600'
-                    : 'bg-green-500 hover:bg-green-600'
-              }`}
-            >
-              {isFallbackTranscribing ? (
-                <Loader2 className="w-7 h-7 animate-spin" />
-              ) : isListening ? (
-                <MicOff className="w-7 h-7" />
-              ) : (
-                <Mic className="w-7 h-7" />
-              )}
-            </Button>
-          </motion.div>
-          <Button
-            ref={resetButtonRef}
-            variant="outline"
-            onClick={handleReset}
-            className="border-indigo-200 text-indigo-600 cursor-pointer"
-          >
-            <RotateCcw className="w-4 h-4 mr-2" /> {t.recording.reset}
-          </Button>
-        </div>
-        {speechError && <p className="text-xs text-red-500 text-center max-w-md">{speechError}</p>}
-        {phase === 'processing' && <p className="text-xs text-amber-600 font-medium">{t.recording.processingSpeech}</p>}
-      </div>
 
       {phase === 'listening' && liveResults && <LiveReadingFeedback results={liveResults} />}
 

--- a/src/components/dashboard/streak-badge.tsx
+++ b/src/components/dashboard/streak-badge.tsx
@@ -1,25 +1,39 @@
 'use client';
 
 import { Flame } from 'lucide-react';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
+import { shiftLocalDateKey } from '@/lib/date-key';
 import { useI18n } from '@/lib/i18n/use-i18n';
+import { cn } from '@/lib/utils';
 import { useDailyPlanStore } from '@/stores/daily-plan-store';
 
 export function StreakBadge() {
-  const { streak, hydrate } = useDailyPlanStore();
+  const { streak, lastActiveDate, hydrate } = useDailyPlanStore();
   const { interfaceLanguage, messages } = useI18n('common');
 
   useEffect(() => {
     hydrate();
   }, [hydrate]);
 
-  if (streak <= 0) return null;
+  const hasContinuousStreak = useMemo(() => {
+    if (streak <= 0) return false;
+    const today = shiftLocalDateKey(0);
+    const yesterday = shiftLocalDateKey(-1);
+    return lastActiveDate === today || lastActiveDate === yesterday;
+  }, [lastActiveDate, streak]);
 
-  const suffix = streak === 1 ? messages.streak.day : messages.streak.days;
-  const label = interfaceLanguage === 'zh' ? `${streak}${suffix}` : `${streak} ${suffix}`;
+  const displayStreak = hasContinuousStreak ? streak : 0;
+  const suffix = displayStreak === 1 ? messages.streak.day : messages.streak.days;
+  const label = interfaceLanguage === 'zh' ? `${displayStreak}${suffix}` : `${displayStreak} ${suffix}`;
 
   return (
-    <span className="inline-flex items-center gap-1 rounded-full bg-orange-100 px-2.5 py-1 text-sm font-semibold text-orange-700">
+    <span
+      className={cn(
+        'inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-sm font-semibold',
+        hasContinuousStreak ? 'bg-orange-100 text-orange-700' : 'bg-slate-100 text-slate-400',
+      )}
+      title={hasContinuousStreak ? undefined : 'Complete today to start a streak'}
+    >
       <Flame className="h-4 w-4" />
       {label}
     </span>

--- a/src/components/dashboard/today-plan.tsx
+++ b/src/components/dashboard/today-plan.tsx
@@ -10,7 +10,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { generateDailyPlan, getDailyPlanSignature } from '@/lib/daily-plan';
 import { getTaskHref } from '@/lib/daily-plan-links';
-import { syncPlanTasksWithActivity } from '@/lib/daily-plan-progress';
+import { SESSION_ACTIVITY_EVENT, syncPlanTasksWithActivity } from '@/lib/daily-plan-progress';
 import { db } from '@/lib/db';
 import { useI18n } from '@/lib/i18n/use-i18n';
 import { buildDailyPlanGoalExplanation } from '@/lib/learning-goals';
@@ -131,6 +131,7 @@ export function TodayPlan() {
 
   useEffect(() => {
     if (!hydrated) return;
+    void activitySignature;
     void refreshPlan();
   }, [activitySignature, hydrated, refreshPlan]);
 
@@ -179,10 +180,12 @@ export function TodayPlan() {
     };
 
     window.addEventListener('focus', handleFocus);
+    window.addEventListener(SESSION_ACTIVITY_EVENT, handleFocus);
     document.addEventListener('visibilitychange', handleVisibilityChange);
 
     return () => {
       window.removeEventListener('focus', handleFocus);
+      window.removeEventListener(SESSION_ACTIVITY_EVENT, handleFocus);
       document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
   }, [hydrated, refreshPlan]);
@@ -304,10 +307,7 @@ export function TodayPlan() {
             const color = moduleColors[task.module] ?? 'bg-indigo-500';
             const taskHref = getTaskHref(task);
             const latestSession = taskSessions[task.id];
-            const taskTitle =
-              task.type === 'speak'
-                ? task.title.replace(/Practice (\d+) scenarios?/, 'Practice $1 scenario lines')
-                : task.title;
+            const taskTitle = task.type === 'speak' ? task.title.replace(/ lines lines\b/, ' lines') : task.title;
 
             if (task.skipped) return null;
 

--- a/src/components/dashboard/today-plan.tsx
+++ b/src/components/dashboard/today-plan.tsx
@@ -3,6 +3,7 @@
 import { useLiveQuery } from 'dexie-react-hooks';
 import { BookOpen, CheckCircle2, Circle, Headphones, Mic, PenTool, Play, SkipForward } from 'lucide-react';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useState } from 'react';
 import { GoalSettingDialog } from '@/components/dashboard/goal-setting-dialog';
 import { StreakBadge } from '@/components/dashboard/streak-badge';
@@ -78,6 +79,7 @@ export function TodayPlan() {
   const [hydrated, setHydrated] = useState(false);
   const [taskSessions, setTaskSessions] = useState<Record<string, TaskSessionSummary>>({});
   const isIOSNativeHost = detectIOSNativeHost();
+  const router = useRouter();
   const activitySignature = useLiveQuery(async () => {
     const [latestSession, latestRecord] = await Promise.all([
       db.sessions.orderBy('startTime').last(),
@@ -196,6 +198,20 @@ export function TodayPlan() {
       updateStreak();
     }
   }, [completedCount, updateStreak]);
+
+  useEffect(() => {
+    if (!hydrated || tasks.length === 0) return;
+
+    const cancelPrefetch = window.setTimeout(() => {
+      for (const task of tasks) {
+        if (!task.skipped) {
+          router.prefetch(getTaskHref(task));
+        }
+      }
+    }, 0);
+
+    return () => window.clearTimeout(cancelPrefetch);
+  }, [hydrated, router, tasks]);
 
   const todayPlanMessages = messages.todayPlan as typeof messages.todayPlan & {
     reopen?: string;

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -75,7 +75,6 @@ function NavLink({
       const link = (
         <Link
           href={item.href}
-          prefetch={false}
           className={cn(
             'flex items-center gap-2.5 rounded-lg text-sm transition-colors duration-150 cursor-pointer select-none',
             collapsed ? 'justify-center px-2 py-2' : 'px-3 py-2',
@@ -108,7 +107,6 @@ function NavLink({
       const link = (
         <Link
           href={item.href}
-          prefetch={false}
           className={cn(
             'flex items-center justify-center px-2 py-2 rounded-lg text-sm transition-colors duration-150 cursor-pointer select-none',
             active
@@ -169,7 +167,6 @@ function NavLink({
   return (
     <Link
       href={item.href}
-      prefetch={false}
       className={cn(
         'flex items-center gap-2 px-2 py-1.5 rounded-md text-[13px] transition-colors duration-150 cursor-pointer',
         childActive

--- a/src/stores/daily-plan-store.ts
+++ b/src/stores/daily-plan-store.ts
@@ -41,6 +41,10 @@ interface DailyPlanStore extends DailyPlanSettings {
   hydrate: () => void;
 }
 
+export function getPlanTaskCompletionKey(task: Pick<PlanTask, 'module' | 'contentId' | 'bookId' | 'type'>): string {
+  return [task.type, task.module, task.bookId ?? '', task.contentId ?? ''].join(':');
+}
+
 // ─── Persistence ───────────────────────────────────────────────────────────────
 
 const STORAGE_KEY = 'echotype_daily_plan';
@@ -129,8 +133,21 @@ export const useDailyPlanStore = create<DailyPlanStore>((set, get) => ({
     const dateKey = todayKey();
     const nextSignature = dataSignature ?? state.dataSignature;
     const nextLevelKey = levelKey ?? state.levelKey;
-    set({ tasks, dateKey, dataSignature: nextSignature, levelKey: nextLevelKey });
-    saveToStorage(getSettings({ ...state, tasks, dateKey, dataSignature: nextSignature, levelKey: nextLevelKey }));
+    const completedKeys = new Set(
+      state.tasks.filter((task) => task.completed).map((task) => getPlanTaskCompletionKey(task)),
+    );
+    const skippedKeys = new Set(
+      state.tasks.filter((task) => task.skipped).map((task) => getPlanTaskCompletionKey(task)),
+    );
+    const mergedTasks = tasks.map((task) => ({
+      ...task,
+      completed: task.completed || completedKeys.has(getPlanTaskCompletionKey(task)),
+      skipped: task.skipped || skippedKeys.has(getPlanTaskCompletionKey(task)),
+    }));
+    set({ tasks: mergedTasks, dateKey, dataSignature: nextSignature, levelKey: nextLevelKey });
+    saveToStorage(
+      getSettings({ ...state, tasks: mergedTasks, dateKey, dataSignature: nextSignature, levelKey: nextLevelKey }),
+    );
   },
 
   setDateKey: (dateKey) => {


### PR DESCRIPTION
## What changed

- Keeps Today's Plan completion/skipped state stable when the plan regenerates with new task IDs by merging state on a content/book task key.
- Refreshes Today's Plan immediately when practice sessions dispatch `echotype:sessions-updated`, so returning to Dashboard reflects completed practice without relying on focus timing.
- Shows the streak pill in a gray inactive state when there is no continuous streak, and keeps the active orange state only for today/yesterday continuity.
- Fixes duplicated speak plan text such as `Practice 4 scenario lines lines`.
- Reworks the read detail page so long text uses the page scroll and the read/record controls live in a sticky bottom dock.

## Validation

- `pnpm typecheck`
- `pnpm test src/__tests__/daily-plan-store.test.ts src/__tests__/daily-plan-progress.test.ts`
- `pnpm exec biome check 'src/app/(app)/read/[id]/page.tsx' src/components/dashboard/today-plan.tsx src/components/dashboard/streak-badge.tsx src/stores/daily-plan-store.ts src/__tests__/daily-plan-store.test.ts`
- `pnpm build`

## Browser QA

Verified with `agent-browser` against the local app:

- Dashboard streak pill renders as gray `0 days` when there is no continuous streak.
- Dashboard plan text no longer shows `scenario lines lines`.
- Injected a completed read session/record into IndexedDB and dispatched `echotype:sessions-updated`; Dashboard updated to `Last practiced just now`, `Accuracy 100%`, `Open`, and `1/4 completed` without a manual refresh.
- Opened a real read task from Dashboard and confirmed `Read controls`, `Start recording`, and `Reset` remain visible in the viewport while viewing long content.
