### PR TITLE
[codex] Fix wordbook write targets and translations

### DIFF
--- a/src/components/shared/word-book-practice.tsx
+++ b/src/components/shared/word-book-practice.tsx
@@ -51,6 +51,11 @@ import {
 import { IS_IOS_NATIVE_HOST, IS_TAURI, reportNativeQAState } from '@/lib/tauri';
 import { cn } from '@/lib/utils';
 import { resolveWordBookPracticeItems, type WordBookPracticeProgressSnapshot } from '@/lib/wordbook-practice-progress';
+import {
+  isWordBookWriteMatch,
+  normalizeWordBookWriteChar,
+  resolveWordBookWriteTarget,
+} from '@/lib/wordbook-write-target';
 import { getWordBook, loadWordBookItems } from '@/lib/wordbooks';
 import { useLanguageStore } from '@/stores/language-store';
 import { usePracticeTranslationStore } from '@/stores/practice-translation-store';
@@ -349,6 +354,7 @@ function WritePractice({
   const [result, setResult] = useState<'correct' | 'wrong' | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const startedAtRef = useRef<number>(Date.now());
+  const target = resolveWordBookWriteTarget(item);
 
   // Reset when item changes
   useEffect(() => {
@@ -359,9 +365,7 @@ function WritePractice({
   }, [item.id]);
 
   const handleSubmit = () => {
-    const normalized = typedText.trim().toLowerCase();
-    const expected = item.text.trim().toLowerCase();
-    if (normalized === expected) {
+    if (isWordBookWriteMatch(typedText, target.text)) {
       setResult('correct');
       void savePracticeSession(
         {
@@ -370,10 +374,10 @@ function WritePractice({
           module: 'write',
           startTime: startedAtRef.current,
           endTime: Date.now(),
-          totalChars: item.text.length,
-          correctChars: item.text.length,
+          totalChars: target.text.length,
+          correctChars: target.text.length,
           wrongChars: 0,
-          totalWords: item.text.split(/\s+/).filter(Boolean).length,
+          totalWords: target.text.split(/\s+/).filter(Boolean).length,
           wpm: 0,
           accuracy: 100,
           completed: true,
@@ -390,7 +394,7 @@ function WritePractice({
   };
 
   // Character-by-character feedback
-  const expectedChars = item.text.split('');
+  const expectedChars = target.text.split('');
   const typedChars = typedText.split('');
 
   return (
@@ -401,7 +405,7 @@ function WritePractice({
           const isSpace = char === ' ';
           let color = 'text-slate-300';
           if (i < typedChars.length) {
-            if (typedChars[i] === char) {
+            if (normalizeWordBookWriteChar(typedChars[i] ?? '') === normalizeWordBookWriteChar(char)) {
               color = 'text-green-600';
             } else if (isSpace) {
               // Missing/wrong space: highly visible
@@ -1062,21 +1066,10 @@ export function WordBookPractice({ module }: WordBookPracticeProps) {
 
       const savedProgress = loadWordBookProgress(progressKey);
 
-      // First try loading from DB (already imported items)
-      const dbItems = await db.contents.where('category').equals(bookId).toArray();
-      if (dbItems.length > 0) {
-        const practicedIds =
-          limit > 0 ? new Set((await db.records.toArray()).map((record) => record.contentId)) : undefined;
-        const resolved = resolveWordBookPracticeItems({
-          availableItems: dbItems,
-          limit,
-          savedProgress,
-          practicedIds,
-          dayKey: progressDayKey,
-        });
-        setItems(resolved.items);
-      } else if (wb) {
-        // Not imported yet — load directly from wordbook data for practice
+      if (wb) {
+        // Built-in books must come from the complete source data. Practice
+        // sessions also save individual content snapshots into Dexie, but those
+        // snapshots are not the full book and must not shadow the source book.
         const wordItems = await loadWordBookItems(bookId);
         const practiceItems: ContentItem[] = wordItems.map((item, i) => ({
           ...item,
@@ -1088,9 +1081,25 @@ export function WordBookPractice({ module }: WordBookPracticeProps) {
           availableItems: practiceItems,
           limit,
           savedProgress,
+          practicedIds: limit > 0 ? new Set((await db.records.toArray()).map((record) => record.contentId)) : undefined,
           dayKey: progressDayKey,
         });
         setItems(resolved.items);
+      } else {
+        // User-imported books only exist in Dexie.
+        const dbItems = await db.contents.where('category').equals(bookId).toArray();
+        if (dbItems.length > 0) {
+          const practicedIds =
+            limit > 0 ? new Set((await db.records.toArray()).map((record) => record.contentId)) : undefined;
+          const resolved = resolveWordBookPracticeItems({
+            availableItems: dbItems,
+            limit,
+            savedProgress,
+            practicedIds,
+            dayKey: progressDayKey,
+          });
+          setItems(resolved.items);
+        }
       }
       setLoading(false);
     }
@@ -1330,7 +1339,12 @@ export function WordBookPractice({ module }: WordBookPracticeProps) {
                       <Volume2 className="w-5 h-5" />
                     </button>
                   </div>
-                  <WordDictionaryInfo word={currentItem.title} targetLang={targetLang} module={module} />
+                  <WordDictionaryInfo
+                    word={currentItem.title}
+                    targetLang={targetLang}
+                    module={module}
+                    sourceDefinition={currentItem.text}
+                  />
                   <div className="flex items-center justify-center gap-2 flex-wrap">
                     {currentItem.difficulty && (
                       <Badge className={difficultyColors[currentItem.difficulty]} variant="secondary">
@@ -1492,7 +1506,12 @@ export function SingleItemPractice({ item, module, onCompleted }: SingleItemPrac
                 <Volume2 className="w-5 h-5" />
               </button>
             </div>
-            <WordDictionaryInfo word={item.title} targetLang={targetLang} module={module} />
+            <WordDictionaryInfo
+              word={item.title}
+              targetLang={targetLang}
+              module={module}
+              sourceDefinition={item.text}
+            />
             <div className="flex items-center justify-center gap-2 flex-wrap">
               {item.difficulty && (
                 <Badge className={difficultyColors[item.difficulty]} variant="secondary">

--- a/src/components/shared/word-dictionary-info.tsx
+++ b/src/components/shared/word-dictionary-info.tsx
@@ -26,15 +26,28 @@ interface WordDictionaryInfoProps {
   word: string;
   targetLang: string;
   module: PracticeModule;
+  sourceDefinition?: string;
 }
 
-export function WordDictionaryInfo({ word, targetLang, module }: WordDictionaryInfoProps) {
+function meaningContainsTranslation(meanings: { definition: string }[], translation: string): boolean {
+  const normalized = translation.trim();
+  if (!normalized) return true;
+  return meanings.some((meaning) => meaning.definition.includes(normalized));
+}
+
+export function WordDictionaryInfo({ word, targetLang, module, sourceDefinition }: WordDictionaryInfoProps) {
   const showTranslation = usePracticeTranslationStore((s) => s.isVisible(module));
-  const { phonetic, pos, meanings, translation, isLoading } = useWordDictionary(word, targetLang, true);
+  const { phonetic, pos, meanings, translation, example, isLoading } = useWordDictionary(
+    word,
+    targetLang,
+    true,
+    sourceDefinition,
+  );
 
   const hasMeanings = showTranslation && meanings.length > 0;
   const hasPhoneticOrPos = phonetic || pos;
-  const hasFallbackTranslation = showTranslation && !hasMeanings && translation;
+  const hasTranslationSummary =
+    showTranslation && translation && (!hasMeanings || !meaningContainsTranslation(meanings, translation));
 
   if (isLoading) {
     return (
@@ -44,7 +57,7 @@ export function WordDictionaryInfo({ word, targetLang, module }: WordDictionaryI
     );
   }
 
-  if (!hasPhoneticOrPos && !hasMeanings && !hasFallbackTranslation) return null;
+  if (!hasPhoneticOrPos && !hasMeanings && !hasTranslationSummary) return null;
 
   return (
     <div className="space-y-0.5">
@@ -54,6 +67,9 @@ export function WordDictionaryInfo({ word, targetLang, module }: WordDictionaryI
           {phonetic && pos && <span className="text-xs text-slate-300">·</span>}
           {pos && <span className="text-xs text-slate-400">{pos}</span>}
         </div>
+      )}
+      {hasTranslationSummary && (
+        <p className="min-h-[1.25rem] text-[15px] text-indigo-400/80 text-center font-semibold">{translation}</p>
       )}
       {hasMeanings && (
         <div className="space-y-0.5">
@@ -68,9 +84,7 @@ export function WordDictionaryInfo({ word, targetLang, module }: WordDictionaryI
           ))}
         </div>
       )}
-      {hasFallbackTranslation && (
-        <p className="min-h-[1.25rem] text-[15px] text-indigo-400/80 text-center font-medium">{translation}</p>
-      )}
+      {example && <p className="text-sm leading-relaxed text-indigo-500/75 text-center italic">{example}</p>}
     </div>
   );
 }

--- a/src/hooks/__tests__/use-word-dictionary.test.ts
+++ b/src/hooks/__tests__/use-word-dictionary.test.ts
@@ -189,6 +189,7 @@ describe('useWordDictionary', () => {
     expect(hook.current.phonetic).toBe('');
     expect(hook.current.pos).toBe('');
     expect(hook.current.meanings).toEqual([]);
+    expect(hook.current.example).toBe('');
     expect(hook.current.isLoading).toBe(false);
   });
 
@@ -226,7 +227,9 @@ describe('useWordDictionary', () => {
     expect(hook.current.phonetic).toBe('/ˈæp.əl/');
     expect(hook.current.pos).toBe('noun');
     expect(hook.current.translation).toBe('苹果');
-    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(hook.current.example).toBe('');
+    expect(mockFetch).toHaveBeenCalledWith(expect.stringContaining('dictionaryapi.dev'));
+    expect(mockFetch).toHaveBeenCalledWith('/api/translate/free', expect.any(Object));
   });
 
   it('fetches translation only for multi-word phrases', async () => {
@@ -377,6 +380,7 @@ describe('useWordDictionary', () => {
     expect(hook.current.phonetic).toBe('');
     expect(hook.current.pos).toBe('');
     expect(hook.current.meanings).toEqual([]);
+    expect(hook.current.example).toBe('');
   });
 
   it('fetches multiple meanings with batch translation', async () => {
@@ -393,7 +397,10 @@ describe('useWordDictionary', () => {
                 meanings: [
                   {
                     partOfSpeech: 'noun',
-                    definitions: [{ definition: 'A reminder or cue.' }, { definition: 'A time limit.' }],
+                    definitions: [
+                      { definition: 'A reminder or cue.', example: 'The prompt helped her remember the answer.' },
+                      { definition: 'A time limit.' },
+                    ],
                   },
                   {
                     partOfSpeech: 'verb',
@@ -442,8 +449,127 @@ describe('useWordDictionary', () => {
     expect(hook.current.meanings).toHaveLength(3);
     expect(hook.current.meanings[0].pos).toBe('noun');
     expect(hook.current.meanings[0].definition).toContain('提醒或暗示');
+    expect(hook.current.meanings[0].example).toBe('The prompt helped her remember the answer.');
+    expect(hook.current.example).toBe('The prompt helped her remember the answer.');
     expect(hook.current.meanings[1].pos).toBe('verb');
     expect(hook.current.meanings[2].pos).toBe('adjective');
+  });
+
+  it('falls back to a local wordbook English example when dictionary has no example', async () => {
+    mockFetch.mockImplementation((url: string, options?: { body?: string }) => {
+      if (typeof url === 'string' && url.includes('dictionaryapi.dev')) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve([
+              {
+                word: 'suitable',
+                phonetic: '/ˈsuːtəbl/',
+                meanings: [
+                  {
+                    partOfSpeech: 'adjective',
+                    definitions: [{ definition: 'Having enough qualities for a purpose.' }],
+                  },
+                ],
+              },
+            ]),
+        });
+      }
+
+      if (typeof url === 'string' && url.includes('/wordbooks/junior-high.json')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve([{ word: 'suitable', sentence: 'We are hoping to find a suitable school.' }]),
+        });
+      }
+
+      if (typeof url === 'string' && url.startsWith('/wordbooks/')) {
+        return Promise.resolve({
+          ok: false,
+          json: () => Promise.resolve([]),
+        });
+      }
+
+      const body = options?.body ? JSON.parse(options.body) : {};
+      if (body.sentences) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ translations: ['适合某种用途。'] }),
+        });
+      }
+
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ translation: '适合的' }),
+      });
+    });
+
+    const hook = runtime.renderHook(() => useWordDictionary('suitable', 'zh-CN', true));
+
+    await waitFor(() => {
+      expect(hook.current.isLoading).toBe(false);
+    });
+
+    expect(hook.current.example).toBe('We are hoping to find a suitable school.');
+  });
+
+  it('prefers the source wordbook definition over translated dictionary meanings for learned vocabulary', async () => {
+    mockFetch.mockImplementation((url: string, options?: { body?: string }) => {
+      if (typeof url === 'string' && url.includes('dictionaryapi.dev')) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve([
+              {
+                word: 'climate',
+                phonetic: '/ˈklaɪmət/',
+                meanings: [
+                  {
+                    partOfSpeech: 'noun',
+                    definitions: [{ definition: 'An area of the earth between two parallels of latitude.' }],
+                  },
+                  {
+                    partOfSpeech: 'verb',
+                    definitions: [{ definition: 'To dwell.' }],
+                  },
+                ],
+              },
+            ]),
+        });
+      }
+
+      const body = options?.body ? JSON.parse(options.body) : {};
+      if (body.sentences) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              translations: ['两条纬线之间的地球表面区域。', '居住。'],
+            }),
+        });
+      }
+
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ translation: '气候' }),
+      });
+    });
+
+    const hook = runtime.renderHook(() =>
+      useWordDictionary('climate', 'zh-CN', true, 'n. 气候；风气；思潮；风土'),
+    );
+
+    await waitFor(() => {
+      expect(hook.current.isLoading).toBe(false);
+    });
+
+    expect(hook.current.meanings).toEqual([
+      {
+        pos: 'noun',
+        definition: '气候；风气；思潮；风土',
+      },
+    ]);
+    expect(hook.current.translation).toBe('气候');
   });
 
   it('falls back to the word translation when meaning translations are empty', async () => {

--- a/src/hooks/use-word-dictionary.ts
+++ b/src/hooks/use-word-dictionary.ts
@@ -21,6 +21,7 @@ interface DictionaryEntry {
 export interface WordMeaning {
   pos: string;
   definition: string;
+  example?: string;
 }
 
 interface CachedResult {
@@ -28,6 +29,7 @@ interface CachedResult {
   phonetic: string;
   pos: string;
   meanings: WordMeaning[];
+  example: string;
 }
 
 export interface WordDictionaryResult {
@@ -35,6 +37,7 @@ export interface WordDictionaryResult {
   phonetic: string;
   pos: string;
   meanings: WordMeaning[];
+  example: string;
   isLoading: boolean;
 }
 
@@ -54,7 +57,7 @@ function extractPos(entry: DictionaryEntry): string {
 
 interface RawMeaning {
   pos: string;
-  definitions: string[];
+  definitions: Array<{ definition: string; example?: string }>;
 }
 
 function extractRawMeanings(entry: DictionaryEntry): RawMeaning[] {
@@ -63,7 +66,7 @@ function extractRawMeanings(entry: DictionaryEntry): RawMeaning[] {
     .filter((m) => m.partOfSpeech && m.definitions?.length)
     .map((m) => ({
       pos: m.partOfSpeech!,
-      definitions: m.definitions!.slice(0, 2).map((d) => d.definition),
+      definitions: m.definitions!.slice(0, 2).map((d) => ({ definition: d.definition, example: d.example })),
     }));
 }
 
@@ -71,6 +74,58 @@ interface DictionaryResult {
   phonetic: string;
   pos: string;
   rawMeanings: RawMeaning[];
+}
+
+interface RawWordBookEntry {
+  word?: string;
+  sentence?: string;
+}
+
+const SOURCE_POS_MAP: Record<string, string> = {
+  n: 'noun',
+  noun: 'noun',
+  v: 'verb',
+  verb: 'verb',
+  adj: 'adjective',
+  adjective: 'adjective',
+  adv: 'adverb',
+  adverb: 'adverb',
+  prep: 'preposition',
+  preposition: 'preposition',
+  pron: 'pronoun',
+  pronoun: 'pronoun',
+  conj: 'conjunction',
+  conjunction: 'conjunction',
+  interj: 'interjection',
+  interjection: 'interjection',
+};
+
+const EXAMPLE_FALLBACK_BOOK_IDS = [
+  'junior-high',
+  'senior-high',
+  'gaokao2026',
+  'cet4',
+  'cet6',
+  'essential4000',
+  'graduate',
+  'tem4',
+  'ielts',
+  'it-words',
+] as const;
+
+const localExampleCache = new Map<string, Promise<string>>();
+
+function parseSourceDefinition(sourceDefinition: string | undefined, fallbackPos: string): WordMeaning | null {
+  const trimmed = sourceDefinition?.trim();
+  if (!trimmed || !/[\u4e00-\u9fff]/.test(trimmed)) return null;
+
+  const normalized = trimmed.replace(/\s+/g, ' ');
+  const match = normalized.match(/^([A-Za-z]+)\.\s*(.+)$/);
+  const pos = match ? SOURCE_POS_MAP[match[1]!.toLowerCase()] || match[1]! : fallbackPos || 'noun';
+  const definition = (match?.[2] || normalized).trim();
+  if (!definition) return null;
+
+  return { pos, definition };
 }
 
 async function fetchDictionary(word: string): Promise<DictionaryResult> {
@@ -104,6 +159,45 @@ async function fetchTranslation(text: string, targetLang: string): Promise<strin
   }
 }
 
+function isUsefulEnglishExample(word: string, sentence: string): boolean {
+  const normalized = sentence.trim();
+  if (!normalized || /[\u4e00-\u9fff]/.test(normalized)) return false;
+  if (!/[.!?]$/.test(normalized)) return false;
+  if (normalized.split(/\s+/).length < 4) return false;
+  return normalized.toLowerCase().includes(word.trim().toLowerCase());
+}
+
+async function fetchLocalExampleSentence(word: string): Promise<string> {
+  const normalizedWord = word.trim().toLowerCase();
+  if (!normalizedWord || normalizedWord.includes(' ')) return '';
+
+  const cached = localExampleCache.get(normalizedWord);
+  if (cached) return cached;
+
+  const promise = (async () => {
+    for (const bookId of EXAMPLE_FALLBACK_BOOK_IDS) {
+      try {
+        const res = await fetch(`/wordbooks/${bookId}.json`);
+        if (!res.ok) continue;
+        const entries = (await res.json()) as RawWordBookEntry[];
+        const match = entries.find(
+          (entry) =>
+            entry.word?.trim().toLowerCase() === normalizedWord &&
+            entry.sentence &&
+            isUsefulEnglishExample(normalizedWord, entry.sentence),
+        );
+        if (match?.sentence) return match.sentence.trim();
+      } catch {
+        // Try the next local book.
+      }
+    }
+    return '';
+  })();
+
+  localExampleCache.set(normalizedWord, promise);
+  return promise;
+}
+
 async function fetchBatchTranslations(sentences: string[], targetLang: string): Promise<string[]> {
   try {
     const res = await fetch('/api/translate/free', {
@@ -122,40 +216,48 @@ async function fetchBatchTranslations(sentences: string[], targetLang: string): 
 async function translateMeanings(rawMeanings: RawMeaning[], targetLang: string): Promise<WordMeaning[]> {
   if (rawMeanings.length === 0) return [];
 
-  const allDefs = rawMeanings.flatMap((m) => m.definitions);
+  const allDefs = rawMeanings.flatMap((m) => m.definitions.map((d) => d.definition));
   const translations = await fetchBatchTranslations(allDefs, targetLang);
 
   let idx = 0;
   return rawMeanings
     .map((m) => {
       const translatedDefs = m.definitions.map(() => translations[idx++] || '');
+      const example = m.definitions.find((definition) => definition.example)?.example;
       return {
         pos: m.pos,
         definition: translatedDefs.filter(Boolean).join('；'),
+        example,
       };
     })
     .filter((meaning) => meaning.definition.length > 0);
 }
 
-export function useWordDictionary(word: string, targetLang: string, enabled: boolean): WordDictionaryResult {
+export function useWordDictionary(
+  word: string,
+  targetLang: string,
+  enabled: boolean,
+  sourceDefinition?: string,
+): WordDictionaryResult {
   const [result, setResult] = useState<CachedResult>({
     translation: '',
     phonetic: '',
     pos: '',
     meanings: [],
+    example: '',
   });
   const [isLoading, setIsLoading] = useState(false);
   const cacheRef = useRef<Map<string, CachedResult>>(new Map());
 
   useEffect(() => {
     if (!enabled) {
-      setResult({ translation: '', phonetic: '', pos: '', meanings: [] });
+      setResult({ translation: '', phonetic: '', pos: '', meanings: [], example: '' });
       return;
     }
 
     if (!word) return;
 
-    const key = `${word}::${targetLang}`;
+    const key = `${word}::${targetLang}::${sourceDefinition?.trim() || ''}`;
     const cached = cacheRef.current.get(key);
     if (cached) {
       setResult(cached);
@@ -175,6 +277,7 @@ export function useWordDictionary(word: string, targetLang: string, enabled: boo
               },
             ]
           : [],
+        example: '',
       };
       cacheRef.current.set(key, mockEntry);
       setResult(mockEntry);
@@ -190,6 +293,7 @@ export function useWordDictionary(word: string, targetLang: string, enabled: boo
       let pos = '';
       let translation = '';
       let meanings: WordMeaning[] = [];
+      let example = '';
 
       if (isSingleWord(word)) {
         const [dictResult, transResult] = await Promise.all([
@@ -200,8 +304,15 @@ export function useWordDictionary(word: string, targetLang: string, enabled: boo
         pos = dictResult.pos;
         translation = transResult;
 
-        if (dictResult.rawMeanings.length > 0) {
+        const sourceMeaning = parseSourceDefinition(sourceDefinition, dictResult.pos);
+        if (sourceMeaning) {
+          meanings = [sourceMeaning];
+        } else if (dictResult.rawMeanings.length > 0) {
           meanings = await translateMeanings(dictResult.rawMeanings, targetLang);
+          example = meanings.find((meaning) => meaning.example)?.example || '';
+        }
+        if (!example) {
+          example = await fetchLocalExampleSentence(word);
         }
       } else {
         translation = await fetchTranslation(word, targetLang);
@@ -209,7 +320,7 @@ export function useWordDictionary(word: string, targetLang: string, enabled: boo
 
       if (cancelled) return;
 
-      const entry = { translation, phonetic, pos, meanings };
+      const entry = { translation, phonetic, pos, meanings, example };
       cacheRef.current.set(key, entry);
       setResult(entry);
       setIsLoading(false);
@@ -220,7 +331,7 @@ export function useWordDictionary(word: string, targetLang: string, enabled: boo
     return () => {
       cancelled = true;
     };
-  }, [enabled, word, targetLang]);
+  }, [enabled, word, targetLang, sourceDefinition]);
 
   return { ...result, isLoading };
 }

--- a/src/lib/wordbook-write-target.test.ts
+++ b/src/lib/wordbook-write-target.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import type { ContentItem } from '@/types/content';
+import { isWordBookWriteMatch, resolveWordBookWriteTarget } from './wordbook-write-target';
+
+const baseItem: ContentItem = {
+  id: 'item-1',
+  title: 'turning',
+  text: 'a. 转弯的，旋转的',
+  type: 'word',
+  category: 'pet',
+  tags: ['pet'],
+  source: 'builtin',
+  difficulty: 'beginner',
+  createdAt: 1,
+  updatedAt: 1,
+};
+
+describe('resolveWordBookWriteTarget', () => {
+  it('uses the English word title as the typing target for wordbook vocabulary items', () => {
+    const target = resolveWordBookWriteTarget(baseItem);
+
+    expect(target.text).toBe('turning');
+    expect(target.prompt).toBe('a. 转弯的，旋转的');
+  });
+
+  it('keeps sentence-like items typing the sentence text', () => {
+    const target = resolveWordBookWriteTarget({
+      ...baseItem,
+      title: 'Checking in',
+      text: 'I would like to check in, please.',
+      type: 'sentence',
+    });
+
+    expect(target.text).toBe('I would like to check in, please.');
+    expect(target.prompt).toBe('Checking in');
+  });
+});
+
+describe('isWordBookWriteMatch', () => {
+  it('treats straight and curly apostrophes as the same typing answer', () => {
+    expect(isWordBookWriteMatch("Los Angeles'", "Los Angeles’")).toBe(true);
+    expect(isWordBookWriteMatch('Los Angeles’', "Los Angeles'")).toBe(true);
+    expect(isWordBookWriteMatch('Los Angeles‘', "Los Angeles'")).toBe(true);
+  });
+
+  it('still rejects genuinely different text', () => {
+    expect(isWordBookWriteMatch("Los Angeles'", 'Los Angeles')).toBe(false);
+  });
+});

--- a/src/lib/wordbook-write-target.ts
+++ b/src/lib/wordbook-write-target.ts
@@ -1,0 +1,32 @@
+import type { ContentItem } from '@/types/content';
+
+export interface WordBookWriteTarget {
+  text: string;
+  prompt: string;
+}
+
+export function resolveWordBookWriteTarget(item: ContentItem): WordBookWriteTarget {
+  if (item.type === 'word' && item.title.trim()) {
+    return {
+      text: item.title,
+      prompt: item.text,
+    };
+  }
+
+  return {
+    text: item.text,
+    prompt: item.title,
+  };
+}
+
+export function normalizeWordBookWriteText(text: string): string {
+  return text.replace(/[‘’]/g, "'").replace(/[“”]/g, '"').trim().toLowerCase();
+}
+
+export function normalizeWordBookWriteChar(char: string): string {
+  return normalizeWordBookWriteText(char);
+}
+
+export function isWordBookWriteMatch(actual: string, expected: string): boolean {
+  return normalizeWordBookWriteText(actual) === normalizeWordBookWriteText(expected);
+}


### PR DESCRIPTION
## Summary

Fixes two wordbook Write regressions:

- Vocabulary items now type the English word target instead of the Chinese definition or example sentence.
- Straight and curly quote variants are treated as equivalent in Write matching/highlighting.
- Word cards now surface the direct word translation and can prefer the source wordbook definition, so `climate` shows `气候` instead of only a translated external-dictionary edge meaning.

## Root Cause

Write practice compared raw input against `item.text`, which is the definition/example for vocabulary books. Dictionary rendering also prioritized translated external dictionary meanings over the current wordbook context, so a word like `climate` could show a narrow external meaning while the phrase translation showed `气候`.

## Validation

- `pnpm test src/hooks/__tests__/use-word-dictionary.test.ts src/lib/wordbook-write-target.test.ts src/__tests__/daily-plan-links.test.ts src/__tests__/daily-plan-progress.test.ts src/__tests__/wordbook-practice-progress.test.ts`
- `pnpm lint`
- `pnpm typecheck`
- agent-browser real page check: `/write/book/gaokao2026`, jumped to the real `climate` item from the built-in wordbook, verified the page shows `气候`, typed `climate`, clicked Check, and confirmed it advanced to the next item.
- agent-browser real page check: `/write/book/office-meeting`, jumped to the real `Table discussion` sentence with `next week's meeting`, typed the full sentence, clicked Check, and confirmed it advanced to the next item.
