### PR TITLE
[codex] Keep Read controls visible and restore sentence selection

### DIFF
--- a/src/app/(app)/read/[id]/page.layout.test.ts
+++ b/src/app/(app)/read/[id]/page.layout.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8');
+
+describe('read practice layout', () => {
+  it('keeps long reference text in an independently scrollable viewport', () => {
+    expect(source).toContain('data-testid="read-reference-scroll"');
+    expect(source).toMatch(/read-reference-scroll[\s\S]*min-h-0 flex-1/);
+    expect(source).toMatch(/read-reference-scroll[\s\S]*overflow-y-auto/);
+  });
+
+  it('keeps read controls attached below the reference viewport', () => {
+    expect(source).toContain('data-testid="read-practice-workspace"');
+    expect(source).toMatch(/read-practice-workspace[\s\S]*h-\[calc\(100dvh-9\.5rem\)\]/);
+    expect(source).toMatch(/read-practice-workspace[\s\S]*ReadAloudInlineControls/);
+  });
+});

--- a/src/app/(app)/read/[id]/page.tsx
+++ b/src/app/(app)/read/[id]/page.tsx
@@ -1103,170 +1103,182 @@ export default function ReadDetailPage() {
         </div>
       )}
 
-      <Card
-        className={cn(isIOSNativeHost ? IOS_SECTION_CARD_CLASS : 'bg-white border-slate-100 shadow-sm', 'shrink-0')}
-      >
-        <CardContent className="p-4 md:p-6">
-          <div className="flex items-center justify-between mb-4 shrink-0 gap-2">
-            <h3 className="font-semibold text-indigo-900 shrink-0">{t.content.referenceText}</h3>
-            <div className="flex items-center gap-1 md:gap-2">
-              {!isIOSNativeHost && <TranslationBar module="read" />}
-              <div className="w-px h-6 bg-indigo-200 mx-0.5 md:mx-1 hidden sm:block" />
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={handlePlayTTS}
-                className={`border-indigo-200 cursor-pointer ${raIsActive && raIsPlaying ? 'bg-indigo-100 text-indigo-700' : 'text-indigo-600'}`}
-              >
-                <Volume2 className="w-4 h-4 mr-1" />
-                <span className="hidden sm:inline">
-                  {raIsActive && raIsPlaying ? t.content.stop : t.content.listenAlong}
-                </span>
-              </Button>
-            </div>
-          </div>
-          <div className={cn('pr-2', isIOSNativeHost && `${IOS_LIST_CARD_CLASS} px-4 py-4`)}>
-            {raIsActive ? (
-              <ReadAloudContent
-                text={content.text}
-                onWordClick={handleReadAloudWordClick}
-                showTranslation={showTranslation}
-                sentenceTranslations={readAloudSentenceTranslations}
-              />
-            ) : showTranslation && sentenceTranslations && sentenceTranslations.length > 0 ? (
-              <div className="space-y-4">
-                {translatedBlocks.map(({ block, translations }) => (
-                  <div key={block.id} className="space-y-1.5">
-                    <div
-                      className={
-                        block.kind === 'title'
-                          ? 'text-2xl font-semibold text-indigo-900 leading-tight whitespace-pre-wrap'
-                          : block.kind === 'label'
-                            ? 'text-xs font-semibold tracking-[0.18em] text-indigo-400 whitespace-pre-wrap'
-                            : block.kind === 'quote'
-                              ? 'border-l-2 border-indigo-200 pl-4 text-lg italic leading-relaxed text-indigo-700 whitespace-pre-wrap'
-                              : 'text-lg leading-relaxed text-indigo-800 whitespace-pre-wrap'
-                      }
-                    >
-                      {block.text}
-                    </div>
-                    {translations.length > 0 && (
-                      <p className="text-sm text-indigo-400/80 leading-relaxed pl-0.5 whitespace-pre-wrap">
-                        {translations.join('\n')}
-                      </p>
-                    )}
-                  </div>
-                ))}
+      <div data-testid="read-practice-workspace" className="flex h-[calc(100dvh-9.5rem)] min-h-0 flex-col gap-3">
+        <Card
+          className={cn(
+            isIOSNativeHost ? IOS_SECTION_CARD_CLASS : 'bg-white border-slate-100 shadow-sm',
+            'min-h-0 flex-1 overflow-hidden',
+          )}
+        >
+          <CardContent className="flex h-full min-h-0 flex-col p-4 md:p-6">
+            <div className="flex items-center justify-between mb-4 shrink-0 gap-2">
+              <h3 className="font-semibold text-indigo-900 shrink-0">{t.content.referenceText}</h3>
+              <div className="flex items-center gap-1 md:gap-2">
+                {!isIOSNativeHost && <TranslationBar module="read" />}
+                <div className="w-px h-6 bg-indigo-200 mx-0.5 md:mx-1 hidden sm:block" />
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handlePlayTTS}
+                  className={`border-indigo-200 cursor-pointer ${raIsActive && raIsPlaying ? 'bg-indigo-100 text-indigo-700' : 'text-indigo-600'}`}
+                >
+                  <Volume2 className="w-4 h-4 mr-1" />
+                  <span className="hidden sm:inline">
+                    {raIsActive && raIsPlaying ? t.content.stop : t.content.listenAlong}
+                  </span>
+                </Button>
               </div>
-            ) : (
-              <FormattedContentText
-                text={content.text}
-                paragraphClassName="text-lg leading-relaxed text-indigo-800"
-                titleClassName="text-2xl font-semibold text-indigo-900 leading-tight"
-                labelClassName="text-xs font-semibold tracking-[0.18em] text-indigo-400"
-                quoteClassName="border-l-2 border-indigo-200 pl-4 text-lg italic leading-relaxed text-indigo-700"
-              />
-            )}
-            {showTranslation && translationLoading && (
-              <TranslationDisplay translation={null} isLoading={true} show={true} error={translationError} />
-            )}
-            {showTranslation && translationError && !translationLoading && (
-              <TranslationDisplay
-                translation={null}
-                isLoading={false}
-                show={true}
-                error={translationError}
-                onRetry={retryTranslation}
-              />
-            )}
-          </div>
-        </CardContent>
-      </Card>
-
-      {raIsActive && (
-        <>
-          {isIOSNativeHost ? (
-            <IOSReadAloudControls
-              label="Read controls"
-              accentClassName="text-orange-500"
-              onPlay={handlePlayTTS}
-              onPause={handleReadAloudPause}
-              onNext={handleReadAloudNext}
-              onPrev={handleReadAloudPrev}
-            />
-          ) : (
-            <ReadAloudInlineControls
-              label="Read controls"
-              accentClassName="text-orange-500"
-              onPlay={handlePlayTTS}
-              onPause={handleReadAloudPause}
-              onNext={handleReadAloudNext}
-              onPrev={handleReadAloudPrev}
+            </div>
+            <div
+              data-testid="read-reference-scroll"
+              data-selection-scope
+              className={cn(
+                'min-h-0 flex-1 overflow-y-auto overscroll-contain pr-2',
+                isIOSNativeHost && `${IOS_LIST_CARD_CLASS} px-4 py-4`,
+              )}
             >
-              <div className="flex flex-col items-center gap-2">
-                <div className="flex items-center justify-center gap-3">
-                  <motion.div
-                    animate={isListening ? { scale: [1, 1.08, 1] } : {}}
-                    transition={isListening ? { repeat: Infinity, duration: 1.5 } : {}}
-                  >
-                    <Button
-                      onClick={isListening ? stopListening : startListening}
-                      disabled={isFallbackTranscribing}
-                      aria-label={
-                        isFallbackTranscribing
-                          ? t.a11y.processingSpeech
+              {raIsActive ? (
+                <ReadAloudContent
+                  text={content.text}
+                  onWordClick={handleReadAloudWordClick}
+                  showTranslation={showTranslation}
+                  sentenceTranslations={readAloudSentenceTranslations}
+                />
+              ) : showTranslation && sentenceTranslations && sentenceTranslations.length > 0 ? (
+                <div className="space-y-4">
+                  {translatedBlocks.map(({ block, translations }) => (
+                    <div key={block.id} className="space-y-1.5">
+                      <div
+                        className={
+                          block.kind === 'title'
+                            ? 'text-2xl font-semibold text-indigo-900 leading-tight whitespace-pre-wrap'
+                            : block.kind === 'label'
+                              ? 'text-xs font-semibold tracking-[0.18em] text-indigo-400 whitespace-pre-wrap'
+                              : block.kind === 'quote'
+                                ? 'border-l-2 border-indigo-200 pl-4 text-lg italic leading-relaxed text-indigo-700 whitespace-pre-wrap'
+                                : 'text-lg leading-relaxed text-indigo-800 whitespace-pre-wrap'
+                        }
+                      >
+                        {block.text}
+                      </div>
+                      {translations.length > 0 && (
+                        <p className="text-sm text-indigo-400/80 leading-relaxed pl-0.5 whitespace-pre-wrap">
+                          {translations.join('\n')}
+                        </p>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <FormattedContentText
+                  text={content.text}
+                  paragraphClassName="text-lg leading-relaxed text-indigo-800"
+                  titleClassName="text-2xl font-semibold text-indigo-900 leading-tight"
+                  labelClassName="text-xs font-semibold tracking-[0.18em] text-indigo-400"
+                  quoteClassName="border-l-2 border-indigo-200 pl-4 text-lg italic leading-relaxed text-indigo-700"
+                />
+              )}
+              {showTranslation && translationLoading && (
+                <TranslationDisplay translation={null} isLoading={true} show={true} error={translationError} />
+              )}
+              {showTranslation && translationError && !translationLoading && (
+                <TranslationDisplay
+                  translation={null}
+                  isLoading={false}
+                  show={true}
+                  error={translationError}
+                  onRetry={retryTranslation}
+                />
+              )}
+            </div>
+          </CardContent>
+        </Card>
+
+        {raIsActive && (
+          <>
+            {isIOSNativeHost ? (
+              <IOSReadAloudControls
+                label="Read controls"
+                accentClassName="text-orange-500"
+                onPlay={handlePlayTTS}
+                onPause={handleReadAloudPause}
+                onNext={handleReadAloudNext}
+                onPrev={handleReadAloudPrev}
+              />
+            ) : (
+              <ReadAloudInlineControls
+                label="Read controls"
+                accentClassName="text-orange-500"
+                onPlay={handlePlayTTS}
+                onPause={handleReadAloudPause}
+                onNext={handleReadAloudNext}
+                onPrev={handleReadAloudPrev}
+              >
+                <div className="flex flex-col items-center gap-2">
+                  <div className="flex items-center justify-center gap-3">
+                    <motion.div
+                      animate={isListening ? { scale: [1, 1.08, 1] } : {}}
+                      transition={isListening ? { repeat: Infinity, duration: 1.5 } : {}}
+                    >
+                      <Button
+                        onClick={isListening ? stopListening : startListening}
+                        disabled={isFallbackTranscribing}
+                        aria-label={
+                          isFallbackTranscribing
+                            ? t.a11y.processingSpeech
+                            : isListening
+                              ? t.a11y.stopRecording
+                              : t.a11y.startRecording
+                        }
+                        className={`h-11 rounded-full px-5 cursor-pointer transition-colors duration-200 ${
+                          isFallbackTranscribing
+                            ? 'bg-amber-500 shadow-lg shadow-amber-200'
+                            : isListening
+                              ? 'bg-red-500 hover:bg-red-600'
+                              : 'bg-green-500 hover:bg-green-600'
+                        }`}
+                      >
+                        {isFallbackTranscribing ? (
+                          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                        ) : isListening ? (
+                          <MicOff className="mr-2 h-4 w-4" />
+                        ) : (
+                          <Mic className="mr-2 h-4 w-4" />
+                        )}
+                        {isFallbackTranscribing
+                          ? t.recording.processingSpeech
                           : isListening
                             ? t.a11y.stopRecording
-                            : t.a11y.startRecording
-                      }
-                      className={`h-11 rounded-full px-5 cursor-pointer transition-colors duration-200 ${
-                        isFallbackTranscribing
-                          ? 'bg-amber-500 shadow-lg shadow-amber-200'
-                          : isListening
-                            ? 'bg-red-500 hover:bg-red-600'
-                            : 'bg-green-500 hover:bg-green-600'
-                      }`}
+                            : t.a11y.startRecording}
+                      </Button>
+                    </motion.div>
+                    <Button
+                      ref={resetButtonRef}
+                      variant="outline"
+                      onClick={handleReset}
+                      className="border-indigo-200 text-indigo-600 cursor-pointer"
                     >
-                      {isFallbackTranscribing ? (
-                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                      ) : isListening ? (
-                        <MicOff className="mr-2 h-4 w-4" />
-                      ) : (
-                        <Mic className="mr-2 h-4 w-4" />
-                      )}
-                      {isFallbackTranscribing
-                        ? t.recording.processingSpeech
-                        : isListening
-                          ? t.a11y.stopRecording
-                          : t.a11y.startRecording}
+                      <RotateCcw className="w-4 h-4 mr-2" /> {t.recording.reset}
                     </Button>
-                  </motion.div>
-                  <Button
-                    ref={resetButtonRef}
-                    variant="outline"
-                    onClick={handleReset}
-                    className="border-indigo-200 text-indigo-600 cursor-pointer"
-                  >
-                    <RotateCcw className="w-4 h-4 mr-2" /> {t.recording.reset}
-                  </Button>
+                  </div>
+                  {speechError && <p className="text-xs text-red-500 text-center max-w-md">{speechError}</p>}
+                  {phase === 'processing' && (
+                    <p className="text-xs text-amber-600 font-medium">{t.recording.processingSpeech}</p>
+                  )}
                 </div>
-                {speechError && <p className="text-xs text-red-500 text-center max-w-md">{speechError}</p>}
-                {phase === 'processing' && (
-                  <p className="text-xs text-amber-600 font-medium">{t.recording.processingSpeech}</p>
-                )}
-              </div>
-            </ReadAloudInlineControls>
-          )}
-          <ImmersiveReaderOverlay
-            text={content.text}
-            onPlay={handlePlayTTS}
-            onPause={handleReadAloudPause}
-            onNext={handleReadAloudNext}
-            onPrev={handleReadAloudPrev}
-            onWordClick={handleReadAloudWordClick}
-          />
-        </>
-      )}
+              </ReadAloudInlineControls>
+            )}
+            <ImmersiveReaderOverlay
+              text={content.text}
+              onPlay={handlePlayTTS}
+              onPause={handleReadAloudPause}
+              onNext={handleReadAloudNext}
+              onPrev={handleReadAloudPrev}
+              onWordClick={handleReadAloudWordClick}
+            />
+          </>
+        )}
+      </div>
 
       {ttsError && (
         <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 text-center">

--- a/src/components/read-aloud/read-aloud-content.test.tsx
+++ b/src/components/read-aloud/read-aloud-content.test.tsx
@@ -10,7 +10,7 @@ describe('ReadAloudContent', () => {
     useReadAloudStore.getState().deactivate();
   });
 
-  it('renders all words as clickable buttons', () => {
+  it('renders selectable word spans with spaces preserved for sentence selection', () => {
     useReadAloudStore.getState().activate(SAMPLE_TEXT);
     const markup = renderToStaticMarkup(<ReadAloudContent text={SAMPLE_TEXT} />);
 
@@ -21,8 +21,9 @@ describe('ReadAloudContent', () => {
     expect(markup).toContain('a');
     expect(markup).toContain('test.');
 
-    const buttonCount = (markup.match(/<button/g) || []).length;
-    expect(buttonCount).toBe(6);
+    expect(markup).toContain('select-text');
+    expect(markup.replace(/<[^>]+>/g, '')).toBe(SAMPLE_TEXT);
+    expect(markup).not.toContain('<button');
   });
 
   it('renders with data-testid attribute', () => {
@@ -31,11 +32,12 @@ describe('ReadAloudContent', () => {
     expect(markup).toContain('data-testid="read-aloud-content"');
   });
 
-  it('renders all buttons with type=button', () => {
+  it('keeps every word clickable without using native buttons', () => {
     useReadAloudStore.getState().activate(SAMPLE_TEXT);
     const markup = renderToStaticMarkup(<ReadAloudContent text={SAMPLE_TEXT} />);
-    const typeButtonCount = (markup.match(/type="button"/g) || []).length;
-    expect(typeButtonCount).toBe(6);
+    const wordCount = (markup.match(/data-read-aloud-word=/g) || []).length;
+    expect(wordCount).toBe(6);
+    expect(markup).toContain('role="button"');
   });
 
   it('renders sentence translations when showTranslation is true', () => {
@@ -77,8 +79,8 @@ describe('ReadAloudContent', () => {
     useReadAloudStore.getState().activate('');
     const markup = renderToStaticMarkup(<ReadAloudContent text="" />);
 
-    const buttonCount = (markup.match(/<button/g) || []).length;
-    expect(buttonCount).toBe(0);
+    const wordCount = (markup.match(/data-read-aloud-word=/g) || []).length;
+    expect(wordCount).toBe(0);
   });
 
   it('renders without crashing when store is not activated', () => {
@@ -97,7 +99,7 @@ describe('ReadAloudContent', () => {
     expect(markup).toContain('Second');
   });
 
-  it('applies cursor-pointer class to word buttons', () => {
+  it('applies cursor-pointer class to word spans', () => {
     useReadAloudStore.getState().activate(SAMPLE_TEXT);
     const markup = renderToStaticMarkup(<ReadAloudContent text={SAMPLE_TEXT} />);
     expect(markup).toContain('cursor-pointer');

--- a/src/components/read-aloud/read-aloud-content.tsx
+++ b/src/components/read-aloud/read-aloud-content.tsx
@@ -12,7 +12,7 @@ interface ReadAloudContentProps {
   sentenceTranslations?: Array<{ startWordIndex: number; endWordIndex: number; translation: string }> | null;
 }
 
-function WordButton({
+function SelectableWord({
   word,
   globalIndex,
   currentWordIndex,
@@ -29,7 +29,7 @@ function WordButton({
   isPlaying: boolean;
   onClick?: (word: string) => void;
 }) {
-  const ref = useRef<HTMLButtonElement>(null);
+  const ref = useRef<HTMLSpanElement>(null);
   const isCurrent = isPlaying && globalIndex === currentWordIndex;
   const isRead = isPlaying && currentWordIndex >= 0 && globalIndex < currentWordIndex;
   const isActiveSentence = isPlaying && currentSentenceIndex >= 0 && sentenceIndex === currentSentenceIndex;
@@ -41,12 +41,20 @@ function WordButton({
   }, [isCurrent]);
 
   return (
-    <button
+    <span
       ref={ref}
-      type="button"
-      onClick={() => onClick?.(word)}
+      role="button"
+      tabIndex={0}
+      data-read-aloud-word={globalIndex}
+      onClick={() => {
+        if (window.getSelection()?.isCollapsed !== false) onClick?.(word);
+      }}
+      onKeyDown={(event) => {
+        if (event.key === ' ') event.preventDefault();
+        if (event.key === 'Enter' || event.key === ' ') onClick?.(word);
+      }}
       className={cn(
-        'inline-block rounded-md px-1 py-0.5 cursor-pointer transition-all duration-300 ease-out',
+        'inline rounded-md px-0.5 py-0.5 cursor-pointer select-text transition-all duration-300 ease-out',
         isCurrent
           ? 'font-semibold scale-[1.06] text-white'
           : isRead
@@ -65,7 +73,7 @@ function WordButton({
       }
     >
       {word}
-    </button>
+    </span>
   );
 }
 
@@ -99,21 +107,23 @@ function SentenceBlock({
                 : 'text-[17px] leading-8 text-slate-700'
         }
       >
-        <div className="flex flex-wrap items-baseline gap-x-1 gap-y-2">
+        <div className="select-text">
           {block.words.map((word, localIndex) => {
             const globalIndex = block.wordStart + localIndex;
             const wordSentenceIndex = getSentenceIndex(globalIndex);
             return (
-              <WordButton
-                key={`${block.id}-${globalIndex}`}
-                word={word}
-                globalIndex={globalIndex}
-                currentWordIndex={currentWordIndex}
-                currentSentenceIndex={currentSentenceIndex}
-                sentenceIndex={wordSentenceIndex}
-                isPlaying={isPlaying}
-                onClick={onWordClick}
-              />
+              <span key={`${block.id}-${globalIndex}`}>
+                <SelectableWord
+                  word={word}
+                  globalIndex={globalIndex}
+                  currentWordIndex={currentWordIndex}
+                  currentSentenceIndex={currentSentenceIndex}
+                  sentenceIndex={wordSentenceIndex}
+                  isPlaying={isPlaying}
+                  onClick={onWordClick}
+                />
+                {localIndex < block.words.length - 1 ? ' ' : null}
+              </span>
             );
           })}
         </div>

--- a/src/components/selection-translation/selection-translation-provider.test.ts
+++ b/src/components/selection-translation/selection-translation-provider.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(new URL('./selection-translation-provider.tsx', import.meta.url), 'utf8');
+
+describe('selection translation triggers', () => {
+  it('handles pointer and native selection completion instead of mouseup only', () => {
+    expect(source).toContain("document.addEventListener('pointerup'");
+    expect(source).toContain("document.addEventListener('selectionchange'");
+    expect(source).not.toContain("document.addEventListener('mouseup'");
+    expect(source).toContain('lastHandledSelectionRef');
+    expect(source).toMatch(/handlePointerUp[\s\S]*clearTimeout\(selectionTimer\)/);
+  });
+});

--- a/src/components/selection-translation/selection-translation-provider.tsx
+++ b/src/components/selection-translation/selection-translation-provider.tsx
@@ -5,6 +5,7 @@ import { createContext, useCallback, useContext, useEffect, useRef, useState } f
 import { PROVIDER_REGISTRY } from '@/lib/providers';
 import {
   buildSelectionTextPayload,
+  extractSentenceAroundOffsets,
   getSelectionFavoriteText,
   getSelectionHistoryText,
   getSelectionTranslationText,
@@ -66,21 +67,17 @@ function getModuleFromPathname(pathname: string): string | undefined {
 
 function extractContextSentence(selection: Selection): string | undefined {
   const range = selection.getRangeAt(0);
-  const container = range.startContainer;
-  if (container.nodeType !== Node.TEXT_NODE) return undefined;
-  const fullText = container.textContent || '';
-  // Find sentence boundaries around selection
-  const selectedText = selection.toString().trim();
-  const idx = fullText.indexOf(selectedText);
-  if (idx === -1) return fullText.trim();
-  // Look backward for sentence start
-  let start = idx;
-  while (start > 0 && !/[.!?]/.test(fullText[start - 1]!)) start--;
-  // Look forward for sentence end
-  let end = idx + selectedText.length;
-  while (end < fullText.length && !/[.!?]/.test(fullText[end]!)) end++;
-  if (end < fullText.length) end++; // include the punctuation
-  return fullText.slice(start, end).trim();
+  const container = range.commonAncestorContainer;
+  const element = container instanceof Element ? container : container.parentElement;
+  const scope = element?.closest('[data-selection-scope]') ?? element;
+  if (!scope?.textContent) return undefined;
+
+  const before = range.cloneRange();
+  before.selectNodeContents(scope);
+  before.setEnd(range.startContainer, range.startOffset);
+  const selectionStart = before.toString().length;
+
+  return extractSentenceAroundOffsets(scope.textContent, selectionStart, selectionStart + range.toString().length);
 }
 
 export function SelectionTranslationProvider({ children }: { children: React.ReactNode }) {
@@ -93,6 +90,12 @@ export function SelectionTranslationProvider({ children }: { children: React.Rea
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const abortRef = useRef<AbortController>(undefined);
   const selectionIdRef = useRef(0);
+  const lastHandledSelectionRef = useRef<{
+    anchorNode: Node | null;
+    anchorOffset: number;
+    focusNode: Node | null;
+    focusOffset: number;
+  } | null>(null);
 
   const enabled = useFavoriteStore((s) => s.selectionTranslateEnabled);
   const targetLang = useTTSStore((s) => s.targetLang);
@@ -118,6 +121,7 @@ export function SelectionTranslationProvider({ children }: { children: React.Rea
     setIsLoading(false);
     if (debounceRef.current) clearTimeout(debounceRef.current);
     if (abortRef.current) abortRef.current.abort();
+    lastHandledSelectionRef.current = null;
   }, []);
 
   // Dismiss on route change
@@ -226,16 +230,18 @@ export function SelectionTranslationProvider({ children }: { children: React.Rea
     [targetLang, activeProviderId, activeApiKey, providerConfigs, pathname],
   );
 
-  // Mouseup handler
+  // Native selection completion handler
   useEffect(() => {
     if (!enabled) return;
 
-    const handleMouseUp = (e: MouseEvent) => {
+    let selectionTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const handleSelection = (targetNode?: EventTarget | null) => {
       // Check if click is inside popup
-      if (popupRef.current?.contains(e.target as Node)) return;
+      if (targetNode instanceof Node && popupRef.current?.contains(targetNode)) return;
 
       // Check exclusion zones
-      const target = e.target instanceof HTMLElement ? e.target : (e.target as Node).parentElement;
+      const target = targetNode instanceof HTMLElement ? targetNode : (targetNode as Node | null)?.parentElement;
       if (target?.closest(EXCLUSION_SELECTORS)) {
         return;
       }
@@ -245,9 +251,26 @@ export function SelectionTranslationProvider({ children }: { children: React.Rea
 
       const selection = document.getSelection();
       if (!selection || selection.isCollapsed) {
+        lastHandledSelectionRef.current = null;
         dismiss();
         return;
       }
+
+      const previous = lastHandledSelectionRef.current;
+      if (
+        previous?.anchorNode === selection.anchorNode &&
+        previous.anchorOffset === selection.anchorOffset &&
+        previous.focusNode === selection.focusNode &&
+        previous.focusOffset === selection.focusOffset
+      ) {
+        return;
+      }
+      lastHandledSelectionRef.current = {
+        anchorNode: selection.anchorNode,
+        anchorOffset: selection.anchorOffset,
+        focusNode: selection.focusNode,
+        focusOffset: selection.focusOffset,
+      };
 
       const text = selection.toString().trim();
       if (!text || text.length > 500) {
@@ -297,8 +320,23 @@ export function SelectionTranslationProvider({ children }: { children: React.Rea
       }, 300);
     };
 
-    document.addEventListener('mouseup', handleMouseUp);
-    return () => document.removeEventListener('mouseup', handleMouseUp);
+    const handlePointerUp = (event: PointerEvent) => {
+      if (selectionTimer) clearTimeout(selectionTimer);
+      selectionTimer = undefined;
+      handleSelection(event.target);
+    };
+    const handleSelectionChange = () => {
+      if (selectionTimer) clearTimeout(selectionTimer);
+      selectionTimer = setTimeout(() => handleSelection(), 160);
+    };
+
+    document.addEventListener('pointerup', handlePointerUp);
+    document.addEventListener('selectionchange', handleSelectionChange);
+    return () => {
+      if (selectionTimer) clearTimeout(selectionTimer);
+      document.removeEventListener('pointerup', handlePointerUp);
+      document.removeEventListener('selectionchange', handleSelectionChange);
+    };
   }, [enabled, pathname, dismiss, translate, createSelectionState]);
 
   // Esc to dismiss

--- a/src/lib/__tests__/selection-translation-text.test.ts
+++ b/src/lib/__tests__/selection-translation-text.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   buildSelectionTextPayload,
+  extractSentenceAroundOffsets,
   getSelectionFavoriteText,
   getSelectionHistoryText,
   getSelectionTranslationText,
@@ -8,6 +9,16 @@ import {
 } from '../selection-translation-text';
 
 describe('buildSelectionTextPayload', () => {
+  it('extracts the complete sentence when a selection spans rendered text nodes', () => {
+    const text = 'Have you ever had a conversation with someone and they just could not understand you? If so, pause.';
+    const selected = 'conversation with someone';
+    const start = text.indexOf(selected);
+
+    expect(extractSentenceAroundOffsets(text, start, start + selected.length)).toBe(
+      'Have you ever had a conversation with someone and they just could not understand you?',
+    );
+  });
+
   it('sanitizes inline explanations from selection text', () => {
     const payload = buildSelectionTextPayload(
       'Will someone take out the trash (= take it outside the house)?',

--- a/src/lib/selection-translation-text.ts
+++ b/src/lib/selection-translation-text.ts
@@ -4,6 +4,21 @@ export interface SelectionTextPayload {
   favoriteText: string;
 }
 
+export function extractSentenceAroundOffsets(fullText: string, selectionStart: number, selectionEnd: number): string {
+  if (!fullText) return '';
+
+  const safeStart = Math.max(0, Math.min(selectionStart, fullText.length));
+  const safeEnd = Math.max(safeStart, Math.min(selectionEnd, fullText.length));
+  let start = safeStart;
+  let end = safeEnd;
+
+  while (start > 0 && !/[.!?]/.test(fullText[start - 1]!)) start--;
+  while (end < fullText.length && !/[.!?]/.test(fullText[end]!)) end++;
+  if (end < fullText.length) end++;
+
+  return normalizeWhitespace(fullText.slice(start, end));
+}
+
 function normalizeWhitespace(text: string): string {
   return text.trim().replace(/\s+/g, ' ');
 }


### PR DESCRIPTION
## What changed

- keep the Read practice workspace within the remaining viewport
- make long reference text scroll inside its card while controls remain visible below it
- render read-aloud words as selectable text while preserving click and keyboard pronunciation
- handle pointer and native selection completion reliably
- extract sentence context across rendered text nodes
- deduplicate selection events so one selection sends one translation request

## Root cause

The long article card had no height boundary, so it pushed the controls below the entire document. Read-aloud mode also rendered every word as a separate native button, which prevented reliable sentence selection. The selection provider then handled `selectionchange` and `pointerup` twice for the same range.

## Validation

- full `pnpm test` suite
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- browser-tested desktop and 390x844 mobile layouts
- verified long content scrolls internally with page scroll at zero
- verified a complete 30-word sentence selection and Chinese translation
- verified one translation request per selection