### PR TITLE
[codex] Improve YouTube transcript extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,4 @@ src-tauri/resources/standalone/*
 .omc
 .playwright-mcp/
 tmp/
+.worktrees/

--- a/docs/superpowers/plans/2026-07-13-youtube-request-budget.md
+++ b/docs/superpowers/plans/2026-07-13-youtube-request-budget.md
@@ -1,0 +1,90 @@
+# YouTube Request Budget Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bound failed YouTube caption extraction to six direct network calls and add capped backoff between retryable failures.
+
+**Architecture:** Add a function-local request wrapper to `fetchYouTubeTranscriptFromSources` so every player, page, timed-text, and caption request shares one counter and backoff state. Keep native fetch and inject only delay for deterministic tests; add no module or dependency.
+
+**Tech Stack:** TypeScript, native Fetch API, Vitest.
+
+---
+
+### Task 1: Shared request budget
+
+**Files:**
+- Modify: `src/lib/youtube-transcript.test.ts`
+- Modify: `src/lib/youtube-transcript.ts`
+
+- [ ] **Step 1: Write a failing request-budget test**
+
+Create a fake fetch that exposes more than six unusable caption tracks across the existing fallback sources. Assert that `fetchYouTubeTranscriptFromSources` returns `null` and fetch is called exactly six times.
+
+- [ ] **Step 2: Verify RED**
+
+Run: `pnpm test src/lib/youtube-transcript.test.ts`
+
+Expected: FAIL because the extractor currently tries every available request.
+
+- [ ] **Step 3: Implement the six-request wrapper**
+
+Inside `fetchYouTubeTranscriptFromSources`, add one counter and a wrapped fetch function that returns no response after six calls. Route all existing `fetchImpl` calls, including caption-track requests, through it.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run: `pnpm test src/lib/youtube-transcript.test.ts`
+
+Expected: all transcript tests pass.
+
+### Task 2: Retryable backoff and abort handling
+
+**Files:**
+- Modify: `src/lib/youtube-transcript.test.ts`
+- Modify: `src/lib/youtube-transcript.ts`
+
+- [ ] **Step 1: Write failing backoff tests**
+
+Inject a delay recorder. Return network errors, `403`, `429`, and `503` before exhaustion and assert recorded delays are `300`, `600`, `1200`, and `1200`. Add an ordinary empty response assertion that records no delay.
+
+- [ ] **Step 2: Verify RED**
+
+Run: `pnpm test src/lib/youtube-transcript.test.ts`
+
+Expected: FAIL because delay injection and retryable classification do not exist.
+
+- [ ] **Step 3: Implement bounded delay**
+
+Add an optional `delay = ms => new Promise(resolve => setTimeout(resolve, ms))` parameter. Record retryable failures in the request wrapper and apply the next delay before the following request. Treat network errors and `403`, `429`, or `>=500` as retryable.
+
+- [ ] **Step 4: Write and verify an abort RED test**
+
+Make fake fetch throw `new DOMException('Aborted', 'AbortError')`; assert no later fetch or delay occurs. Run the focused test and confirm it fails before implementation.
+
+- [ ] **Step 5: Stop on abort and verify GREEN**
+
+Propagate abort state to all source loops and return `null` without waiting or issuing another request. Run: `pnpm test src/lib/youtube-transcript.test.ts src/app/api/import/youtube/route.test.ts`.
+
+Expected: all focused tests pass.
+
+### Task 3: Verification
+
+**Files:**
+- Modify only if a scoped verification failure is found.
+
+- [ ] **Step 1: Run static and production gates**
+
+Run: `pnpm typecheck && pnpm lint && pnpm build`
+
+Expected: all commands exit 0.
+
+- [ ] **Step 2: Confirm existing full-suite baseline**
+
+Run: `pnpm test`
+
+Expected: YouTube tests pass; the previously recorded unrelated `daily-plan.test.ts:283` failure may remain and must be reported separately.
+
+- [ ] **Step 3: Inspect scope and commit**
+
+Run: `git diff --check && git status --short && git diff --stat`.
+
+Expected: no whitespace errors and changes limited to the plan, transcript implementation, and transcript tests. Commit the implementation with `fix: bound YouTube transcript retries`.

--- a/docs/superpowers/plans/2026-07-13-youtube-transcript-extraction.md
+++ b/docs/superpowers/plans/2026-07-13-youtube-transcript-extraction.md
@@ -1,0 +1,140 @@
+# YouTube Transcript Extraction Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make EchoType's YouTube import recover manual and automatic captions through the same fallback sources used by CaptionDesk while preserving the current route contract.
+
+**Architecture:** Keep parsing and network fallback logic in `src/lib/youtube-transcript.ts`; keep `src/app/api/import/youtube/route.ts` limited to request validation, compatibility fallback, and response mapping. Reuse native `fetch`, existing timeouts, and the installed `youtube-transcript` package; add no dependencies.
+
+**Tech Stack:** TypeScript, Next.js route handlers, Vitest, native Fetch API, YouTube player and timed-text endpoints.
+
+---
+
+### Task 1: URL, track ordering, and JSON3 normalization
+
+**Files:**
+- Modify: `src/lib/youtube-transcript.ts`
+- Modify: `src/lib/youtube-transcript.test.ts`
+
+- [ ] **Step 1: Write failing tests for supported URLs and hostile lookalike hosts**
+
+Add table-driven assertions that `extractYouTubeVideoId` accepts `watch`, `shorts`, `live`, `embed`, and `youtu.be` URLs and rejects `notyoutube.com` and malformed input.
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run: `pnpm test src/lib/youtube-transcript.test.ts`
+
+Expected: FAIL because `/live/` is unsupported and hostname checks accept lookalikes.
+
+- [ ] **Step 3: Implement strict URL parsing**
+
+Use exact `youtube.com` subdomain matching, exact `youtu.be` matching, and a shared pathname segment reader. Keep the public return type `string | null`.
+
+- [ ] **Step 4: Add failing tests for track priority and JSON3 conversion**
+
+Test preferred manual, preferred ASR, English manual, English ASR, other manual, and other ASR ordering. Test JSON3 events containing multiple segments, blank events, newlines, offsets, and durations.
+
+- [ ] **Step 5: Run the focused test and verify RED**
+
+Run: `pnpm test src/lib/youtube-transcript.test.ts`
+
+Expected: FAIL because the pure helpers are not exported yet.
+
+- [ ] **Step 6: Implement minimal pure helpers**
+
+Export `orderYouTubeCaptionTracks(tracks, preferredLang)` and `parseYouTubeJson3(payload)`. Normalize preferred languages to their base code, join event segments, discard blank events, and derive duration from `dDurationMs`.
+
+- [ ] **Step 7: Run the focused test and verify GREEN**
+
+Run: `pnpm test src/lib/youtube-transcript.test.ts`
+
+Expected: all assertions pass.
+
+### Task 2: Server-side multi-source extraction
+
+**Files:**
+- Modify: `src/lib/youtube-transcript.ts`
+- Modify: `src/lib/youtube-transcript.test.ts`
+
+- [ ] **Step 1: Write a failing fallback-chain test**
+
+Inject a fake `fetch` that returns empty iOS metadata, usable Android caption tracks, and JSON3 caption events. Assert request order, `fmt=json3`, language, text, and millisecond timing.
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run: `pnpm test src/lib/youtube-transcript.test.ts`
+
+Expected: FAIL because `fetchYouTubeTranscriptFromSources` does not exist.
+
+- [ ] **Step 3: Implement player-client extraction**
+
+Add `fetchYouTubeTranscriptFromSources(videoId, preferredLang, fetchImpl = fetch)`. POST to `/youtubei/v1/player` with the iOS and Android client payloads, order returned tracks, and accept the first non-empty JSON3 response.
+
+- [ ] **Step 4: Write failing tests for watch-page and timed-text fallback**
+
+Return no mobile tracks, then separately provide embedded watch-page tracks and timed-text XML. Assert both recover captions and skip unusable track responses.
+
+- [ ] **Step 5: Run the focused test and verify RED**
+
+Run: `pnpm test src/lib/youtube-transcript.test.ts`
+
+Expected: FAIL because later fallback branches are absent.
+
+- [ ] **Step 6: Implement remaining sources**
+
+Reuse `extractJsonByMarker` for page tracks. Parse timed-text `<track>` attributes, decode XML entities, build caption URLs, and try ordered tracks with `fmt=json3`. Keep each failed response local to its branch.
+
+- [ ] **Step 7: Run the focused test and verify GREEN**
+
+Run: `pnpm test src/lib/youtube-transcript.test.ts`
+
+Expected: all assertions pass.
+
+### Task 3: Route integration and compatibility fallback
+
+**Files:**
+- Modify: `src/app/api/import/youtube/route.ts`
+- Create: `src/app/api/import/youtube/route.test.ts`
+
+- [ ] **Step 1: Write failing route contract tests**
+
+Mock the shared extractor and installed package at module boundaries. Assert missing/malformed URLs return 400, direct extraction returns the existing response shape, direct exhaustion falls back to the package, and total exhaustion returns 404.
+
+- [ ] **Step 2: Run the route test and verify RED**
+
+Run: `pnpm test src/app/api/import/youtube/route.test.ts`
+
+Expected: FAIL because the route still calls only the package and owns duplicate URL parsing.
+
+- [ ] **Step 3: Integrate the shared extractor**
+
+Import `extractYouTubeVideoId` and `fetchYouTubeTranscriptFromSources`. Map direct results to `{ text, offset, duration }`; if direct extraction returns no segments, retain the English-then-default package fallback. Keep current error statuses and response field names.
+
+- [ ] **Step 4: Run route and library tests and verify GREEN**
+
+Run: `pnpm test src/lib/youtube-transcript.test.ts src/app/api/import/youtube/route.test.ts`
+
+Expected: both suites pass.
+
+### Task 4: Verification
+
+**Files:**
+- Modify only if a verification failure exposes a scoped defect.
+
+- [ ] **Step 1: Run complete automated gates**
+
+Run: `pnpm test && pnpm typecheck && pnpm lint && pnpm build`
+
+Expected: every command exits 0.
+
+- [ ] **Step 2: Run a real caption extraction smoke test**
+
+Invoke the shared extractor for a stable public captioned YouTube video from a small TypeScript runner or through the local route. Assert non-empty text and segments and print only title-independent counts/language.
+
+Expected: non-zero segment and text counts. If YouTube blocks the server IP, record the exact limitation and verify the same response contract through deterministic route tests.
+
+- [ ] **Step 3: Inspect final scope**
+
+Run: `git diff --check && git status --short && git diff --stat HEAD~1`
+
+Expected: no whitespace errors; changes limited to the design/plan, transcript library/tests, and route/tests.

--- a/docs/superpowers/specs/2026-07-13-youtube-request-budget-design.md
+++ b/docs/superpowers/specs/2026-07-13-youtube-request-budget-design.md
@@ -1,0 +1,31 @@
+# YouTube Request Budget and Backoff Design
+
+## Goal
+
+Prevent one failed YouTube import from rapidly amplifying into many unauthenticated server requests while preserving the existing caption-source fallback chain.
+
+## Behavior
+
+Each direct extraction call owns one shared budget of six YouTube network requests. iOS player, Android player, watch-page tracks, caption payloads, and timed-text tracks all consume that same budget. When the budget is exhausted, direct extraction stops and the API route advances to its existing `youtube-transcript` compatibility fallback.
+
+The extractor does not immediately retry the same endpoint. Before moving to another source after a retryable failure, it waits using a bounded `300ms`, `600ms`, then `1200ms` schedule. Retryable failures are network errors and HTTP `403`, `429`, or `5xx` responses. Other empty or unsuccessful responses advance without delay because waiting cannot make that response usable.
+
+An aborted request stops extraction immediately. It must not wait or issue another request.
+
+## Implementation
+
+Keep the logic inside `fetchYouTubeTranscriptFromSources` in `src/lib/youtube-transcript.ts`. Add a small request-budget helper local to that function rather than introducing a new module or dependency. Accept an injectable delay function after the existing injectable fetch function so tests can record backoff without sleeping.
+
+The budget wrapper checks for aborts, refuses calls after six attempts, records retryable failures, and applies the next bounded delay before the following source request. Caption-track loops use the same wrapper, so a video exposing many unusable tracks cannot bypass the limit.
+
+## Testing
+
+Add focused Vitest coverage proving:
+
+- no more than six fetch calls occur across all sources and caption tracks;
+- retryable failures produce `300`, `600`, and capped `1200` millisecond delays;
+- ordinary empty responses do not add delay;
+- an abort prevents later source requests;
+- existing successful extraction and route compatibility tests remain green.
+
+Run focused transcript and route tests, typecheck, lint, production build, and inspect the final diff. The unrelated existing daily-plan baseline failure remains outside this change.

--- a/docs/superpowers/specs/2026-07-13-youtube-transcript-extraction-design.md
+++ b/docs/superpowers/specs/2026-07-13-youtube-transcript-extraction-design.md
@@ -1,0 +1,55 @@
+# YouTube Transcript Extraction Design
+
+## Goal
+
+Make EchoType's server-side YouTube import recover the same caption content as the CaptionDesk browser extension whenever YouTube exposes manual or automatic captions, while preserving the existing API response consumed by the import UI and chat tool.
+
+## Scope
+
+- Support `watch`, `shorts`, `live`, `embed`, and `youtu.be` video URLs.
+- Prefer the requested language, then English, then manual captions, then any available automatic caption.
+- Try YouTube mobile player clients, caption tracks embedded in the watch page, and the timed-text track list.
+- Parse JSON3 captions into the existing segment and full-text response shape.
+- Keep the installed `youtube-transcript` package as the final compatibility fallback.
+- Return stable client errors for invalid URLs and videos without captions.
+
+Copy/download controls and AI summarization from CaptionDesk are outside this feature.
+
+## Architecture
+
+Keep the route thin. Extend `src/lib/youtube-transcript.ts` with pure URL, track-ordering, and JSON3 parsing helpers plus one server-side extraction function. The function owns the fallback sequence and accepts an injectable fetch implementation so each network branch can be tested without adding dependencies.
+
+The route validates the request, calls the shared extractor, and maps its result to the current `{ videoId, segments, fullText, segmentCount }` contract. Existing consumers require no changes.
+
+## Data Flow
+
+1. Parse and validate the video ID from the submitted URL.
+2. Request YouTube player metadata with the iOS client, then Android client.
+3. For each response, order caption tracks by language and manual-caption preference and request each track as JSON3.
+4. If mobile metadata has no usable transcript, inspect caption tracks from the watch page.
+5. If still empty, request `/api/timedtext?type=list`, build track URLs, and try those tracks.
+6. If the direct extraction chain fails, call the existing `youtube-transcript` package in English and then its default language.
+7. Normalize successful events into millisecond offsets and durations, preserving line text without duplicate whitespace.
+
+Each network attempt is bounded by the existing request timeout style. A failed branch advances to the next branch; an abort or final exhaustion produces a stable error rather than exposing upstream response contents.
+
+## Error Handling
+
+- Missing URL: HTTP 400.
+- Unsupported or malformed URL: HTTP 400 with the existing import guidance.
+- Valid video with no usable caption text after all fallbacks: HTTP 404.
+- Unexpected request or parsing failure: HTTP 500 with a generic message; details remain server-side.
+
+Blank JSON3 events and HTTP failures are treated as an unavailable branch, not a successful empty transcript.
+
+## Testing
+
+Use Vitest with test-first red/green cycles for:
+
+- all supported URL forms and rejection of lookalike hosts;
+- caption-track ordering across preferred language, English, manual, and ASR tracks;
+- JSON3 text, offsets, durations, and blank-event handling;
+- fallback from mobile clients to page tracks and timed-text tracks;
+- route response compatibility and 400/404 behavior.
+
+After unit tests, run the focused tests, project typecheck/lint gates available in `package.json`, and a production build. Finally, call the route or extraction helper against at least one real public captioned video and report any network or YouTube bot-protection limitation explicitly.

--- a/src/app/api/import/youtube/route.test.ts
+++ b/src/app/api/import/youtube/route.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const extractYouTubeVideoIdMock = vi.fn();
+const fetchYouTubeTranscriptFromSourcesMock = vi.fn();
+const fetchTranscriptMock = vi.fn();
+
+vi.mock('@/lib/youtube-transcript', () => ({
+  extractYouTubeVideoId: extractYouTubeVideoIdMock,
+  fetchYouTubeTranscriptFromSources: fetchYouTubeTranscriptFromSourcesMock,
+}));
+
+vi.mock('youtube-transcript', () => ({
+  YoutubeTranscript: { fetchTranscript: fetchTranscriptMock },
+}));
+
+describe('POST /api/import/youtube', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('rejects missing and malformed URLs', async () => {
+    const { POST } = await import('./route');
+    expect((await POST(new Request('http://localhost', { method: 'POST', body: '{}' }))).status).toBe(400);
+
+    extractYouTubeVideoIdMock.mockReturnValue(null);
+    expect(
+      (
+        await POST(
+          new Request('http://localhost', {
+            method: 'POST',
+            body: JSON.stringify({ url: 'https://example.com/watch?v=nope' }),
+          }),
+        )
+      ).status,
+    ).toBe(400);
+  });
+
+  it('returns the existing response contract from direct extraction', async () => {
+    extractYouTubeVideoIdMock.mockReturnValue('abc123');
+    fetchYouTubeTranscriptFromSourcesMock.mockResolvedValue({
+      segments: [{ text: 'Hello', start: 1.25, duration: 2.5 }],
+    });
+    const { POST } = await import('./route');
+    const response = await POST(
+      new Request('http://localhost', {
+        method: 'POST',
+        body: JSON.stringify({ url: 'https://youtu.be/abc123' }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      videoId: 'abc123',
+      segments: [{ text: 'Hello', offset: 1250, duration: 2500 }],
+      fullText: 'Hello',
+      segmentCount: 1,
+    });
+    expect(fetchTranscriptMock).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the installed package when direct sources are exhausted', async () => {
+    extractYouTubeVideoIdMock.mockReturnValue('abc123');
+    fetchYouTubeTranscriptFromSourcesMock.mockResolvedValue({ segments: [] });
+    fetchTranscriptMock.mockRejectedValueOnce(new Error('no English')).mockResolvedValueOnce([
+      { text: 'Fallback', offset: 10, duration: 20 },
+    ]);
+    const { POST } = await import('./route');
+    const response = await POST(
+      new Request('http://localhost', {
+        method: 'POST',
+        body: JSON.stringify({ url: 'https://youtu.be/abc123' }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetchTranscriptMock).toHaveBeenNthCalledWith(1, 'abc123', { lang: 'en' });
+    expect(fetchTranscriptMock).toHaveBeenNthCalledWith(2, 'abc123');
+  });
+
+  it('returns 404 when every transcript source is exhausted', async () => {
+    extractYouTubeVideoIdMock.mockReturnValue('abc123');
+    fetchYouTubeTranscriptFromSourcesMock.mockRejectedValue(new Error('no direct captions'));
+    fetchTranscriptMock.mockRejectedValue(new Error('no package captions'));
+    const { POST } = await import('./route');
+    const response = await POST(
+      new Request('http://localhost', {
+        method: 'POST',
+        body: JSON.stringify({ url: 'https://youtu.be/abc123' }),
+      }),
+    );
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/src/app/api/import/youtube/route.ts
+++ b/src/app/api/import/youtube/route.ts
@@ -1,19 +1,6 @@
 import { NextResponse } from 'next/server';
 import { YoutubeTranscript } from 'youtube-transcript';
-
-function extractVideoId(url: string): string | null {
-  const patterns = [
-    /(?:youtube\.com\/watch\?v=)([^&\s]+)/,
-    /(?:youtu\.be\/)([^?\s]+)/,
-    /(?:youtube\.com\/embed\/)([^?\s]+)/,
-    /(?:youtube\.com\/shorts\/)([^?\s]+)/,
-  ];
-  for (const pattern of patterns) {
-    const match = url.match(pattern);
-    if (match) return match[1];
-  }
-  return null;
-}
+import { extractYouTubeVideoId, fetchYouTubeTranscriptFromSources } from '@/lib/youtube-transcript';
 
 export async function POST(req: Request) {
   try {
@@ -22,7 +9,7 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: 'URL is required' }, { status: 400 });
     }
 
-    const videoId = extractVideoId(url);
+    const videoId = extractYouTubeVideoId(url);
     if (!videoId) {
       return NextResponse.json(
         {
@@ -33,24 +20,37 @@ export async function POST(req: Request) {
       );
     }
 
-    let transcript = await YoutubeTranscript.fetchTranscript(videoId, {
-      lang: 'en',
-    }).catch(() => null);
+    const directTranscript = await fetchYouTubeTranscriptFromSources(videoId, 'en').catch(() => null);
+    let segments =
+      directTranscript?.segments.map((segment) => ({
+        text: segment.text,
+        offset: Math.round(segment.start * 1000),
+        duration: Math.round(segment.duration * 1000),
+      })) ?? [];
+
+    let transcript = null;
+    if (!segments || segments.length === 0) {
+      transcript = await YoutubeTranscript.fetchTranscript(videoId, {
+        lang: 'en',
+      }).catch(() => null);
+    }
 
     // Fall back to default language if English not available
-    if (!transcript || transcript.length === 0) {
+    if ((!segments || segments.length === 0) && (!transcript || transcript.length === 0)) {
       transcript = await YoutubeTranscript.fetchTranscript(videoId).catch(() => null);
     }
 
-    if (!transcript || transcript.length === 0) {
+    if ((!segments || segments.length === 0) && (!transcript || transcript.length === 0)) {
       return NextResponse.json({ error: 'No transcript available for this video' }, { status: 404 });
     }
 
-    const segments = transcript.map((seg) => ({
-      text: seg.text,
-      offset: Math.round(seg.offset),
-      duration: Math.round(seg.duration),
-    }));
+    if (segments.length === 0 && transcript) {
+      segments = transcript.map((seg) => ({
+        text: seg.text,
+        offset: Math.round(seg.offset),
+        duration: Math.round(seg.duration),
+      }));
+    }
 
     const fullText = segments.map((s) => s.text).join(' ');
 

--- a/src/lib/youtube-transcript.test.ts
+++ b/src/lib/youtube-transcript.test.ts
@@ -140,6 +140,80 @@ describe('YouTube transcript extraction', () => {
     expect(calls.some((url) => url.includes('name=English+%26+bad') && url.includes('fmt=json3'))).toBe(true);
     expect(calls.some((url) => url.includes('lang=de') && url.includes('kind=asr') && url.includes('fmt=json3'))).toBe(true);
   });
+
+  it('limits all direct extraction sources to six network requests', async () => {
+    const calls: string[] = [];
+    const fetchImpl = async (input: string | URL | Request) => {
+      const url = String(input);
+      calls.push(url);
+      if (url.includes('/youtubei/v1/player')) return Response.json({});
+      if (url.includes('/watch?')) return new Response('<html></html>');
+      if (url.includes('type=list')) {
+        return new Response(
+          '<track lang_code="en"/><track lang_code="fr"/><track lang_code="de"/><track lang_code="es"/>',
+        );
+      }
+      return Response.json({ events: [] });
+    };
+
+    await expect(fetchYouTubeTranscriptFromSources('video', 'en', fetchImpl)).resolves.toBeNull();
+    expect(calls).toHaveLength(6);
+  });
+
+  it('backs off retryable failures with a capped schedule', async () => {
+    let calls = 0;
+    const delays: number[] = [];
+    const fetchImpl = async () => {
+      calls++;
+      if (calls === 1) {
+        return Response.json({
+          captions: {
+            playerCaptionsTracklistRenderer: {
+              captionTracks: Array.from({ length: 5 }, (_, index) => ({
+                baseUrl: `https://captions.test/${index}`,
+                languageCode: 'en',
+              })),
+            },
+          },
+        });
+      }
+      if (calls === 2) return new Response('', { status: 403 });
+      if (calls === 3) return new Response('', { status: 429 });
+      if (calls === 4) return new Response('', { status: 503 });
+      if (calls === 5) throw new TypeError('network failed');
+      return new Response('', { status: 404 });
+    };
+
+    await fetchYouTubeTranscriptFromSources('video', 'en', fetchImpl, async (ms) => delays.push(ms));
+    expect(delays).toEqual([300, 600, 1200, 1200]);
+  });
+
+  it('does not back off ordinary empty responses', async () => {
+    const delays: number[] = [];
+    await fetchYouTubeTranscriptFromSources(
+      'video',
+      'en',
+      async () => new Response('', { status: 404 }),
+      async (ms) => delays.push(ms),
+    );
+    expect(delays).toEqual([]);
+  });
+
+  it('stops without delay after an aborted request', async () => {
+    let calls = 0;
+    const delays: number[] = [];
+    await fetchYouTubeTranscriptFromSources(
+      'video',
+      'en',
+      async () => {
+        calls++;
+        throw new DOMException('Aborted', 'AbortError');
+      },
+      async (ms) => delays.push(ms),
+    );
+    expect(calls).toBe(1);
+    expect(delays).toEqual([]);
+  });
 });
 
 describe('sortAudioCandidates', () => {

--- a/src/lib/youtube-transcript.test.ts
+++ b/src/lib/youtube-transcript.test.ts
@@ -1,5 +1,147 @@
 import { describe, expect, it } from 'vitest';
 
+import {
+  extractYouTubeVideoId,
+  fetchYouTubeTranscriptFromSources,
+  orderYouTubeCaptionTracks,
+  parseYouTubeJson3,
+} from './youtube-transcript';
+
+describe('YouTube transcript extraction', () => {
+  it.each([
+    ['https://www.youtube.com/watch?v=watch-id', 'watch-id'],
+    ['https://m.youtube.com/shorts/short-id', 'short-id'],
+    ['https://youtube.com/live/live-id', 'live-id'],
+    ['https://www.youtube.com/embed/embed-id', 'embed-id'],
+    ['https://youtu.be/brief-id?t=3', 'brief-id'],
+  ])('extracts supported video URL %s', (url, expected) => {
+    expect(extractYouTubeVideoId(url)).toBe(expected);
+  });
+
+  it.each(['https://notyoutube.com/watch?v=bad', 'https://youtube.com.evil.test/watch?v=bad', 'bad']) (
+    'rejects invalid URL %s',
+    (url) => expect(extractYouTubeVideoId(url)).toBeNull(),
+  );
+
+  it('orders preferred, English, and other tracks with manual before ASR', () => {
+    const tracks = [
+      { baseUrl: 'other-asr', languageCode: 'fr', kind: 'asr' },
+      { baseUrl: 'en-asr', languageCode: 'en', kind: 'asr' },
+      { baseUrl: 'preferred-asr', languageCode: 'zh-Hans', kind: 'asr' },
+      { baseUrl: 'other-manual', languageCode: 'fr' },
+      { baseUrl: 'en-manual', languageCode: 'en-US' },
+      { baseUrl: 'preferred-manual', languageCode: 'zh' },
+    ];
+
+    expect(orderYouTubeCaptionTracks(tracks, 'zh-CN').map((track) => track.baseUrl)).toEqual([
+      'preferred-manual',
+      'preferred-asr',
+      'en-manual',
+      'en-asr',
+      'other-manual',
+      'other-asr',
+    ]);
+  });
+
+  it('normalizes JSON3 events to non-empty millisecond segments', () => {
+    expect(
+      parseYouTubeJson3({
+        events: [
+          { tStartMs: 1000, dDurationMs: 2500, segs: [{ utf8: 'Hello' }, { utf8: '\nworld' }] },
+          { tStartMs: 4000, dDurationMs: 500, segs: [{ utf8: '  ' }] },
+          { tStartMs: 5000, segs: [{ utf8: 'Again' }] },
+        ],
+      }),
+    ).toEqual([
+      { text: 'Hello world', start: 1000, duration: 2500 },
+      { text: 'Again', start: 5000, duration: 0 },
+    ]);
+  });
+
+  it('falls back from iOS to Android tracks and requests JSON3', async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const fetchImpl = async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input);
+      calls.push({ url, init });
+      if (url.includes('/youtubei/v1/player')) {
+        const client = JSON.parse(String(init?.body)).context.client.clientName;
+        return Response.json(
+          client === 'IOS'
+            ? {}
+            : {
+                captions: {
+                  playerCaptionsTracklistRenderer: {
+                    captionTracks: [{ baseUrl: 'https://captions.test/android', languageCode: 'en' }],
+                  },
+                },
+              },
+        );
+      }
+      if (url.startsWith('https://captions.test/android')) {
+        return Response.json({ events: [{ tStartMs: 12, dDurationMs: 34, segs: [{ utf8: 'Works' }] }] });
+      }
+      return new Response('', { status: 404 });
+    };
+
+    await expect(fetchYouTubeTranscriptFromSources('video', 'en', fetchImpl)).resolves.toEqual({
+      text: 'Works',
+      segments: [{ text: 'Works', start: 12, duration: 34 }],
+      language: 'en',
+    });
+    expect(calls.map(({ url }) => url)).toEqual([
+      'https://www.youtube.com/youtubei/v1/player?prettyPrint=false',
+      'https://www.youtube.com/youtubei/v1/player?prettyPrint=false',
+      'https://captions.test/android?fmt=json3',
+    ]);
+  });
+
+  it('falls back to watch-page caption tracks', async () => {
+    let playerCalls = 0;
+    const fetchImpl = async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes('/youtubei/v1/player')) {
+        playerCalls++;
+        return Response.json({});
+      }
+      if (url.includes('/watch?')) {
+        return new Response('<script>var x={"captionTracks":[{"baseUrl":"https://captions.test/page","languageCode":"fr"}]};</script>');
+      }
+      if (url.startsWith('https://captions.test/page')) {
+        return Response.json({ events: [{ tStartMs: 1, dDurationMs: 2, segs: [{ utf8: 'Page' }] }] });
+      }
+      return new Response('', { status: 404 });
+    };
+
+    expect((await fetchYouTubeTranscriptFromSources('video', 'fr', fetchImpl))?.text).toBe('Page');
+    expect(playerCalls).toBe(2);
+  });
+
+  it('falls back to timed-text list and skips unusable tracks', async () => {
+    const calls: string[] = [];
+    const fetchImpl = async (input: string | URL | Request) => {
+      const url = String(input);
+      calls.push(url);
+      if (url.includes('/youtubei/v1/player')) return Response.json({});
+      if (url.includes('/watch?')) return new Response('<html></html>');
+      if (url.includes('/api/timedtext?type=list')) {
+        return new Response('<transcript_list><track lang_code="en" name="English &amp; bad"/><track lang_code="de" kind="asr"/></transcript_list>');
+      }
+      if (url.includes('lang=en')) return Response.json({ events: [] });
+      if (url.includes('lang=de')) {
+        return Response.json({ events: [{ tStartMs: 8, dDurationMs: 9, segs: [{ utf8: 'Zeit' }] }] });
+      }
+      return new Response('', { status: 404 });
+    };
+
+    await expect(fetchYouTubeTranscriptFromSources('video', 'en-US', fetchImpl)).resolves.toMatchObject({
+      text: 'Zeit',
+      language: 'de',
+    });
+    expect(calls.some((url) => url.includes('name=English+%26+bad') && url.includes('fmt=json3'))).toBe(true);
+    expect(calls.some((url) => url.includes('lang=de') && url.includes('kind=asr') && url.includes('fmt=json3'))).toBe(true);
+  });
+});
+
 describe('sortAudioCandidates', () => {
   it('orders valid audio candidates by bitrate and filters missing URLs', async () => {
     const { sortAudioCandidates } = await import('./youtube-transcript');

--- a/src/lib/youtube-transcript.test.ts
+++ b/src/lib/youtube-transcript.test.ts
@@ -43,7 +43,7 @@ describe('YouTube transcript extraction', () => {
     ]);
   });
 
-  it('normalizes JSON3 events to non-empty millisecond segments', () => {
+  it('normalizes JSON3 millisecond events to non-empty second-based segments', () => {
     expect(
       parseYouTubeJson3({
         events: [
@@ -53,8 +53,8 @@ describe('YouTube transcript extraction', () => {
         ],
       }),
     ).toEqual([
-      { text: 'Hello world', start: 1000, duration: 2500 },
-      { text: 'Again', start: 5000, duration: 0 },
+      { text: 'Hello world', start: 1, duration: 2.5 },
+      { text: 'Again', start: 5, duration: 0 },
     ]);
   });
 
@@ -85,7 +85,7 @@ describe('YouTube transcript extraction', () => {
 
     await expect(fetchYouTubeTranscriptFromSources('video', 'en', fetchImpl)).resolves.toEqual({
       text: 'Works',
-      segments: [{ text: 'Works', start: 12, duration: 34 }],
+      segments: [{ text: 'Works', start: 0.012, duration: 0.034 }],
       language: 'en',
     });
     expect(calls.map(({ url }) => url)).toEqual([

--- a/src/lib/youtube-transcript.ts
+++ b/src/lib/youtube-transcript.ts
@@ -136,14 +136,45 @@ export async function fetchYouTubeTranscriptFromSources(
   videoId: string,
   preferredLang = 'en',
   fetchImpl: typeof fetch = fetch,
+  delay: (ms: number) => Promise<unknown> = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
 ): Promise<TranscriptResponse | null> {
+  let requests = 0;
+  let failures = 0;
+  let pendingDelay = 0;
+  let aborted = false;
+  const markRetryableFailure = () => {
+    pendingDelay = [300, 600, 1200][Math.min(failures++, 2)];
+  };
+  const request = async (...args: Parameters<typeof fetch>): Promise<Response | null> => {
+    if (aborted || requests >= 6) return null;
+    if (pendingDelay) {
+      const wait = pendingDelay;
+      pendingDelay = 0;
+      await delay(wait);
+    }
+    if (aborted) return null;
+    requests++;
+    try {
+      const response = await fetchImpl(...args);
+      if (response.status === 403 || response.status === 429 || response.status >= 500) markRetryableFailure();
+      return response;
+    } catch (error) {
+      if (error instanceof Error && error.name === 'AbortError') {
+        aborted = true;
+        return null;
+      }
+      markRetryableFailure();
+      throw error;
+    }
+  };
+
   const fetchTracks = async (tracks: CaptionTrack[]) => {
     for (const track of orderYouTubeCaptionTracks(tracks, preferredLang)) {
       try {
         const url = new URL(track.baseUrl.replace(/\\u0026/g, '&'));
         url.searchParams.set('fmt', 'json3');
-        const response = await fetchImpl(url);
-        if (!response.ok) continue;
+        const response = await request(url);
+        if (!response?.ok) continue;
         const segments = parseYouTubeJson3(await response.json());
         if (segments.length)
           return { text: segments.map((segment) => segment.text).join(' '), segments, language: track.languageCode };
@@ -180,12 +211,12 @@ export async function fetchYouTubeTranscriptFromSources(
 
   for (const client of clients) {
     try {
-      const response = await fetchImpl('https://www.youtube.com/youtubei/v1/player?prettyPrint=false', {
+      const response = await request('https://www.youtube.com/youtubei/v1/player?prettyPrint=false', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ context: { client }, videoId, contentCheckOk: true, racyCheckOk: true }),
       });
-      if (response.ok) {
+      if (response?.ok) {
         const result = await fetchTracks(readCaptionTracks(await response.json()));
         if (result) return result;
       }
@@ -195,8 +226,8 @@ export async function fetchYouTubeTranscriptFromSources(
   }
 
   try {
-    const response = await fetchImpl(`https://www.youtube.com/watch?v=${encodeURIComponent(videoId)}`);
-    if (response.ok) {
+    const response = await request(`https://www.youtube.com/watch?v=${encodeURIComponent(videoId)}`);
+    if (response?.ok) {
       const result = await fetchTracks(extractCaptionTracks(await response.text()) ?? []);
       if (result) return result;
     }
@@ -205,10 +236,8 @@ export async function fetchYouTubeTranscriptFromSources(
   }
 
   try {
-    const response = await fetchImpl(
-      `https://www.youtube.com/api/timedtext?type=list&v=${encodeURIComponent(videoId)}`,
-    );
-    if (response.ok) return await fetchTracks(parseTimedTextTracks(await response.text(), videoId));
+    const response = await request(`https://www.youtube.com/api/timedtext?type=list&v=${encodeURIComponent(videoId)}`);
+    if (response?.ok) return await fetchTracks(parseTimedTextTracks(await response.text(), videoId));
   } catch {
     // All sources exhausted.
   }

--- a/src/lib/youtube-transcript.ts
+++ b/src/lib/youtube-transcript.ts
@@ -5,19 +5,19 @@
  * Uses the same API that YouTube's web player uses to fetch captions.
  */
 
-interface TranscriptSegment {
+export interface TranscriptSegment {
   text: string;
   start: number;
   duration: number;
 }
 
-interface TranscriptResponse {
+export interface TranscriptResponse {
   text: string;
   segments: TranscriptSegment[];
   language: string;
 }
 
-interface CaptionTrack {
+export interface CaptionTrack {
   baseUrl: string;
   languageCode: string;
   name?: { simpleText?: string };
@@ -30,33 +30,181 @@ interface CaptionTrack {
 export function extractYouTubeVideoId(url: string): string | null {
   try {
     const urlObj = new URL(url);
+    const hostname = urlObj.hostname.toLowerCase();
+    const isYouTube = hostname === 'youtube.com' || hostname.endsWith('.youtube.com');
 
-    if (urlObj.hostname.includes('youtube.com')) {
-      // youtube.com/watch?v=VIDEO_ID
-      const videoId = urlObj.searchParams.get('v');
-      if (videoId) return videoId;
-
-      // youtube.com/shorts/VIDEO_ID
-      const shortsMatch = urlObj.pathname.match(/\/shorts\/([^/?]+)/);
-      if (shortsMatch) return shortsMatch[1];
+    if (isYouTube) {
+      if (urlObj.pathname === '/watch') return urlObj.searchParams.get('v') || null;
+      const [type, videoId] = urlObj.pathname.split('/').filter(Boolean);
+      if (['shorts', 'live', 'embed'].includes(type) && videoId) return videoId;
+      return null;
     }
 
-    // youtu.be/VIDEO_ID
-    if (urlObj.hostname.includes('youtu.be')) {
-      const videoId = urlObj.pathname.slice(1).split('?')[0];
-      if (videoId) return videoId;
-    }
-
-    // youtube.com/embed/VIDEO_ID
-    if (urlObj.pathname.includes('/embed/')) {
-      const videoId = urlObj.pathname.split('/embed/')[1]?.split('?')[0];
-      if (videoId) return videoId;
-    }
+    if (hostname === 'youtu.be') return urlObj.pathname.split('/').filter(Boolean)[0] || null;
 
     return null;
   } catch {
     return null;
   }
+}
+
+const baseLanguage = (language = '') => language.toLowerCase().split('-')[0];
+
+export function orderYouTubeCaptionTracks(tracks: CaptionTrack[], preferredLang = 'en'): CaptionTrack[] {
+  const preferred = baseLanguage(preferredLang);
+  const score = (track: CaptionTrack) => {
+    const language = baseLanguage(track.languageCode);
+    const automatic = track.kind === 'asr';
+    if (preferred && language === preferred) return automatic ? 1 : 0;
+    if (language === 'en') return automatic ? 3 : 2;
+    return automatic ? 5 : 4;
+  };
+
+  return tracks
+    .filter((track) => Boolean(track.baseUrl))
+    .map((track, index) => ({ track, index }))
+    .sort((a, b) => score(a.track) - score(b.track) || a.index - b.index)
+    .map(({ track }) => track);
+}
+
+interface Json3Payload {
+  events?: Array<{
+    tStartMs?: number;
+    dDurationMs?: number;
+    segs?: Array<{ utf8?: string }>;
+  }>;
+}
+
+export function parseYouTubeJson3(payload: unknown): TranscriptSegment[] {
+  const events = (payload as Json3Payload | null)?.events;
+  if (!Array.isArray(events)) return [];
+
+  return events.flatMap((event) => {
+    const text = (event.segs ?? [])
+      .map((segment) => segment.utf8 ?? '')
+      .join('')
+      .replace(/\s+/g, ' ')
+      .trim();
+    return text ? [{ text, start: Number(event.tStartMs) || 0, duration: Number(event.dDurationMs) || 0 }] : [];
+  });
+}
+
+const readCaptionTracks = (player: unknown): CaptionTrack[] => {
+  const tracks = (
+    player as {
+      captions?: { playerCaptionsTracklistRenderer?: { captionTracks?: CaptionTrack[] } };
+    } | null
+  )?.captions?.playerCaptionsTracklistRenderer?.captionTracks;
+  return Array.isArray(tracks) ? tracks : [];
+};
+
+const decodeXml = (value: string) =>
+  value
+    .replace(/&amp;/g, '&')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>');
+
+const parseTimedTextTracks = (xml: string, videoId: string): CaptionTrack[] =>
+  Array.from(xml.matchAll(/<track\b([^>]*)>/g)).map((match) => {
+    const attrs = Object.fromEntries(
+      Array.from(match[1].matchAll(/\s([\w:-]+)="([^"]*)"/g), (attribute) => [attribute[1], decodeXml(attribute[2])]),
+    );
+    const url = new URL('https://www.youtube.com/api/timedtext');
+    url.searchParams.set('v', videoId);
+    url.searchParams.set('lang', attrs.lang_code ?? '');
+    if (attrs.name) url.searchParams.set('name', attrs.name);
+    if (attrs.kind) url.searchParams.set('kind', attrs.kind);
+    return {
+      baseUrl: url.toString(),
+      languageCode: attrs.lang_code ?? '',
+      kind: attrs.kind,
+      name: { simpleText: attrs.name },
+    };
+  });
+
+export async function fetchYouTubeTranscriptFromSources(
+  videoId: string,
+  preferredLang = 'en',
+  fetchImpl: typeof fetch = fetch,
+): Promise<TranscriptResponse | null> {
+  const fetchTracks = async (tracks: CaptionTrack[]) => {
+    for (const track of orderYouTubeCaptionTracks(tracks, preferredLang)) {
+      try {
+        const url = new URL(track.baseUrl.replace(/\\u0026/g, '&'));
+        url.searchParams.set('fmt', 'json3');
+        const response = await fetchImpl(url);
+        if (!response.ok) continue;
+        const segments = parseYouTubeJson3(await response.json());
+        if (segments.length)
+          return { text: segments.map((segment) => segment.text).join(' '), segments, language: track.languageCode };
+      } catch {
+        // Try the next track or source.
+      }
+    }
+    return null;
+  };
+
+  const clients = [
+    {
+      clientName: 'IOS',
+      clientVersion: '20.10.4',
+      deviceMake: 'Apple',
+      deviceModel: 'iPhone16,2',
+      osName: 'iOS',
+      osVersion: '18.3.2',
+      hl: 'en',
+      gl: 'US',
+    },
+    {
+      clientName: 'ANDROID',
+      clientVersion: '20.10.38',
+      androidSdkVersion: 35,
+      deviceMake: 'Google',
+      deviceModel: 'Pixel 9 Pro',
+      osName: 'Android',
+      osVersion: '15',
+      hl: 'en',
+      gl: 'US',
+    },
+  ];
+
+  for (const client of clients) {
+    try {
+      const response = await fetchImpl('https://www.youtube.com/youtubei/v1/player?prettyPrint=false', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ context: { client }, videoId, contentCheckOk: true, racyCheckOk: true }),
+      });
+      if (response.ok) {
+        const result = await fetchTracks(readCaptionTracks(await response.json()));
+        if (result) return result;
+      }
+    } catch {
+      // Try the next client.
+    }
+  }
+
+  try {
+    const response = await fetchImpl(`https://www.youtube.com/watch?v=${encodeURIComponent(videoId)}`);
+    if (response.ok) {
+      const result = await fetchTracks(extractCaptionTracks(await response.text()) ?? []);
+      if (result) return result;
+    }
+  } catch {
+    // Try timed text.
+  }
+
+  try {
+    const response = await fetchImpl(
+      `https://www.youtube.com/api/timedtext?type=list&v=${encodeURIComponent(videoId)}`,
+    );
+    if (response.ok) return await fetchTracks(parseTimedTextTracks(await response.text(), videoId));
+  } catch {
+    // All sources exhausted.
+  }
+  return null;
 }
 
 /**

--- a/src/lib/youtube-transcript.ts
+++ b/src/lib/youtube-transcript.ts
@@ -85,7 +85,15 @@ export function parseYouTubeJson3(payload: unknown): TranscriptSegment[] {
       .join('')
       .replace(/\s+/g, ' ')
       .trim();
-    return text ? [{ text, start: Number(event.tStartMs) || 0, duration: Number(event.dDurationMs) || 0 }] : [];
+    return text
+      ? [
+          {
+            text,
+            start: (Number(event.tStartMs) || 0) / 1000,
+            duration: (Number(event.dDurationMs) || 0) / 1000,
+          },
+        ]
+      : [];
   });
 }
 


### PR DESCRIPTION
## What changed

- add resilient YouTube caption extraction through mobile player clients, watch-page tracks, timed-text tracks, and the existing package fallback
- support watch, Shorts, live, embed, and youtu.be URLs with strict host validation
- normalize JSON3 captions and preserve the existing import API response contract
- cap direct extraction at six YouTube requests with 300ms, 600ms, and 1200ms backoff for retryable failures
- stop extraction after aborts and add focused route/parser/fallback/budget tests

## Why

The previous route relied only on `youtube-transcript`, so videos available through YouTube's other caption sources frequently returned no transcript. Unbounded fallback attempts could also amplify failures and trigger YouTube network protection.

## Impact

YouTube imports recover more manual and automatic captions while limiting request bursts during rate limits or upstream failures. Existing API consumers keep the same response shape.

## Validation

- `pnpm test src/lib/youtube-transcript.test.ts src/app/api/import/youtube/route.test.ts` — 22/22 passed
- `pnpm typecheck` — passed
- `pnpm lint` — passed
- `pnpm build` — passed
- real public-video smoke test recovered 61 English segments / 2089 characters before later network throttling
- full suite: 720/721 passed; the sole failure is the pre-existing `daily-plan.test.ts:283` assertion
