### PR TITLE
[codex] Polish settings and practice UI

### DIFF
--- a/e2e/listen.spec.ts
+++ b/e2e/listen.spec.ts
@@ -190,7 +190,7 @@ test.describe('Listen Module', () => {
   test('listen list page loads with content', async ({ page }) => {
     await waitForSeedAndReload(page, '/listen');
     await expect(page.getByRole('heading', { level: 1 })).toContainText('Listen');
-    await expect(page.getByText('Listen to English content with text-to-speech')).toBeVisible();
+    await expect(page.getByRole('main').getByText('Listen to English content with text-to-speech').first()).toBeVisible();
 
     // Should have content items (word book cards on default tab)
     const items = page.locator('[class*="grid gap"] a');
@@ -238,23 +238,21 @@ test.describe('Listen Module', () => {
     expect(count).toBeGreaterThan(0);
   });
 
-  test('listen detail shows Kokoro estimated sentence highlighting mode when Kokoro is selected', async ({ page }) => {
+  test('listen detail shows selected Edge TTS voice', async ({ page }) => {
     await page.addInitScript(() => {
       window.localStorage.setItem(
         'echotype_tts_settings',
         JSON.stringify({
-          voiceSource: 'kokoro',
-          kokoroServerUrl: 'http://example.invalid:8880',
-          kokoroVoiceId: 'af_heart',
-          kokoroVoiceName: 'Heart',
+          voiceSource: 'edge',
+          edgeVoiceId: 'en-US-JennyNeural',
+          edgeVoiceName: 'Jenny',
         }),
       );
     });
 
     await navigateToContentDetail(page, 'listen');
 
-    await expect(page.getByText('Kokoro playback is active on this page.')).toBeVisible();
-    await expect(page.getByText('Mode: Kokoro audio with estimated sentence highlighting')).toBeVisible();
+    await expect(page.getByText('Jenny')).toBeVisible();
   });
 
   test('listen detail back button returns to list', async ({ page }) => {
@@ -292,6 +290,7 @@ test.describe('Listen Module', () => {
     await expect(page.getByText('Listen Mode')).toBeVisible({ timeout: 15000 });
 
     await navigateToBookItem(page, 'action');
+    await expect(page.getByTestId('read-aloud-inline-controls')).toHaveCount(0);
 
     await selectTextInParagraph(page, 'action');
 
@@ -307,7 +306,20 @@ test.describe('Listen Module', () => {
     await popup.getByRole('button', { name: '♡ 收藏' }).click();
     await expect(popup.getByRole('button', { name: '取消收藏' })).toBeVisible();
 
-    await popup.getByLabel('选择收藏夹').selectOption('auto');
+    await popup.getByRole('button', { name: '选择收藏夹' }).click();
+    await expect(popup.getByRole('button', { name: '智能收藏' })).toBeVisible();
+    await popup.getByText('行动', { exact: true }).first().click();
+    await expect(popup.getByRole('button', { name: '智能收藏' })).toHaveCount(0);
+
+    await popup.getByRole('button', { name: '选择收藏夹' }).click();
+    await popup.getByRole('button', { name: '智能收藏' }).click();
+    await expect(popup.getByRole('button', { name: '移动到此收藏夹' })).toBeVisible();
+    await popup.getByRole('button', { name: '移动到此收藏夹' }).click();
+    await expect(popup.getByRole('button', { name: '取消收藏' })).toBeVisible();
+
+    await popup.getByRole('button', { name: '新建收藏夹' }).click();
+    await popup.getByLabel('新收藏夹名称').fill('考试收藏');
+    await popup.getByRole('button', { name: '创建' }).click();
     await expect(popup.getByRole('button', { name: '移动到此收藏夹' })).toBeVisible();
     await popup.getByRole('button', { name: '移动到此收藏夹' }).click();
     await expect(popup.getByRole('button', { name: '取消收藏' })).toBeVisible();
@@ -322,7 +334,7 @@ test.describe('Listen Module', () => {
 
     await page.goto('/favorites');
     await expect(page.getByRole('heading', { level: 1, name: 'Favorites' })).toBeVisible();
-    await page.getByRole('button', { name: '🤖 智能收藏' }).click();
+    await page.getByRole('button', { name: '考试收藏' }).click();
     await expect(page.getByText('action', { exact: true })).toBeVisible();
     await expect(page.getByText('行动', { exact: true })).toBeVisible();
   });

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -1625,6 +1625,23 @@ function SettingsContent() {
     setRecommendationsEnabled,
     setRecommendationsCount,
   } = useTTSStore();
+  const speedMarks = [
+    { value: 0.5, label: voiceMessages.speedSlow, ariaValue: '0.5x' },
+    { value: 1, label: voiceMessages.speedNormal, ariaValue: '1.0x' },
+    { value: 1.5, label: '1.5x', ariaValue: '1.5x' },
+    { value: 2, label: voiceMessages.speedFast, ariaValue: '2.0x' },
+  ] as const;
+  const pitchMarks = [
+    { value: 0.5, label: voiceMessages.pitchLow, ariaValue: '0.5' },
+    { value: 1, label: voiceMessages.pitchNormal, ariaValue: '1.0' },
+    { value: 1.5, label: '1.5', ariaValue: '1.5' },
+    { value: 2, label: voiceMessages.pitchHigh, ariaValue: '2.0' },
+  ] as const;
+  const volumeMarks = [
+    { value: 0, label: '0%', ariaValue: '0%' },
+    { value: 0.5, label: '50%', ariaValue: '50%' },
+    { value: 1, label: '100%', ariaValue: '100%' },
+  ] as const;
   const shadowReadingEnabled = useShadowReadingStore((s) => s.enabled);
   const setShadowReadingEnabled = useShadowReadingStore((s) => s.setEnabled);
   const practiceTranslationVisibility = usePracticeTranslationStore((s) => s.visibility);
@@ -1690,6 +1707,80 @@ function SettingsContent() {
     const handle = window.setTimeout(() => setShowVoicePicker(true), 300);
     return () => window.clearTimeout(handle);
   }, []);
+
+  const renderMarkedSlider = (
+    marks: readonly { value: number; label: string; ariaValue: string }[],
+    currentValue: number,
+    min: number,
+    max: number,
+    onSelect: (value: number) => void,
+    label: string,
+  ) => (
+    <div className="relative pb-7">
+      <Slider
+        value={[currentValue]}
+        onValueChange={(v) => onSelect(v[0])}
+        min={min}
+        max={max}
+        step={0.1}
+        className="relative z-10 [&_[data-slot=slider-range]]:bg-indigo-500 [&_[data-slot=slider-thumb]]:size-5 [&_[data-slot=slider-thumb]]:border-2 [&_[data-slot=slider-thumb]]:border-white [&_[data-slot=slider-thumb]]:bg-indigo-600 [&_[data-slot=slider-thumb]]:shadow-md [&_[data-slot=slider-track]]:h-2 [&_[data-slot=slider-track]]:bg-slate-200"
+      />
+      {marks.map((mark) => {
+        const position = ((mark.value - min) / (max - min)) * 100;
+        const selected = Math.abs(currentValue - mark.value) < 0.05;
+
+        return (
+          <button
+            key={`dot-${mark.value}`}
+            type="button"
+            aria-label={`Set ${label} ${mark.ariaValue}`}
+            className={cn(
+              'absolute top-[3px] z-20 flex size-7 -translate-x-1/2 -translate-y-1/2 cursor-pointer touch-manipulation items-center justify-center rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-200',
+              selected && 'pointer-events-none',
+            )}
+            style={{ left: `${position}%` }}
+            onClick={() => onSelect(mark.value)}
+          >
+            <span
+              className={cn(
+                'h-2.5 w-2.5 rounded-full border-2 border-indigo-200 bg-white shadow-sm transition-colors hover:border-indigo-400',
+                selected && 'opacity-0',
+              )}
+            />
+          </button>
+        );
+      })}
+      <div className="absolute inset-x-0 top-6 h-5 text-[10px] text-slate-400">
+        {marks.map((mark) => {
+          const position = ((mark.value - min) / (max - min)) * 100;
+          const selected = Math.abs(currentValue - mark.value) < 0.05;
+          const isStart = Math.abs(mark.value - min) < 0.001;
+          const isEnd = Math.abs(mark.value - max) < 0.001;
+
+          return (
+            <button
+              key={`label-${mark.value}`}
+              type="button"
+              aria-label={`Set ${label} ${mark.ariaValue}`}
+              className={cn(
+                'absolute top-0 w-20 cursor-pointer touch-manipulation rounded-sm leading-none text-slate-400 transition-colors hover:text-indigo-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-200',
+                isStart
+                  ? 'translate-x-0 text-left'
+                  : isEnd
+                    ? '-translate-x-full text-right'
+                    : '-translate-x-1/2 text-center',
+                selected && 'font-semibold text-indigo-600',
+              )}
+              style={{ left: `${position}%` }}
+              onClick={() => onSelect(mark.value)}
+            >
+              {mark.label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
 
   // Handle OAuth callback redirect
   useEffect(() => {
@@ -2179,31 +2270,21 @@ function SettingsContent() {
               <p className="text-sm font-medium text-slate-700">{voiceMessages.speed}</p>
               <span className="text-xs font-mono text-slate-500">{speed.toFixed(1)}x</span>
             </div>
-            <Slider value={[speed]} onValueChange={(v) => setSpeed(v[0])} min={0.5} max={2.0} step={0.1} />
-            <div className="flex justify-between text-[10px] text-slate-400 mt-1">
-              <span>{voiceMessages.speedSlow}</span>
-              <span>{voiceMessages.speedNormal}</span>
-              <span>{voiceMessages.speedFast}</span>
-            </div>
+            {renderMarkedSlider(speedMarks, speed, 0.5, 2, setSpeed, 'speed')}
           </div>
           <div>
             <div className="flex items-center justify-between mb-2">
               <p className="text-sm font-medium text-slate-700">{voiceMessages.pitch}</p>
               <span className="text-xs font-mono text-slate-500">{pitch.toFixed(1)}</span>
             </div>
-            <Slider value={[pitch]} onValueChange={(v) => setPitch(v[0])} min={0.5} max={2.0} step={0.1} />
-            <div className="flex justify-between text-[10px] text-slate-400 mt-1">
-              <span>{voiceMessages.pitchLow}</span>
-              <span>{voiceMessages.pitchNormal}</span>
-              <span>{voiceMessages.pitchHigh}</span>
-            </div>
+            {renderMarkedSlider(pitchMarks, pitch, 0.5, 2, setPitch, 'pitch')}
           </div>
           <div>
             <div className="flex items-center justify-between mb-2">
               <p className="text-sm font-medium text-slate-700">{voiceMessages.volume}</p>
               <span className="text-xs font-mono text-slate-500">{Math.round(volume * 100)}%</span>
             </div>
-            <Slider value={[volume]} onValueChange={(v) => setVolume(v[0])} min={0} max={1} step={0.1} />
+            {renderMarkedSlider(volumeMarks, volume, 0, 1, setVolume, 'volume')}
           </div>
 
           {(voiceSource === 'fish' || voiceSource === 'google' || voiceSource === 'openai') && (

--- a/src/components/read-aloud/read-aloud-inline-controls.tsx
+++ b/src/components/read-aloud/read-aloud-inline-controls.tsx
@@ -23,6 +23,7 @@ interface ReadAloudInlineControlsProps {
   onNext: () => void;
   onRestart?: () => void;
   showImmersive?: boolean;
+  showProgress?: boolean;
 }
 
 export function ReadAloudInlineControls({
@@ -36,6 +37,7 @@ export function ReadAloudInlineControls({
   onNext,
   onRestart,
   showImmersive = true,
+  showProgress = true,
 }: ReadAloudInlineControlsProps) {
   const raT = PRACTICE_UI_LOCALES[useLanguageStore((s) => s.interfaceLanguage)].readAloud;
   const isPlaying = useReadAloudStore((s) => s.isPlaying);
@@ -45,7 +47,10 @@ export function ReadAloudInlineControls({
   const currentWordIndex = useReadAloudStore((s) => s.currentWordIndex);
   const { speed, setSpeed } = useTTSStore();
 
-  const progress = words.length > 0 && currentWordIndex >= 0 ? ((currentWordIndex + 1) / words.length) * 100 : 0;
+  const progress =
+    words.length > 0 && currentWordIndex >= 0
+      ? Math.min(100, Math.max(0, ((currentWordIndex + 1) / words.length) * 100))
+      : 0;
 
   return (
     <div
@@ -55,25 +60,29 @@ export function ReadAloudInlineControls({
       <div className="flex flex-wrap items-start justify-between gap-2">
         <div>
           <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">{label}</p>
-          <p className="mt-1 text-sm text-slate-500">
-            {Math.round(progress)}% {raT.progress.toLowerCase()}
-          </p>
+          {showProgress ? (
+            <p className="mt-1 text-sm text-slate-500">
+              {Math.round(progress)}% {raT.progress.toLowerCase()}
+            </p>
+          ) : null}
         </div>
         <div className="rounded-full bg-white px-3 py-1.5 text-sm font-semibold text-slate-700 shadow-sm tabular-nums">
           {speed}x
         </div>
       </div>
 
-      <div className="mt-2 h-2 overflow-hidden rounded-full bg-white">
-        <div
-          className={cn(
-            'h-full rounded-full bg-[linear-gradient(90deg,rgba(79,70,229,0.96)_0%,rgba(129,140,248,0.92)_100%)] transition-all duration-300',
-            accentClassName.includes('orange') &&
-              'bg-[linear-gradient(90deg,rgba(249,115,22,0.94)_0%,rgba(251,146,60,0.9)_100%)]',
-          )}
-          style={{ width: `${Math.max(progress, 4)}%` }}
-        />
-      </div>
+      {showProgress ? (
+        <div className="mt-2 h-2 overflow-hidden rounded-full bg-white">
+          <div
+            className={cn(
+              'h-full rounded-full bg-[linear-gradient(90deg,rgba(79,70,229,0.96)_0%,rgba(129,140,248,0.92)_100%)] transition-all duration-300',
+              accentClassName.includes('orange') &&
+                'bg-[linear-gradient(90deg,rgba(249,115,22,0.94)_0%,rgba(251,146,60,0.9)_100%)]',
+            )}
+            style={{ width: `${Math.max(progress, 4)}%` }}
+          />
+        </div>
+      ) : null}
 
       <div className="mt-3 flex flex-wrap items-center justify-center gap-2">
         <Button type="button" variant="outline" size="icon" onClick={onPrev} aria-label={raT.previousSentence}>

--- a/src/components/selection-translation/selection-translation-popup.tsx
+++ b/src/components/selection-translation/selection-translation-popup.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { Check, Copy, Mic, MicOff, Volume2, X } from 'lucide-react';
-import { forwardRef, useCallback, useEffect, useMemo, useState } from 'react';
+import { Check, ChevronDown, Copy, Mic, MicOff, Plus, Volume2, X } from 'lucide-react';
+import { forwardRef, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 import { useTTS } from '@/hooks/use-tts';
 import { getFavoriteSelectionAction } from '@/lib/favorite-selection-action';
 import { IS_IOS_NATIVE_HOST, IS_TAURI } from '@/lib/tauri';
@@ -52,10 +53,16 @@ export const SelectionTranslationPopup = forwardRef<HTMLDivElement, Props>(
     const [isRecording, setIsRecording] = useState(false);
     const [spokenText, setSpokenText] = useState<string | null>(null);
     const [favoriteError, setFavoriteError] = useState<string | null>(null);
+    const [isCreatingFolder, setIsCreatingFolder] = useState(false);
+    const [isFolderMenuOpen, setIsFolderMenuOpen] = useState(false);
+    const [newFolderName, setNewFolderName] = useState('');
+    const [isSavingFolder, setIsSavingFolder] = useState(false);
+    const favoriteFooterRef = useRef<HTMLDivElement>(null);
     const favorites = useFavoriteStore((s) => s.favorites);
     const addFavorite = useFavoriteStore((s) => s.addFavorite);
     const removeFavorite = useFavoriteStore((s) => s.removeFavorite);
     const updateFavorite = useFavoriteStore((s) => s.updateFavorite);
+    const addFolder = useFavoriteStore((s) => s.addFolder);
     const loadFavorites = useFavoriteStore((s) => s.loadFavorites);
     const isFavoritesLoaded = useFavoriteStore((s) => s.isLoaded);
     const folders = useFavoriteStore((s) => s.folders);
@@ -79,6 +86,9 @@ export const SelectionTranslationPopup = forwardRef<HTMLDivElement, Props>(
       setFavoriteError(null);
       setCopied(false);
       setSpokenText(null);
+      setIsCreatingFolder(false);
+      setIsFolderMenuOpen(false);
+      setNewFolderName('');
       setSelectedFolderId(activeFolderId || 'default');
     }, [activeFolderId, selection.selectionId]);
 
@@ -96,6 +106,17 @@ export const SelectionTranslationPopup = forwardRef<HTMLDivElement, Props>(
         setSelectedFolderId(preferredFolderId);
       }
     }, [activeFolderId, folders, selectedFolderId]);
+
+    useEffect(() => {
+      if (!isFolderMenuOpen) return;
+      const handlePointerDown = (event: PointerEvent) => {
+        if (!favoriteFooterRef.current?.contains(event.target as Node)) {
+          setIsFolderMenuOpen(false);
+        }
+      };
+      document.addEventListener('pointerdown', handlePointerDown);
+      return () => document.removeEventListener('pointerdown', handlePointerDown);
+    }, [isFolderMenuOpen]);
 
     const position = useMemo(() => {
       const { rect } = selection;
@@ -183,6 +204,7 @@ export const SelectionTranslationPopup = forwardRef<HTMLDivElement, Props>(
     const handleFavorite = useCallback(
       async (e: React.MouseEvent) => {
         e.stopPropagation();
+        setIsFolderMenuOpen(false);
         setFavoriteError(null);
         if (favoriteAction === 'remove' && existingFavorite) {
           try {
@@ -232,6 +254,30 @@ export const SelectionTranslationPopup = forwardRef<HTMLDivElement, Props>(
       ],
     );
 
+    const handleCreateFolder = useCallback(
+      async (e: React.FormEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
+        const name = newFolderName.trim();
+        if (!name) return;
+        setIsSavingFolder(true);
+        setFavoriteError(null);
+        try {
+          const maxOrder = Math.max(0, ...folders.map((f) => f.sortOrder));
+          const id = await addFolder({ name, emoji: '', sortOrder: maxOrder + 1 });
+          setSelectedFolderId(id);
+          setIsFolderMenuOpen(false);
+          setNewFolderName('');
+          setIsCreatingFolder(false);
+        } catch (err) {
+          setFavoriteError(err instanceof Error ? err.message : 'Failed to create folder');
+        } finally {
+          setIsSavingFolder(false);
+        }
+      },
+      [addFolder, folders, newFolderName],
+    );
+
     const handleDismiss = useCallback(
       (e: React.MouseEvent) => {
         e.stopPropagation();
@@ -249,6 +295,8 @@ export const SelectionTranslationPopup = forwardRef<HTMLDivElement, Props>(
     const badge = typeBadge[selection.type];
     const itemTranslation = result?.itemTranslation || result?.translation;
     const exampleSentence = result?.exampleSentence;
+    const folderOptions = folders.length === 0 ? [{ id: 'default', name: '默认收藏' }] : folders;
+    const selectedFolderName = folderOptions.find((folder) => folder.id === selectedFolderId)?.name ?? '默认收藏';
 
     return createPortal(
       <div
@@ -341,29 +389,49 @@ export const SelectionTranslationPopup = forwardRef<HTMLDivElement, Props>(
 
           {/* Footer */}
           {result?.translation && (
-            <div className="border-t border-slate-100 bg-slate-50/30 px-3 py-2">
+            <div ref={favoriteFooterRef} className="border-t border-slate-100 bg-slate-50/30 px-3 py-2">
               <div className="flex items-end gap-2">
-                <label className="min-w-0 flex-1 text-[10px] font-medium text-slate-500">
-                  收藏到
-                  <select
-                    aria-label="选择收藏夹"
-                    value={selectedFolderId}
-                    onChange={(e) => setSelectedFolderId(e.target.value)}
-                    className="mt-1 h-8 w-full rounded-md border border-slate-200 bg-white px-2 text-xs text-slate-700"
-                  >
-                    {folders.length === 0 ? <option value="default">⭐ 默认收藏</option> : null}
-                    {folders.map((f) => (
-                      <option key={f.id} value={f.id}>
-                        {f.emoji} {f.name}
-                      </option>
-                    ))}
-                  </select>
-                </label>
+                <div className="min-w-0 flex-1">
+                  <label htmlFor="selection-favorite-folder" className="text-[10px] font-medium text-slate-500">
+                    收藏到
+                  </label>
+                  <div className="relative mt-1">
+                    <button
+                      id="selection-favorite-folder"
+                      type="button"
+                      aria-label="选择收藏夹"
+                      aria-haspopup="true"
+                      aria-expanded={isFolderMenuOpen}
+                      aria-controls="selection-favorite-folder-list"
+                      className="flex h-9 w-full items-center justify-between rounded-md border border-slate-200 bg-white px-3 text-left text-xs font-medium text-slate-800 shadow-sm transition hover:border-indigo-200 hover:bg-indigo-50/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-200"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setIsFolderMenuOpen((value) => !value);
+                      }}
+                    >
+                      <span className="truncate">{selectedFolderName}</span>
+                      <ChevronDown className="h-3.5 w-3.5 text-slate-400" />
+                    </button>
+                  </div>
+                </div>
+                <Button
+                  variant="outline"
+                  size="icon"
+                  className="h-9 w-9 shrink-0 border-slate-200 bg-white"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setIsFolderMenuOpen(false);
+                    setIsCreatingFolder((value) => !value);
+                  }}
+                  aria-label="新建收藏夹"
+                >
+                  <Plus className="h-4 w-4" />
+                </Button>
                 <Button
                   variant={favoriteAction === 'remove' ? 'default' : 'outline'}
                   size="sm"
                   className={cn(
-                    'h-8 shrink-0 text-xs',
+                    'h-9 shrink-0 text-xs',
                     favoriteAction === 'remove' && 'bg-green-500 hover:bg-green-600',
                   )}
                   onClick={handleFavorite}
@@ -371,6 +439,55 @@ export const SelectionTranslationPopup = forwardRef<HTMLDivElement, Props>(
                   {favoriteAction === 'remove' ? '取消收藏' : favoriteAction === 'move' ? '移动到此收藏夹' : '♡ 收藏'}
                 </Button>
               </div>
+              {isFolderMenuOpen && (
+                <div
+                  id="selection-favorite-folder-list"
+                  role="group"
+                  aria-label="收藏夹"
+                  className="mt-2 max-h-36 overflow-y-auto rounded-lg border border-slate-200 bg-white p-1 shadow-lg"
+                >
+                  {folderOptions.map((folder) => (
+                    <button
+                      key={folder.id}
+                      type="button"
+                      aria-pressed={folder.id === selectedFolderId}
+                      className={cn(
+                        'flex h-8 w-full items-center justify-between rounded-md px-2 text-left text-xs text-slate-700 transition hover:bg-indigo-50',
+                        folder.id === selectedFolderId && 'bg-indigo-50 font-semibold text-indigo-700',
+                      )}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setSelectedFolderId(folder.id);
+                        setIsFolderMenuOpen(false);
+                      }}
+                    >
+                      <span className="truncate">{folder.name}</span>
+                      {folder.id === selectedFolderId && <Check className="h-3.5 w-3.5" />}
+                    </button>
+                  ))}
+                </div>
+              )}
+              {isCreatingFolder && (
+                <form className="mt-2 flex gap-2" onSubmit={handleCreateFolder}>
+                  <Input
+                    aria-label="新收藏夹名称"
+                    value={newFolderName}
+                    onChange={(e) => setNewFolderName(e.target.value)}
+                    onClick={(e) => e.stopPropagation()}
+                    placeholder="新收藏夹名称"
+                    className="h-8 bg-white text-xs"
+                    autoFocus
+                  />
+                  <Button
+                    type="submit"
+                    size="sm"
+                    className="h-8 shrink-0 text-xs"
+                    disabled={isSavingFolder || !newFolderName.trim()}
+                  >
+                    创建
+                  </Button>
+                </form>
+              )}
               {favoriteError && <p className="mt-1 text-[11px] leading-4 text-red-500">{favoriteError}</p>}
             </div>
           )}

--- a/src/components/shared/word-book-practice.tsx
+++ b/src/components/shared/word-book-practice.tsx
@@ -323,6 +323,16 @@ function WordBookPlaybackControls({
     onNext();
   }, [handlePause, onNext]);
 
+  if (module === 'listen') {
+    return boundaryPlaybackNotice ? (
+      <div className="pt-2">
+        <div className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+          {boundaryPlaybackNotice}
+        </div>
+      </div>
+    ) : null;
+  }
+
   return (
     <div className="space-y-3 pt-2">
       {boundaryPlaybackNotice && (
@@ -331,12 +341,13 @@ function WordBookPlaybackControls({
         </div>
       )}
       <ReadAloudInlineControls
-        label={module === 'listen' ? 'Listen controls' : 'Read aloud controls'}
+        label="Read aloud controls"
         onPlay={handlePlay}
         onPause={handlePause}
         onPrev={handlePrev}
         onNext={handleNext}
         showImmersive={false}
+        showProgress={false}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- redesign the settings voice speed, pitch, and volume sliders with clickable inline marks and cleaner indigo styling
- allow creating and choosing favorite folders directly from the selection translation popup, with outside-click dismissal
- remove redundant listen-mode read-aloud controls from word book practice and hide progress where it is not useful

## Why
The settings sliders had inaccurate mark placement and then became visually noisy because mark dots overlapped the slider thumb. The favorite popup also forced users to leave the current flow to create folders, and word book listen mode showed extra controls that duplicated nearby playback actions.

## Validation
- `pnpm lint`
- `pnpm typecheck`
- Playwright smoke script against `http://localhost:3000/settings` for slider mark clicks and selected-dot behavior
- `pnpm build`
