### PR TITLE
[codex] Stabilize Read practice feedback

### DIFF
--- a/e2e/read-word-highlight.spec.ts
+++ b/e2e/read-word-highlight.spec.ts
@@ -116,15 +116,24 @@ test.describe('Read word highlight', () => {
 
     await page.getByRole('button', { name: /Listen Along|Stop/ }).click();
 
+    await expect
+      .poll(async () => {
+        const value = await page
+          .getByRole('progressbar', { name: 'Read controls progress' })
+          .getAttribute('aria-valuenow');
+        return Number(value ?? 0);
+      })
+      .toBeGreaterThan(0);
+
     await page.waitForFunction(() => {
-      return Array.from(document.querySelectorAll('[data-testid="read-aloud-content"] button')).some((button) => {
-        const style = button.getAttribute('style') || '';
-        const cls = String(button.className || '');
-        return style.includes('linear-gradient') || cls.includes('text-white');
+      return Array.from(document.querySelectorAll('[data-read-aloud-word]')).some((word) => {
+        return window.getComputedStyle(word).backgroundColor === 'rgb(249, 115, 22)';
       });
     });
 
-    const highlightedWordCount = await page.locator('[data-testid="read-aloud-content"] button[style*="linear-gradient"]').count();
+    const highlightedWordCount = await page.locator('[data-read-aloud-word]').evaluateAll((words) => {
+      return words.filter((word) => window.getComputedStyle(word).backgroundColor === 'rgb(249, 115, 22)').length;
+    });
     expect(highlightedWordCount).toBeGreaterThan(0);
   });
 });

--- a/e2e/read.spec.ts
+++ b/e2e/read.spec.ts
@@ -1,5 +1,72 @@
 import { expect, test } from '@playwright/test';
 
+async function installSpeechRecognitionMock(page: import('@playwright/test').Page) {
+  await page.addInitScript(() => {
+    class FakeSpeechRecognition {
+      static activeInstance: FakeSpeechRecognition | null = null;
+      continuous = true;
+      interimResults = true;
+      lang = 'en-US';
+      onresult: ((event: SpeechRecognitionEvent) => void) | null = null;
+      onerror: ((event: SpeechRecognitionErrorEvent) => void) | null = null;
+      onend: (() => void) | null = null;
+
+      start() {
+        FakeSpeechRecognition.activeInstance = this;
+      }
+
+      stop() {
+        this.onend?.();
+      }
+
+      abort() {
+        if (FakeSpeechRecognition.activeInstance === this) FakeSpeechRecognition.activeInstance = null;
+      }
+
+      static emit(text: string, isFinal: boolean) {
+        const instance = FakeSpeechRecognition.activeInstance;
+        if (!instance?.onresult) return;
+
+        const result = {
+          0: { transcript: text, confidence: 1 },
+          isFinal,
+          length: 1,
+          item(index: number) {
+            return this[index as 0];
+          },
+        };
+
+        instance.onresult({
+          resultIndex: 0,
+          results: {
+            0: result,
+            length: 1,
+            item(index: number) {
+              return this[index as 0];
+            },
+          },
+        } as SpeechRecognitionEvent);
+      }
+
+      static endUnexpectedly() {
+        FakeSpeechRecognition.activeInstance?.onend?.();
+      }
+    }
+
+    const speechWindow = window as Window & typeof globalThis & {
+      SpeechRecognition?: typeof FakeSpeechRecognition;
+      webkitSpeechRecognition?: typeof FakeSpeechRecognition;
+      __emitReadSpeech?: (text: string, isFinal: boolean) => void;
+      __endReadSpeech?: () => void;
+    };
+
+    speechWindow.SpeechRecognition = FakeSpeechRecognition;
+    speechWindow.webkitSpeechRecognition = FakeSpeechRecognition;
+    speechWindow.__emitReadSpeech = (text, isFinal) => FakeSpeechRecognition.emit(text, isFinal);
+    speechWindow.__endReadSpeech = () => FakeSpeechRecognition.endUnexpectedly();
+  });
+}
+
 async function waitForSeedAndReload(page: import('@playwright/test').Page, url: string) {
   await page.goto(url);
   await page.waitForSelector('main[data-seeded="true"]', { timeout: 15000 });
@@ -21,7 +88,9 @@ test.describe('Read Module', () => {
   test('read list page loads with content', async ({ page }) => {
     await waitForSeedAndReload(page, '/read');
     await expect(page.getByRole('heading', { level: 1 })).toContainText('Read');
-    await expect(page.getByText('Read English content aloud and get pronunciation feedback')).toBeVisible();
+    await expect(
+      page.getByRole('main').getByText('Read English content aloud and get pronunciation feedback').first(),
+    ).toBeVisible();
 
     const items = page.locator('[class*="grid gap"] a');
     await expect(items.first()).toBeVisible({ timeout: 10000 });
@@ -40,6 +109,81 @@ test.describe('Read Module', () => {
     await expect(page.getByRole('heading', { name: 'Your Speech' })).toHaveCount(0);
     await expect(page.getByRole('heading', { name: 'Live Reading Feedback' })).toHaveCount(0);
     await expect(page.getByRole('heading', { name: 'Your Results' })).toHaveCount(0);
+  });
+
+  async function startMockReading(page: import('@playwright/test').Page) {
+    await installSpeechRecognitionMock(page);
+    await openFirstReadDetail(page);
+
+    const spokenWords = (await page.locator('[data-read-aloud-word]').allTextContents()).slice(0, 3);
+    expect(spokenWords).toHaveLength(3);
+
+    await page.getByRole('button', { name: 'Start recording' }).click();
+    await page.evaluate((text) => {
+      const speechWindow = window as Window & typeof globalThis & {
+        __emitReadSpeech?: (value: string, isFinal: boolean) => void;
+      };
+      speechWindow.__emitReadSpeech?.(text, true);
+    }, spokenWords.join(' '));
+
+    await expect(page.getByText('3 words processed')).toBeVisible();
+  }
+
+  test('updates microphone reading progress as words are recognized', async ({ page }) => {
+    await startMockReading(page);
+
+    const progress = page.getByRole('progressbar', { name: 'Read controls progress' });
+    await expect
+      .poll(async () => Number((await progress.getAttribute('aria-valuenow')) ?? 0))
+      .toBeGreaterThan(0);
+  });
+
+  test('keeps recording when browser speech recognition ends unexpectedly', async ({ page }) => {
+    await startMockReading(page);
+
+    await page.evaluate(() => {
+      const speechWindow = window as Window & typeof globalThis & { __endReadSpeech?: () => void };
+      speechWindow.__endReadSpeech?.();
+    });
+
+    await expect(page.getByRole('button', { name: 'Stop recording' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Your Results' })).toHaveCount(0);
+  });
+
+  test('shows reading results without celebration UI after the user stops', async ({ page }) => {
+    await startMockReading(page);
+
+    await page.getByRole('button', { name: 'Stop recording' }).click({ force: true });
+    await expect(page.getByRole('heading', { name: 'Your Results' })).toBeVisible();
+    await expect(page.getByText('Read Aloud Complete!')).toHaveCount(0);
+    await expect(page.locator('canvas')).toHaveCount(0);
+  });
+
+  test('passes the mouse wheel to the page when the reference text does not overflow', async ({ page }) => {
+    await openFirstReadDetail(page);
+
+    const main = page.locator('main').first();
+    const reference = page.getByTestId('read-reference-scroll');
+    const sizes = await page.evaluate(() => {
+      const mainElement = document.querySelector('main');
+      const referenceElement = document.querySelector('[data-testid="read-reference-scroll"]');
+      if (!(mainElement instanceof HTMLElement) || !(referenceElement instanceof HTMLElement)) return null;
+      mainElement.scrollTop = 0;
+      return {
+        mainClientHeight: mainElement.clientHeight,
+        mainScrollHeight: mainElement.scrollHeight,
+        referenceClientHeight: referenceElement.clientHeight,
+        referenceScrollHeight: referenceElement.scrollHeight,
+      };
+    });
+
+    expect(sizes).not.toBeNull();
+    expect(sizes!.mainScrollHeight).toBeGreaterThan(sizes!.mainClientHeight);
+    expect(sizes!.referenceScrollHeight).toBeLessThanOrEqual(sizes!.referenceClientHeight + 1);
+
+    await reference.hover();
+    await page.mouse.wheel(0, 600);
+    await expect.poll(() => main.evaluate((element) => element.scrollTop)).toBeGreaterThan(0);
   });
 
   test('read detail back button returns to list', async ({ page }) => {

--- a/e2e/wordbook-practice.spec.ts
+++ b/e2e/wordbook-practice.spec.ts
@@ -303,6 +303,46 @@ test.describe('WordBook Practice – Write', () => {
 
     await expect(page.getByText('Session Complete!')).toBeVisible({ timeout: 3000 });
     await expect(page.locator('.bg-green-50').filter({ hasText: 'Completed' }).getByText('1', { exact: true })).toBeVisible();
+    await expect(page.locator('canvas')).toHaveCount(0);
+  });
+
+  test('shows the completion celebration only for a matching daily-plan task', async ({ page }) => {
+    await page.addInitScript((bookId) => {
+      localStorage.setItem(
+        'echotype_daily_plan',
+        JSON.stringify({
+          goal: { wordsPerDay: 20, sessionsPerDay: 4 },
+          tasks: [
+            {
+              id: 'daily-wordbook-task',
+              type: 'new-words',
+              title: 'Learn 1 new word',
+              description: 'Daily plan',
+              module: 'write',
+              bookId,
+              limit: 1,
+              completed: false,
+              skipped: false,
+            },
+          ],
+          dateKey: '',
+          dataSignature: '',
+          levelKey: '',
+          streak: 0,
+          lastActiveDate: '',
+        }),
+      );
+    }, BOOK_ID);
+    await page.goto(`/write/book/${BOOK_ID}?limit=1`);
+    await waitForPracticeCard(page);
+
+    const textContent = await page.locator('.bg-indigo-50\\/50 p').textContent();
+    expect(textContent).toBeTruthy();
+    await page.getByPlaceholder('Type the text above...').fill(textContent!);
+    await page.getByRole('button', { name: 'Check' }).click();
+
+    await expect(page.getByText('Session Complete!')).toBeVisible({ timeout: 3000 });
+    await expect(page.locator('canvas')).toHaveCount(1);
   });
 });
 

--- a/src/__tests__/daily-plan.test.ts
+++ b/src/__tests__/daily-plan.test.ts
@@ -251,7 +251,7 @@ describe('generateDailyPlan', () => {
       ];
       // No records = all are unpracticed
 
-      const tasks = await generateDailyPlan(defaultGoal);
+      const tasks = await generateDailyPlan(defaultGoal, { currentLevel: 'B2' });
       const newWordsTask = tasks.find((t) => t.type === 'new-words');
       expect(newWordsTask).toBeDefined();
       expect(newWordsTask!.title).toContain('20');
@@ -272,12 +272,12 @@ describe('generateDailyPlan', () => {
     });
 
     it('skips wordbook where all words are already practiced', async () => {
-      mockContents = [
-        makeContent({ id: 'w1', category: 'cet4', type: 'word' }),
-      ];
-      mockRecords = [
-        makeRecord({ contentId: 'w1', nextReview: Date.now() + 86400000 }), // not due
-      ];
+      mockContents = Array.from({ length: 4500 }, (_, index) =>
+        makeContent({ id: `cet4-${index}`, category: 'cet4', type: 'word' }),
+      );
+      mockRecords = mockContents.map((content) =>
+        makeRecord({ contentId: content.id, nextReview: Date.now() + 86400000 }), // not due
+      );
 
       const tasks = await generateDailyPlan(defaultGoal);
       expect(tasks.find((t) => t.type === 'new-words')?.bookId).not.toBe('cet4');

--- a/src/app/(app)/listen/[id]/page.tsx
+++ b/src/app/(app)/listen/[id]/page.tsx
@@ -42,6 +42,7 @@ import { cn } from '@/lib/utils';
 import { resolveWeakSpot, upsertWeakSpot } from '@/lib/weak-spots';
 import { fetchAlignment, matchTimestampsToText, WordAlignmentPlayer } from '@/lib/word-alignment';
 import { useContentStore } from '@/stores/content-store';
+import { useDailyPlanStore } from '@/stores/daily-plan-store';
 import { useLanguageStore } from '@/stores/language-store';
 import { usePracticeTranslationStore } from '@/stores/practice-translation-store';
 import { useReadAloudStore } from '@/stores/read-aloud-store';
@@ -103,6 +104,11 @@ export default function ListenDetailPage() {
   const shadowReadingSession = useShadowReadingStore((s) => s.session);
   const markModuleProgress = useShadowReadingStore((s) => s.markModuleProgress);
   const [sessionCompleted, setSessionCompleted] = useState(false);
+  const isDailyPlanPractice = useDailyPlanStore((s) =>
+    s.tasks.some(
+      (task) => !task.completed && !task.skipped && task.module === 'listen' && task.contentId === params.id,
+    ),
+  );
   const { addContent } = useContentStore();
 
   const raActivate = useReadAloudStore((s) => s.activate);
@@ -1265,7 +1271,7 @@ export default function ListenDetailPage() {
         onWordClick={handleWordClick}
       />
 
-      {sessionCompleted && <PracticeCompleteBanner module="listen" />}
+      {sessionCompleted && isDailyPlanPractice && <PracticeCompleteBanner module="listen" />}
 
       {recommendationsEnabled && <RecommendationPanel content={content} onNavigate={handleRecommendationNavigate} />}
     </div>

--- a/src/app/(app)/read/[id]/page.tsx
+++ b/src/app/(app)/read/[id]/page.tsx
@@ -49,10 +49,12 @@ import {
 import { estimateSentenceHighlightTimings } from '@/lib/listen-highlight';
 import { attachWordBoundaryTracking, isSpeechSynthesisUtteranceResult } from '@/lib/read-aloud-playback';
 import { matchesShortcutEvent } from '@/lib/shortcut-utils';
+import { joinSpeechTranscripts } from '@/lib/speech-feedback';
 import { detectIOSNativeHost, IS_TAURI, reportNativeQAState } from '@/lib/tauri';
 import { cn } from '@/lib/utils';
 import { fetchAlignment, matchTimestampsToText, WordAlignmentPlayer } from '@/lib/word-alignment';
 import { useContentStore } from '@/stores/content-store';
+import { useDailyPlanStore } from '@/stores/daily-plan-store';
 import { useLanguageStore } from '@/stores/language-store';
 import { usePracticeTranslationStore } from '@/stores/practice-translation-store';
 import { useReadAloudStore } from '@/stores/read-aloud-store';
@@ -62,6 +64,7 @@ import { useTTSStore } from '@/stores/tts-store';
 import type { ContentItem } from '@/types/content';
 
 const READ_DETAIL_LOCALES = { en: enReadDetail, zh: zhReadDetail } as const;
+const MAX_SPEECH_RECOGNITION_RESTARTS = 20;
 
 type ReadPracticePhase = 'idle' | 'listening' | 'processing' | 'completed';
 type LiveFeedbackResult = ProgressiveWordResult & {
@@ -85,10 +88,14 @@ export default function ReadDetailPage() {
   const transcriptRef = useRef('');
   const interimTranscriptRef = useRef('');
   const hasPersistedResultRef = useRef(false);
+  const recognitionActiveRef = useRef(false);
+  const recognitionIntentionalStopRef = useRef(false);
+  const recognitionRestartCountRef = useRef(0);
+  const recognitionBaseTranscriptRef = useRef('');
+  const recognitionSessionFinalRef = useRef('');
   const useNative = useRef(
     typeof window !== 'undefined' && !IS_TAURI && !!(window.SpeechRecognition || window.webkitSpeechRecognition),
   );
-  const [sessionCompleted, setSessionCompleted] = useState(false);
   const isIOSNativeHost = detectIOSNativeHost();
   const pronunciation = usePronunciation({ referenceText: content?.text || '' });
   const showTranslation = usePracticeTranslationStore((s) => s.visibility.read);
@@ -96,6 +103,9 @@ export default function ReadDetailPage() {
   const recommendationsEnabled = useTTSStore((s) => s.recommendationsEnabled);
   const shadowReadingSession = useShadowReadingStore((s) => s.session);
   const markModuleProgress = useShadowReadingStore((s) => s.markModuleProgress);
+  const isDailyPlanPractice = useDailyPlanStore((s) =>
+    s.tasks.some((task) => !task.completed && !task.skipped && task.module === 'read' && task.contentId === params.id),
+  );
   const { addContent } = useContentStore();
   const {
     sentenceTranslations,
@@ -289,6 +299,15 @@ export default function ReadDetailPage() {
     }));
   }, [interimTranscript, phase, referenceWords, transcript]);
 
+  const readPracticeProgress = useMemo(() => {
+    if (phase === 'idle' || referenceWords.length === 0) return undefined;
+    const recognizedWordCount = `${transcript} ${interimTranscript}`
+      .split(/\s+/)
+      .map((word) => word.replace(/[^a-zA-Z']/g, ''))
+      .filter(Boolean).length;
+    return (Math.min(recognizedWordCount, referenceWords.length) / referenceWords.length) * 100;
+  }, [interimTranscript, phase, referenceWords.length, transcript]);
+
   useEffect(() => {
     reportNativeQAState({
       page: 'read-detail',
@@ -297,9 +316,9 @@ export default function ReadDetailPage() {
       phase,
       isListening,
       hasResults: !!results,
-      sessionCompleted,
+      sessionCompleted: phase === 'completed',
     });
-  }, [content, isListening, phase, results, sessionCompleted]);
+  }, [content, isListening, phase, results]);
 
   // Fallback STT for Tauri / browsers without SpeechRecognition
   const fallbackSTT = useFallbackSTT({
@@ -346,22 +365,61 @@ export default function ReadDetailPage() {
           interim += result[0].transcript;
         }
       }
-      transcriptRef.current = final;
+      recognitionSessionFinalRef.current = final.trim();
+      const confirmed = joinSpeechTranscripts(recognitionBaseTranscriptRef.current, final);
+      transcriptRef.current = confirmed;
       interimTranscriptRef.current = interim;
-      setTranscript(final);
+      setTranscript(confirmed);
       setInterimTranscript(interim);
     };
 
-    rec.onerror = () => {
+    rec.onerror = (event: SpeechRecognitionErrorEvent) => {
+      if (event.error === 'aborted' && recognitionIntentionalStopRef.current) return;
+      if (event.error === 'no-speech' && recognitionActiveRef.current) return;
+      recognitionActiveRef.current = false;
       setIsListening(false);
     };
 
     rec.onend = () => {
+      if (!recognitionActiveRef.current) return;
+
+      if (
+        !recognitionIntentionalStopRef.current &&
+        recognitionRestartCountRef.current < MAX_SPEECH_RECOGNITION_RESTARTS
+      ) {
+        recognitionRestartCountRef.current += 1;
+        recognitionBaseTranscriptRef.current = joinSpeechTranscripts(
+          recognitionBaseTranscriptRef.current,
+          recognitionSessionFinalRef.current,
+        );
+        recognitionSessionFinalRef.current = '';
+        transcriptRef.current = recognitionBaseTranscriptRef.current;
+        interimTranscriptRef.current = '';
+        setTranscript(recognitionBaseTranscriptRef.current);
+        setInterimTranscript('');
+        try {
+          rec.start();
+          return;
+        } catch {
+          // The browser refused an automatic restart. Keep the partial result without completing the session.
+        }
+      }
+
+      recognitionActiveRef.current = false;
       setIsListening(false);
-      finalizePracticeRef.current();
+      if (recognitionIntentionalStopRef.current) {
+        finalizePracticeRef.current();
+      }
     };
 
     recognitionRef.current = rec;
+
+    return () => {
+      recognitionActiveRef.current = false;
+      recognitionIntentionalStopRef.current = true;
+      rec.abort();
+      if (recognitionRef.current === rec) recognitionRef.current = null;
+    };
   }, [t.recording.speechNotSupported]);
 
   const finalizePractice = useCallback(() => {
@@ -393,7 +451,6 @@ export default function ReadDetailPage() {
       accuracy,
       completed: true,
     });
-    setSessionCompleted(true);
     if (shadowReadingSession?.contentId === content.id) {
       markModuleProgress('read', 'completed');
     }
@@ -411,17 +468,23 @@ export default function ReadDetailPage() {
     transcriptRef.current = '';
     interimTranscriptRef.current = '';
     hasPersistedResultRef.current = false;
+    recognitionActiveRef.current = false;
+    recognitionIntentionalStopRef.current = false;
+    recognitionRestartCountRef.current = 0;
+    recognitionBaseTranscriptRef.current = '';
+    recognitionSessionFinalRef.current = '';
     setTranscript('');
     setInterimTranscript('');
     setResults(null);
-    setSessionCompleted(false);
     speakStartRef.current = Date.now();
 
     if (useNative.current && recognitionRef.current) {
+      recognitionActiveRef.current = true;
       try {
         recognitionRef.current.start();
         setIsListening(true);
       } catch (err) {
+        recognitionActiveRef.current = false;
         console.error('Speech recognition start failed:', err);
         setSpeechError(
           t.recording.failedToStart.replace('{{error}}', err instanceof Error ? err.message : String(err)),
@@ -445,9 +508,8 @@ export default function ReadDetailPage() {
     }
 
     if (useNative.current && recognitionRef.current) {
+      recognitionIntentionalStopRef.current = true;
       recognitionRef.current.stop();
-      setIsListening(false);
-      finalizePractice();
     } else {
       fallbackSTT.stopRecording();
       setIsFallbackTranscribing(true);
@@ -966,6 +1028,8 @@ export default function ReadDetailPage() {
   );
 
   const handleReset = () => {
+    recognitionActiveRef.current = false;
+    recognitionIntentionalStopRef.current = true;
     recognitionRef.current?.abort();
     fallbackSTT.stopRecording();
     setIsListening(false);
@@ -973,6 +1037,8 @@ export default function ReadDetailPage() {
     transcriptRef.current = '';
     interimTranscriptRef.current = '';
     hasPersistedResultRef.current = false;
+    recognitionBaseTranscriptRef.current = '';
+    recognitionSessionFinalRef.current = '';
     pronunciation.clearResult();
     flushSync(() => {
       setTranscript('');
@@ -1133,7 +1199,7 @@ export default function ReadDetailPage() {
               data-testid="read-reference-scroll"
               data-selection-scope
               className={cn(
-                'min-h-0 flex-1 overflow-y-auto overscroll-contain pr-2',
+                'min-h-0 flex-1 overflow-y-auto pr-2',
                 isIOSNativeHost && `${IOS_LIST_CARD_CLASS} px-4 py-4`,
               )}
             >
@@ -1204,6 +1270,7 @@ export default function ReadDetailPage() {
                 onPause={handleReadAloudPause}
                 onNext={handleReadAloudNext}
                 onPrev={handleReadAloudPrev}
+                progress={readPracticeProgress}
               />
             ) : (
               <ReadAloudInlineControls
@@ -1213,6 +1280,7 @@ export default function ReadDetailPage() {
                 onPause={handleReadAloudPause}
                 onNext={handleReadAloudNext}
                 onPrev={handleReadAloudPrev}
+                progress={readPracticeProgress}
               >
                 <div className="flex flex-col items-center gap-2">
                   <div className="flex items-center justify-center gap-3">
@@ -1342,7 +1410,7 @@ export default function ReadDetailPage() {
         )}
       </AnimatePresence>
 
-      {sessionCompleted && <PracticeCompleteBanner module="read" />}
+      {phase === 'completed' && isDailyPlanPractice && <PracticeCompleteBanner module="read" />}
 
       {recommendationsEnabled && <RecommendationPanel content={content} onNavigate={handleRecommendationNavigate} />}
     </div>

--- a/src/app/(app)/write/[id]/page.tsx
+++ b/src/app/(app)/write/[id]/page.tsx
@@ -9,7 +9,7 @@ import { CrossModuleNav } from '@/components/shared/cross-module-nav';
 import { FormattedContentText } from '@/components/shared/formatted-content-text';
 import { IOS_LIST_CARD_CLASS, IOS_SECTION_CARD_CLASS } from '@/components/shared/ios-native-ui';
 import { PageSpinner } from '@/components/shared/page-spinner';
-import { fireConfetti } from '@/components/shared/practice-complete-banner';
+import { PracticeCompleteBanner } from '@/components/shared/practice-complete-banner';
 import { RecommendationPanel } from '@/components/shared/recommendation-panel';
 import { ShadowReadingProgressBar } from '@/components/shared/shadow-reading-progress-bar';
 import { TranslationBar } from '@/components/translation/translation-bar';
@@ -30,6 +30,7 @@ import { matchesShortcutEvent } from '@/lib/shortcut-utils';
 import { detectIOSNativeHost, reportNativeQAState } from '@/lib/tauri';
 import { cn } from '@/lib/utils';
 import { useContentStore } from '@/stores/content-store';
+import { useDailyPlanStore } from '@/stores/daily-plan-store';
 import { useLanguageStore } from '@/stores/language-store';
 import { usePracticeTranslationStore } from '@/stores/practice-translation-store';
 import { useShadowReadingStore } from '@/stores/shadow-reading-store';
@@ -75,6 +76,9 @@ export default function WriteDetailPage() {
   const recommendationsEnabled = useTTSStore((s) => s.recommendationsEnabled);
   const shadowReadingSession = useShadowReadingStore((s) => s.session);
   const markModuleProgress = useShadowReadingStore((s) => s.markModuleProgress);
+  const isDailyPlanPractice = useDailyPlanStore((s) =>
+    s.tasks.some((task) => !task.completed && !task.skipped && task.module === 'write' && task.contentId === params.id),
+  );
   const { addContent } = useContentStore();
   const { speak } = useTTS();
   const {
@@ -209,15 +213,6 @@ export default function WriteDetailPage() {
   useEffect(() => {
     if (state.mode === 'finished' && content) {
       const isShadowContent = shadowReadingSession?.contentId === content.id;
-      const willTriggerShadowCompletion =
-        isShadowContent &&
-        shadowReadingSession.moduleProgress.listen === 'completed' &&
-        shadowReadingSession.moduleProgress.read === 'completed';
-
-      if (!willTriggerShadowCompletion) {
-        fireConfetti();
-      }
-
       const session = {
         id: nanoid(),
         contentId: content.id,
@@ -725,6 +720,8 @@ export default function WriteDetailPage() {
           </CardContent>
         </Card>
       )}
+
+      {state.mode === 'finished' && isDailyPlanPractice && <PracticeCompleteBanner module="write" />}
 
       {recommendationsEnabled && <RecommendationPanel content={content} onNavigate={handleRecommendationNavigate} />}
     </div>

--- a/src/components/read-aloud/ios-read-aloud-controls.tsx
+++ b/src/components/read-aloud/ios-read-aloud-controls.tsx
@@ -21,6 +21,7 @@ interface IOSReadAloudControlsProps {
   onPrev: () => void;
   onNext: () => void;
   onRestart?: () => void;
+  progress?: number;
 }
 
 export function IOSReadAloudControls({
@@ -31,6 +32,7 @@ export function IOSReadAloudControls({
   onPrev,
   onNext,
   onRestart,
+  progress: progressOverride,
 }: IOSReadAloudControlsProps) {
   const raT = PRACTICE_UI_LOCALES[useLanguageStore((s) => s.interfaceLanguage)].readAloud;
   const isPlaying = useReadAloudStore((s) => s.isPlaying);
@@ -40,7 +42,8 @@ export function IOSReadAloudControls({
   const currentWordIndex = useReadAloudStore((s) => s.currentWordIndex);
   const { speed, setSpeed } = useTTSStore();
 
-  const progress = words.length > 0 && currentWordIndex >= 0 ? ((currentWordIndex + 1) / words.length) * 100 : 0;
+  const ttsProgress = words.length > 0 && currentWordIndex >= 0 ? ((currentWordIndex + 1) / words.length) * 100 : 0;
+  const progress = Math.min(100, Math.max(0, progressOverride ?? ttsProgress));
   const nextSpeed = SPEED_STEPS.find((step) => step > speed);
   const previousSpeed = [...SPEED_STEPS].reverse().find((step) => step < speed);
 
@@ -58,14 +61,21 @@ export function IOSReadAloudControls({
         </div>
       </div>
 
-      <div className="h-2 overflow-hidden rounded-full bg-slate-100">
+      <div
+        role="progressbar"
+        aria-label={`${label} progress`}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={Math.round(progress)}
+        className="h-2 overflow-hidden rounded-full bg-slate-100"
+      >
         <div
           className={cn(
             'h-full rounded-full bg-[linear-gradient(90deg,rgba(79,70,229,0.95)_0%,rgba(129,140,248,0.9)_100%)] transition-all duration-300',
             accentClassName.includes('orange') &&
               'bg-[linear-gradient(90deg,rgba(249,115,22,0.92)_0%,rgba(251,146,60,0.88)_100%)]',
           )}
-          style={{ width: `${Math.max(progress, 4)}%` }}
+          style={{ width: `${progress}%` }}
         />
       </div>
 

--- a/src/components/read-aloud/read-aloud-inline-controls.tsx
+++ b/src/components/read-aloud/read-aloud-inline-controls.tsx
@@ -22,6 +22,7 @@ interface ReadAloudInlineControlsProps {
   onPrev: () => void;
   onNext: () => void;
   onRestart?: () => void;
+  progress?: number;
   showImmersive?: boolean;
   showProgress?: boolean;
 }
@@ -36,6 +37,7 @@ export function ReadAloudInlineControls({
   onPrev,
   onNext,
   onRestart,
+  progress: progressOverride,
   showImmersive = true,
   showProgress = true,
 }: ReadAloudInlineControlsProps) {
@@ -47,10 +49,8 @@ export function ReadAloudInlineControls({
   const currentWordIndex = useReadAloudStore((s) => s.currentWordIndex);
   const { speed, setSpeed } = useTTSStore();
 
-  const progress =
-    words.length > 0 && currentWordIndex >= 0
-      ? Math.min(100, Math.max(0, ((currentWordIndex + 1) / words.length) * 100))
-      : 0;
+  const ttsProgress = words.length > 0 && currentWordIndex >= 0 ? ((currentWordIndex + 1) / words.length) * 100 : 0;
+  const progress = Math.min(100, Math.max(0, progressOverride ?? ttsProgress));
 
   return (
     <div
@@ -72,14 +72,21 @@ export function ReadAloudInlineControls({
       </div>
 
       {showProgress ? (
-        <div className="mt-2 h-2 overflow-hidden rounded-full bg-white">
+        <div
+          role="progressbar"
+          aria-label={`${label} progress`}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuenow={Math.round(progress)}
+          className="mt-2 h-2 overflow-hidden rounded-full bg-white"
+        >
           <div
             className={cn(
               'h-full rounded-full bg-[linear-gradient(90deg,rgba(79,70,229,0.96)_0%,rgba(129,140,248,0.92)_100%)] transition-all duration-300',
               accentClassName.includes('orange') &&
                 'bg-[linear-gradient(90deg,rgba(249,115,22,0.94)_0%,rgba(251,146,60,0.9)_100%)]',
             )}
-            style={{ width: `${Math.max(progress, 4)}%` }}
+            style={{ width: `${progress}%` }}
           />
         </div>
       ) : null}

--- a/src/components/shared/practice-complete-banner.tsx
+++ b/src/components/shared/practice-complete-banner.tsx
@@ -36,20 +36,15 @@ export function fireConfetti() {
       origin: { x: 1, y: 0.7 },
       colors: ['#4F46E5', '#22C55E', '#FBBF24', '#F472B6'],
     });
-
-    if (Date.now() < end) {
-      requestAnimationFrame(frame);
-    }
+    if (Date.now() < end) requestAnimationFrame(frame);
   };
 
-  // Initial burst
   confetti({
     particleCount: 80,
     spread: 100,
     origin: { y: 0.6 },
     colors: ['#4F46E5', '#22C55E', '#FBBF24', '#F472B6', '#818CF8'],
   });
-
   frame();
 }
 

--- a/src/components/shared/shadow-reading-completion.tsx
+++ b/src/components/shared/shadow-reading-completion.tsx
@@ -2,8 +2,7 @@
 
 import { BookOpen, Check, Headphones, Mic, PartyPopper, PenLine, RotateCcw, Trophy } from 'lucide-react';
 import Link from 'next/link';
-import { useEffect, useRef } from 'react';
-import { fireConfetti } from '@/components/shared/practice-complete-banner';
+import { useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { useI18n } from '@/lib/i18n/use-i18n';
 import { playSessionCompleteSound } from '@/lib/sounds';
@@ -55,17 +54,8 @@ export function ShadowReadingCompletion() {
   const startSession = useShadowReadingStore((s) => s.startSession);
   const { messages } = useI18n('shadowReading');
   const compMessages = messages.completion;
-  const firedRef = useRef(false);
-
   useEffect(() => {
-    if (showModal && !firedRef.current) {
-      firedRef.current = true;
-      fireConfetti();
-      playSessionCompleteSound();
-    }
-    if (!showModal) {
-      firedRef.current = false;
-    }
+    if (showModal) playSessionCompleteSound();
   }, [showModal]);
 
   if (!showModal || !session) return null;

--- a/src/components/shared/word-book-practice.tsx
+++ b/src/components/shared/word-book-practice.tsx
@@ -21,7 +21,7 @@ import { useParams, useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { ReadAloudInlineControls } from '@/components/read-aloud';
 import { PageSpinner } from '@/components/shared/page-spinner';
-import { fireConfetti } from '@/components/shared/practice-complete-banner';
+import { PracticeCompleteBanner } from '@/components/shared/practice-complete-banner';
 import { WordDictionaryInfo } from '@/components/shared/word-dictionary-info';
 import { TranslationBar } from '@/components/translation/translation-bar';
 import { Badge } from '@/components/ui/badge';
@@ -61,6 +61,7 @@ import {
   resolveWordBookWriteTarget,
 } from '@/lib/wordbook-write-target';
 import { getWordBook, loadWordBookItems } from '@/lib/wordbooks';
+import { useDailyPlanStore } from '@/stores/daily-plan-store';
 import { useLanguageStore } from '@/stores/language-store';
 import { usePracticeTranslationStore } from '@/stores/practice-translation-store';
 import { useReadAloudStore } from '@/stores/read-aloud-store';
@@ -974,27 +975,22 @@ const encourageMessagesByLang = { en: encourageMessagesEn, zh: encourageMessages
 
 function WordBookCompleteScreen({
   module,
+  isDailyPlanPractice,
   completedCount,
   total,
   onRestart,
 }: {
   module: string;
+  isDailyPlanPractice: boolean;
   completedCount: number;
   total: number;
   onRestart: () => void;
 }) {
   const lang = useLanguageStore((s) => s.interfaceLanguage);
   const t = WB_LOCALES[lang];
-  const firedRef = useRef(false);
-
-  useEffect(() => {
-    if (firedRef.current) return;
-    firedRef.current = true;
-    fireConfetti();
-  }, []);
-
   return (
     <div className="max-w-2xl mx-auto space-y-6">
+      {isDailyPlanPractice && <PracticeCompleteBanner module={module as 'listen' | 'speak' | 'read' | 'write'} />}
       <Card className="bg-gradient-to-br from-green-50 via-white to-indigo-50 border-green-200 shadow-lg">
         <CardContent className="p-8 text-center space-y-6">
           <div className="w-20 h-20 rounded-full bg-green-100 flex items-center justify-center mx-auto">
@@ -1042,6 +1038,9 @@ export function WordBookPractice({ module }: WordBookPracticeProps) {
   const progressKey = buildWordBookProgressKey(module, bookId, limit);
   const progressScopeByDay = limit > 0;
   const progressDayKey = toLocalDateKey();
+  const isDailyPlanPractice = useDailyPlanStore((s) =>
+    s.tasks.some((task) => !task.completed && !task.skipped && task.module === module && task.bookId === bookId),
+  );
 
   const [book, setBook] = useState<WordBook | null>(null);
   const [bookInfo, setBookInfo] = useState<BookInfo | null>(null);
@@ -1293,6 +1292,7 @@ export function WordBookPractice({ module }: WordBookPracticeProps) {
     return (
       <WordBookCompleteScreen
         module={module}
+        isDailyPlanPractice={isDailyPlanPractice}
         completedCount={completedCount}
         total={total}
         onRestart={() => {


### PR DESCRIPTION
## What changed
- Update Read microphone progress from recognized speech and keep recognition active across recoverable browser stops.
- Restore page scrolling when the reference pane cannot scroll further.
- Show the completion celebration only for matching daily-plan tasks, not ordinary practice completions.
- Add browser coverage for Read progress, scrolling, normal completion, and daily-plan celebration behavior.
- Stabilize daily-plan vocabulary test fixtures and selection context.

## Why
Read practice did not update visible progress while learners spoke, could trap mouse-wheel scrolling, and showed celebration UI outside the daily-plan workflow.

## Validation
- pnpm test
- pnpm typecheck
- pnpm lint
- git diff --check
- Playwright coverage for ordinary and daily-plan wordbook completion