### PR TITLE
[codex] Isolate local learning data by user

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -10,6 +10,7 @@ import { SelectionTranslationProvider } from '@/components/selection-translation
 import { ShadowReadingCompletion } from '@/components/shared/shadow-reading-completion';
 import { ShadowReadingStatusBar } from '@/components/shared/shadow-reading-status-bar';
 import { useShortcuts } from '@/hooks/use-shortcuts';
+import { LOCAL_DATABASE_CHANGED_EVENT } from '@/lib/db';
 import { I18nProvider } from '@/lib/i18n/provider';
 import { hydrateIOSNativeQA } from '@/lib/ios-native-qa';
 import { seedDatabase } from '@/lib/seed';
@@ -161,10 +162,30 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
   };
 
   useEffect(() => {
+    const refreshUserScopedData = () => {
+      if (!seeded) return;
+      void seedDatabase().then(() => {
+        void useContentStore.getState().loadContents(true);
+        void useFavoriteStore.getState().loadFavorites(true);
+      });
+    };
+
+    window.addEventListener(LOCAL_DATABASE_CHANGED_EVENT, refreshUserScopedData);
+    return () => window.removeEventListener(LOCAL_DATABASE_CHANGED_EVENT, refreshUserScopedData);
+  }, [seeded]);
+
+  useEffect(() => {
     let cancelled = false;
     let cancelWarmup = () => {};
 
-    void seedDatabase().then(async () => {
+    void (async () => {
+      try {
+        await useAuthStore.getState().initialize();
+      } catch {
+        // Continue in the anonymous local database when auth initialization is unavailable.
+      }
+
+      await seedDatabase();
       await hydrateIOSNativeQA();
       if (cancelled) return;
 
@@ -175,7 +196,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
       cancelWarmup = scheduleBackgroundTask(() => {
         void useFavoriteStore.getState().loadFavorites(true);
       });
-    });
+    })();
 
     void useProviderStore.getState().hydrate();
     useAssessmentStore.getState().hydrate();
@@ -183,8 +204,6 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
     usePracticeTranslationStore.getState().hydrate();
     useShadowReadingStore.getState().hydrate();
     useShortcutStore.getState().hydrate();
-    void useAuthStore.getState().initialize();
-
     if (IS_TAURI) {
       void useUpdaterStore.getState().checkForUpdate();
       useUpdaterStore.getState().startPeriodicCheck();

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -42,8 +42,8 @@ class EchoTypeDB extends Dexie {
   weakSpots!: Table<WeakSpot>;
   journals!: Table<JournalEntry>;
 
-  constructor() {
-    super('echotype');
+  constructor(name: string) {
+    super(name);
     this.version(1).stores({
       contents: 'id, type, category, source, difficulty, createdAt',
       records: 'id, contentId, module, lastPracticed, nextReview',
@@ -294,4 +294,24 @@ class EchoTypeDB extends Dexie {
   }
 }
 
-export const db = new EchoTypeDB();
+export const LOCAL_DATABASE_CHANGED_EVENT = 'echotype:local-database-changed';
+
+export function getDatabaseNameForUser(userId: string | null): string {
+  return userId ? `echotype:user:${userId}` : 'echotype:anonymous';
+}
+
+let activeUserId: string | null = null;
+export let db = new EchoTypeDB(getDatabaseNameForUser(activeUserId));
+
+export async function switchDatabaseForUser(userId: string | null): Promise<void> {
+  if (activeUserId === userId) return;
+
+  db.close();
+  activeUserId = userId;
+  db = new EchoTypeDB(getDatabaseNameForUser(userId));
+  await db.open();
+
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new CustomEvent(LOCAL_DATABASE_CHANGED_EVENT, { detail: { userId } }));
+  }
+}

--- a/src/stores/auth-store.test.ts
+++ b/src/stores/auth-store.test.ts
@@ -2,10 +2,15 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const createClientMock = vi.fn();
 const isSupabaseConfiguredMock = vi.fn();
+const switchDatabaseForUserMock = vi.fn();
 
 vi.mock('@/lib/supabase/client', () => ({
   createClient: createClientMock,
   isSupabaseConfigured: isSupabaseConfiguredMock,
+}));
+
+vi.mock('@/lib/db', () => ({
+  switchDatabaseForUser: switchDatabaseForUserMock,
 }));
 
 vi.mock('@/lib/tauri', () => ({
@@ -17,6 +22,7 @@ describe('auth-store', () => {
     vi.resetModules();
     vi.clearAllMocks();
     isSupabaseConfiguredMock.mockReturnValue(true);
+    switchDatabaseForUserMock.mockResolvedValue(undefined);
   });
 
   it('hydrates the authenticated user from getUser for cookie-backed sessions', async () => {
@@ -45,6 +51,7 @@ describe('auth-store', () => {
     expect(getUser).toHaveBeenCalledTimes(1);
     expect(getSession).not.toHaveBeenCalled();
     expect(onAuthStateChange).toHaveBeenCalledTimes(1);
+    expect(switchDatabaseForUserMock).toHaveBeenCalledWith('user-1');
     expect(useAuthStore.getState()).toMatchObject({
       isAuthenticated: true,
       isLoading: false,
@@ -81,6 +88,32 @@ describe('auth-store', () => {
       isAuthenticated: true,
       isLoading: false,
       user,
+    });
+  });
+
+  it('switches the local database before exposing a different signed-in user', async () => {
+    const userA = { id: 'user-a', email: 'a@example.com', user_metadata: {} };
+    const userB = { id: 'user-b', email: 'b@example.com', user_metadata: {} };
+    let onAuthStateChange: ((event: string, session: { user: typeof userB } | null) => void) | undefined;
+
+    createClientMock.mockReturnValue({
+      auth: {
+        getUser: vi.fn().mockResolvedValue({ data: { user: userA }, error: null }),
+        getSession: vi.fn(),
+        onAuthStateChange: vi.fn((callback) => {
+          onAuthStateChange = callback;
+          return { data: { subscription: { unsubscribe: vi.fn() } } };
+        }),
+      },
+    });
+
+    const { useAuthStore } = await import('./auth-store');
+    await useAuthStore.getState().initialize();
+    onAuthStateChange?.('SIGNED_IN', { user: userB });
+
+    await vi.waitFor(() => {
+      expect(switchDatabaseForUserMock).toHaveBeenLastCalledWith('user-b');
+      expect(useAuthStore.getState().user).toBe(userB);
     });
   });
 });

--- a/src/stores/auth-store.ts
+++ b/src/stores/auth-store.ts
@@ -1,6 +1,7 @@
 import type { AuthChangeEvent, Session, User } from '@supabase/supabase-js';
 import { createClient as createSupabaseClient } from '@supabase/supabase-js';
 import { create } from 'zustand';
+import { switchDatabaseForUser } from '@/lib/db';
 import { createClient, isSupabaseConfigured } from '@/lib/supabase/client';
 import { IOS_NATIVE_AUTH_CALLBACK_URL, IS_IOS_NATIVE_HOST, IS_NATIVE_HOST, IS_TAURI } from '@/lib/tauri';
 
@@ -171,16 +172,19 @@ export const useAuthStore = create<AuthState>((set) => ({
         const {
           data: { subscription },
         } = supabase.auth.onAuthStateChange((_event: AuthChangeEvent, session: Session | null) => {
-          set({
-            user: session?.user ?? null,
-            isAuthenticated: !!session?.user,
-            isLoading: false,
+          void switchDatabaseForUser(session?.user?.id ?? null).then(() => {
+            set({
+              user: session?.user ?? null,
+              isAuthenticated: !!session?.user,
+              isLoading: false,
+            });
           });
         });
         authSubscription = subscription;
       }
 
       const user = await resolveInitialUser(supabase);
+      await switchDatabaseForUser(user?.id ?? null);
 
       set({
         user,
@@ -310,6 +314,7 @@ export const useAuthStore = create<AuthState>((set) => ({
     const supabase = createClient();
     if (!supabase) return;
     await supabase.auth.signOut();
+    await switchDatabaseForUser(null);
     set({ user: null, isAuthenticated: false });
   },
 }));


### PR DESCRIPTION
## What changed
- Use a distinct local Dexie database for each authenticated user and for anonymous sessions.
- Switch the local database before updating application authentication state.
- Refresh seeded Library and Favorites data after an account change.
- Add account-switch regression coverage.

## Why
The previous shared local database exposed one browser profile user's Library data to another user and could upload it under the new user's cloud account.

## Validation
- pnpm test (112 files, 734 tests)
- pnpm typecheck
- pnpm lint
- pnpm build
- Production-browser Library smoke test