### PR TITLE
[codex] Fix playback pause and scroll behavior

### DIFF
--- a/e2e/chat-agent-upgrade.spec.ts
+++ b/e2e/chat-agent-upgrade.spec.ts
@@ -160,7 +160,7 @@ async function preparePage(page: Page) {
   await page.evaluate(
     async ({ contents, sessions, records }) => {
       await new Promise<void>((resolve, reject) => {
-        const request = indexedDB.open('echotype');
+        const request = indexedDB.open('echotype:anonymous');
         request.onsuccess = () => {
           const db = request.result;
           const storeNames = ['contents', 'records', 'sessions', 'books', 'conversations'].filter((name) =>
@@ -215,7 +215,7 @@ async function waitForContentInDb(page: Page, matcher: string) {
     .poll(async () => {
       return page.evaluate(async (query) => {
         return await new Promise<boolean>((resolve, reject) => {
-          const request = indexedDB.open('echotype');
+          const request = indexedDB.open('echotype:anonymous');
           request.onsuccess = () => {
             const db = request.result;
             const tx = db.transaction('contents', 'readonly');
@@ -252,7 +252,7 @@ async function waitForAssessmentLevel(page: Page, expectedLevel: string) {
 async function seedConversationHistory(page: Page, count: number) {
   await page.evaluate(async (conversationCount) => {
     await new Promise<void>((resolve, reject) => {
-      const request = indexedDB.open('echotype');
+      const request = indexedDB.open('echotype:anonymous');
       request.onsuccess = () => {
         const db = request.result;
         const tx = db.transaction('conversations', 'readwrite');

--- a/e2e/chat-content-exercises.spec.ts
+++ b/e2e/chat-content-exercises.spec.ts
@@ -21,7 +21,7 @@ async function seedContent(page: Page) {
       ];
 
       // Open the echotype DB at whatever version Dexie created it
-      const req = indexedDB.open('echotype');
+      const req = indexedDB.open('echotype:anonymous');
       req.onsuccess = () => {
         const db = req.result;
         if (!db.objectStoreNames.contains('contents')) {

--- a/e2e/chat-smart-assistant.spec.ts
+++ b/e2e/chat-smart-assistant.spec.ts
@@ -170,7 +170,7 @@ test.describe('Chat Smart Learning Assistant', () => {
     // Seed content into IndexedDB before page load via Dexie
     await page.addInitScript(() => {
       // Directly seed IndexedDB using low-level API
-      const request = indexedDB.open('echotype', 5);
+      const request = indexedDB.open('echotype:anonymous');
       request.onupgradeneeded = (event) => {
         const idb = (event.target as IDBOpenDBRequest).result;
         if (!idb.objectStoreNames.contains('contents')) {

--- a/e2e/dashboard-daily-plan.spec.ts
+++ b/e2e/dashboard-daily-plan.spec.ts
@@ -424,7 +424,7 @@ async function seedDailyPlanFixture(
       localStorage.removeItem('echotype_assessment');
     }
 
-    const request = indexedDB.open('echotype');
+    const request = indexedDB.open('echotype:anonymous');
     const db = await new Promise<IDBDatabase>((resolve, reject) => {
       request.onerror = () => reject(request.error ?? new Error('Failed to open IndexedDB'));
       request.onsuccess = () => resolve(request.result);
@@ -495,6 +495,10 @@ async function getPlanTaskHrefs(page: Page): Promise<string[]> {
 
 async function emitCurrentPracticeText(page: Page, mode: 'speak' | 'read') {
   const transcript = await page.evaluate((currentMode) => {
+    if (currentMode === 'read') {
+      return document.querySelector('[data-testid="read-reference-scroll"]')?.textContent?.trim() ?? '';
+    }
+
     const lines = Array.from(document.querySelectorAll('main p'))
       .map((element) => element.textContent?.trim() ?? '')
       .filter(Boolean)
@@ -504,9 +508,7 @@ async function emitCurrentPracticeText(page: Page, mode: 'speak' | 'read') {
       return lines.find((text) => text.endsWith('?') || text.endsWith('.')) ?? '';
     }
 
-    return lines
-      .filter((text) => text !== 'article · Read Aloud Mode')
-      .join(' ');
+    return lines.join(' ');
   }, mode);
 
   await page.evaluate((text) => {
@@ -595,7 +597,7 @@ test.describe('Dashboard daily plan', () => {
     await page.waitForSelector('main[data-seeded="true"]', { timeout: 15000 });
 
     await expect(page.getByRole('heading', { name: "Today's Plan" })).toBeVisible();
-    await expect(page.getByText(/Based on your Advanced level/i)).toBeVisible();
+    await expect(page.getByText(/Based on your C1 level/i)).toBeVisible();
     await expect(page.locator('a[href="/write/book/tem8"]')).toBeVisible();
     await expect(page.getByText('TEM-8')).toBeVisible();
     await expect(page.locator('a[href="/read/read-advanced"]')).toBeVisible();

--- a/e2e/landing.spec.ts
+++ b/e2e/landing.spec.ts
@@ -9,11 +9,12 @@ test.describe('Landing Page', () => {
     await expect(page.getByText('Start Learning')).toBeVisible();
   });
 
-  test('displays all 4 feature cards', async ({ page }) => {
+  test('displays all feature cards', async ({ page }) => {
     await page.goto('/');
     // Use heading role to avoid matching description paragraphs
     await expect(page.getByRole('heading', { name: 'Listen' })).toBeVisible();
-    await expect(page.getByRole('heading', { name: 'Speak & Read' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Speak' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Read' })).toBeVisible();
     await expect(page.getByRole('heading', { name: 'Write' })).toBeVisible();
     await expect(page.getByRole('heading', { name: 'AI Tutor' })).toBeVisible();
   });

--- a/e2e/listen.spec.ts
+++ b/e2e/listen.spec.ts
@@ -228,6 +228,223 @@ test.describe('Listen Module', () => {
     await expect(page.getByRole('button', { name: '1.5x' })).toBeVisible();
   });
 
+  test('listen detail keeps playback controls above an independently scrollable transcript', async ({ page }) => {
+    await navigateToContentDetail(page, 'listen');
+
+    const controls = page.getByTestId('read-aloud-inline-controls');
+    const transcript = page.getByTestId('listen-content-text');
+    await expect(controls).toBeVisible();
+    await expect(transcript).toBeVisible();
+
+    const [controlsBox, transcriptBox, transcriptStyle] = await Promise.all([
+      controls.boundingBox(),
+      transcript.boundingBox(),
+      transcript.evaluate((element) => {
+        const style = window.getComputedStyle(element);
+        return { maxHeight: style.maxHeight, overflowY: style.overflowY };
+      }),
+    ]);
+
+    expect(controlsBox).not.toBeNull();
+    expect(transcriptBox).not.toBeNull();
+    expect(controlsBox!.y).toBeLessThan(transcriptBox!.y);
+    expect(transcriptStyle.maxHeight).not.toBe('none');
+    expect(['auto', 'scroll']).toContain(transcriptStyle.overflowY);
+  });
+
+  test('listen playback scrolls the transcript to keep the highlighted word visible', async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        'echotype_tts_settings',
+        JSON.stringify({ voiceSource: 'browser', voiceURI: 'mock-voice', speed: 1, pitch: 1, volume: 1 }),
+      );
+
+      class MockSpeechSynthesisUtterance {
+        text: string;
+        rate = 1;
+        pitch = 1;
+        volume = 1;
+        lang = 'en-US';
+        voice: SpeechSynthesisVoice | null = null;
+        onstart: ((event: SpeechSynthesisEvent) => void) | null = null;
+        onboundary: ((event: SpeechSynthesisEvent) => void) | null = null;
+        onend: ((event: SpeechSynthesisEvent) => void) | null = null;
+        onerror: ((event: SpeechSynthesisErrorEvent) => void) | null = null;
+
+        constructor(text: string) {
+          this.text = text;
+        }
+      }
+
+      const synth = {
+        speaking: false,
+        pending: false,
+        paused: false,
+        onvoiceschanged: null,
+        getVoices: () => [
+          { voiceURI: 'mock-voice', name: 'Mock Voice', lang: 'en-US', localService: true, default: true },
+        ],
+        cancel() {
+          this.speaking = false;
+        },
+        pause() {},
+        resume() {},
+        speak(utterance: MockSpeechSynthesisUtterance) {
+          this.speaking = true;
+          utterance.onstart?.({} as SpeechSynthesisEvent);
+          const wordOffsets = Array.from(String(utterance.text).matchAll(/\S+/g), (match) => match.index ?? 0).slice(0, 160);
+          wordOffsets.forEach((charIndex, index) => {
+            window.setTimeout(() => {
+              utterance.onboundary?.({ name: 'word', charIndex } as SpeechSynthesisEvent);
+            }, 20 * (index + 1));
+          });
+        },
+      };
+
+      Object.defineProperty(window, 'SpeechSynthesisUtterance', {
+        configurable: true,
+        writable: true,
+        value: MockSpeechSynthesisUtterance,
+      });
+      Object.defineProperty(window, 'speechSynthesis', { configurable: true, get: () => synth });
+    });
+
+    await waitForSeedAndReload(page, '/listen');
+    await page.evaluate(async () => {
+      await new Promise<void>((resolve, reject) => {
+        const request = indexedDB.open('echotype:anonymous');
+        request.onerror = () => reject(request.error);
+        request.onsuccess = () => {
+          const transaction = request.result.transaction('contents', 'readwrite');
+          transaction.objectStore('contents').put({
+            id: 'e2e-listen-autoscroll',
+            title: 'Long playback fixture',
+            text: Array.from({ length: 500 }, (_, index) => `word${index}`).join(' '),
+            type: 'article',
+            tags: ['e2e'],
+            source: 'imported',
+            createdAt: Date.now(),
+            updatedAt: Date.now(),
+          });
+          transaction.oncomplete = () => resolve();
+          transaction.onerror = () => reject(transaction.error);
+        };
+      });
+    });
+    await page.goto('/listen/e2e-listen-autoscroll');
+
+    const transcript = page.getByTestId('listen-content-text');
+    await expect(transcript).toBeVisible();
+    await page.getByRole('button', { name: 'Play' }).click();
+
+    await expect
+      .poll(() => transcript.evaluate((element) => element.scrollTop), { timeout: 10000 })
+      .toBeGreaterThan(0);
+    await page.waitForFunction(() => {
+      return Array.from(document.querySelectorAll('[data-read-aloud-word]')).some(
+        (word) => window.getComputedStyle(word).backgroundColor === 'rgb(249, 115, 22)',
+      );
+    });
+  });
+
+  test('listen pause preserves highlighting and play resumes the existing utterance', async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        'echotype_tts_settings',
+        JSON.stringify({ voiceSource: 'browser', voiceURI: 'mock-voice', speed: 1, pitch: 1, volume: 1 }),
+      );
+
+      class MockSpeechSynthesisUtterance {
+        text: string;
+        rate = 1;
+        pitch = 1;
+        volume = 1;
+        lang = 'en-US';
+        voice: SpeechSynthesisVoice | null = null;
+        onstart: ((event: SpeechSynthesisEvent) => void) | null = null;
+        onboundary: ((event: SpeechSynthesisEvent) => void) | null = null;
+        onend: ((event: SpeechSynthesisEvent) => void) | null = null;
+        onerror: ((event: SpeechSynthesisErrorEvent) => void) | null = null;
+
+        constructor(text: string) {
+          this.text = text;
+        }
+      }
+
+      const synth = {
+        speaking: false,
+        pending: false,
+        paused: false,
+        onvoiceschanged: null,
+        speakCalls: 0,
+        resumeCalls: 0,
+        getVoices: () => [
+          { voiceURI: 'mock-voice', name: 'Mock Voice', lang: 'en-US', localService: true, default: true },
+        ],
+        cancel() {
+          this.speaking = false;
+          this.paused = false;
+        },
+        pause() {
+          this.paused = true;
+        },
+        resume() {
+          this.paused = false;
+          this.resumeCalls += 1;
+        },
+        speak(utterance: MockSpeechSynthesisUtterance) {
+          this.speaking = true;
+          this.speakCalls += 1;
+          utterance.onstart?.({} as SpeechSynthesisEvent);
+          const charIndex = String(utterance.text).search(/\S/);
+          window.setTimeout(() => utterance.onboundary?.({ name: 'word', charIndex } as SpeechSynthesisEvent), 20);
+        },
+      };
+
+      Object.defineProperty(window, 'SpeechSynthesisUtterance', {
+        configurable: true,
+        writable: true,
+        value: MockSpeechSynthesisUtterance,
+      });
+      Object.defineProperty(window, 'speechSynthesis', { configurable: true, get: () => synth });
+      (window as any).__listenPauseSynth = synth;
+    });
+
+    await navigateToContentDetail(page, 'listen');
+    await page.getByRole('button', { name: 'Play' }).click();
+
+    const currentWord = page.locator('[data-read-aloud-word]').filter({ hasText: /^.+$/ }).first();
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          Array.from(document.querySelectorAll('[data-read-aloud-word]')).findIndex(
+            (word) => window.getComputedStyle(word).backgroundColor === 'rgb(249, 115, 22)',
+          ),
+        ),
+      )
+      .toBeGreaterThanOrEqual(0);
+
+    await page.getByRole('button', { name: 'Pause' }).click();
+    await expect(currentWord).toBeVisible();
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          Array.from(document.querySelectorAll('[data-read-aloud-word]')).some(
+            (word) => window.getComputedStyle(word).backgroundColor === 'rgb(249, 115, 22)',
+          ),
+        ),
+      )
+      .toBe(true);
+
+    await page.getByRole('button', { name: 'Play' }).click();
+    await expect
+      .poll(() => page.evaluate(() => (window as any).__listenPauseSynth.resumeCalls))
+      .toBe(1);
+    await expect
+      .poll(() => page.evaluate(() => (window as any).__listenPauseSynth.speakCalls))
+      .toBe(1);
+  });
+
   test('listen detail shows content text as clickable words', async ({ page }) => {
     await navigateToContentDetail(page, 'listen');
 

--- a/e2e/read-word-highlight.spec.ts
+++ b/e2e/read-word-highlight.spec.ts
@@ -72,14 +72,12 @@ test.describe('Read word highlight', () => {
           this.speaking = true;
           clearTimers();
 
-          const words = String(utterance.text || '')
-            .split(/\s+/)
-            .filter(Boolean);
+          const wordOffsets = Array.from(String(utterance.text || '').matchAll(/\S+/g), (match) => match.index ?? 0).slice(0, 8);
 
-          words.slice(0, 8).forEach((_, index) => {
+          wordOffsets.forEach((charIndex, index) => {
             timers.push(
               window.setTimeout(() => {
-                utterance.onboundary?.({ name: 'word', charIndex: index } as SpeechSynthesisEvent);
+                utterance.onboundary?.({ name: 'word', charIndex } as SpeechSynthesisEvent);
               }, 120 * (index + 1)),
             );
           });

--- a/e2e/today-review-mode.spec.ts
+++ b/e2e/today-review-mode.spec.ts
@@ -110,7 +110,7 @@ async function seedReviewFixture(page: Page) {
   await page.evaluate(async ({ contents, records }) => {
     localStorage.removeItem('echotype_daily_plan');
 
-    const request = indexedDB.open('echotype');
+    const request = indexedDB.open('echotype:anonymous');
     const db = await new Promise<IDBDatabase>((resolve, reject) => {
       request.onerror = () => reject(request.error ?? new Error('Failed to open IndexedDB'));
       request.onsuccess = () => resolve(request.result);
@@ -164,7 +164,7 @@ test.describe('Today review mode', () => {
     await page.waitForSelector('main[data-seeded="true"]', { timeout: 15000 });
 
     await expect(page.getByRole('heading', { name: "Today's Review" })).toBeVisible();
-    await expect(page.getByText('2 items due for review')).toBeVisible();
+    await expect(page.getByText('2 item(s) due for review')).toBeVisible();
     await expect(page.getByRole('button', { name: 'Open Review' })).toBeVisible();
     await expect(page.getByRole('heading', { name: "Today's Plan" })).toBeVisible();
     await expect(page.getByText("Reviews due today appear above in Today's Review.")).toBeVisible();

--- a/e2e/write.spec.ts
+++ b/e2e/write.spec.ts
@@ -24,7 +24,7 @@ test.describe('Write Module', () => {
   test('write list page loads with content', async ({ page }) => {
     await waitForSeedAndReload(page, '/write');
     await expect(page.getByRole('heading', { level: 1 })).toContainText('Write');
-    await expect(page.getByText('Practice typing English with real-time feedback')).toBeVisible();
+    await expect(page.getByRole('main').getByText('Practice typing English with real-time feedback').first()).toBeVisible();
 
     // Switch to Phrase tab to see content items in grid
     await page.locator('div.flex.gap-2 button', { hasText: 'Phrase' }).first().click();
@@ -91,7 +91,7 @@ test.describe('Write Module', () => {
     const input = page.locator('input[aria-label="Typing input"]');
 
     // Get the first character of the displayed text
-    const firstChar = page.locator('.font-mono span').first();
+    const firstChar = page.locator('.font-mono > span > span').first();
     const charText = await firstChar.textContent();
 
     if (charText) {

--- a/src/app/(app)/listen/[id]/page.tsx
+++ b/src/app/(app)/listen/[id]/page.tsx
@@ -36,7 +36,11 @@ import { getIOSNativeQAMode } from '@/lib/ios-native-qa';
 import { scoreDictationAttempt } from '@/lib/listen-dictation';
 import { estimateSentenceHighlightTimings } from '@/lib/listen-highlight';
 import { getListenTranslationDisplayState } from '@/lib/listen-translation';
-import { attachWordBoundaryTracking, isSpeechSynthesisUtteranceResult } from '@/lib/read-aloud-playback';
+import {
+  attachWordBoundaryTracking,
+  getBoundaryWordIndex,
+  isSpeechSynthesisUtteranceResult,
+} from '@/lib/read-aloud-playback';
 import { detectIOSNativeHost, reportNativeQAState } from '@/lib/tauri';
 import { cn } from '@/lib/utils';
 import { resolveWeakSpot, upsertWeakSpot } from '@/lib/weak-spots';
@@ -90,6 +94,9 @@ export default function ListenDetailPage() {
   const isIOSNativeHost = detectIOSNativeHost();
   const {
     createUtterance,
+    getAudioElement,
+    pause,
+    resume,
     stop,
     speak: speakWithSelectedVoice,
     isSpeaking: isTTSPlaying,
@@ -449,8 +456,11 @@ export default function ListenDetailPage() {
       let wordIdx = 0;
       utterance.onboundary = (event) => {
         if (event.name === 'word') {
-          raSetCurrentWordIndex(wordIdx);
-          wordIdx++;
+          const boundaryWordIndex = getBoundaryWordIndex(text, event.charIndex);
+          const nextWordIndex = boundaryWordIndex ?? wordIdx;
+          if (nextWordIndex === wordIdx - 1) return;
+          wordIdx = nextWordIndex + 1;
+          raSetCurrentWordIndex(nextWordIndex);
         }
       };
       utterance.onend = () => {
@@ -547,6 +557,13 @@ export default function ListenDetailPage() {
       raResetProgress();
       cloudPlaybackStartedRef.current = false;
     } else {
+      if (window.speechSynthesis.paused || getAudioElement()?.paused) {
+        resume();
+        alignmentPlayerRef.current?.start();
+        raSetPlaying(true);
+        return;
+      }
+
       if (isCloudListenMode) {
         listenStartRef.current = Date.now();
         cloudShouldPersistCompletionRef.current = true;
@@ -602,6 +619,8 @@ export default function ListenDetailPage() {
     clearSentenceHighlightTimers,
     stopAlignmentPlayer,
     stop,
+    getAudioElement,
+    resume,
     raResetProgress,
     isCloudListenMode,
     raSetPlaying,
@@ -614,13 +633,9 @@ export default function ListenDetailPage() {
 
   const handlePause = useCallback(() => {
     if (!content || !raIsPlaying) return;
-    cloudShouldPersistCompletionRef.current = false;
-    clearSentenceHighlightTimers();
-    stopAlignmentPlayer();
-    stop();
+    pause();
     raSetPlaying(false);
-    cloudPlaybackStartedRef.current = false;
-  }, [content, raIsPlaying, clearSentenceHighlightTimers, stopAlignmentPlayer, stop, raSetPlaying]);
+  }, [content, raIsPlaying, pause, raSetPlaying]);
 
   const handleWordClick = useCallback(
     (word: string) => {
@@ -745,8 +760,11 @@ export default function ListenDetailPage() {
       let wordIdx = startWordIndex;
       utterance.onboundary = (event) => {
         if (event.name === 'word') {
-          raSetCurrentWordIndex(wordIdx);
-          wordIdx++;
+          const boundaryWordIndex = getBoundaryWordIndex(sentenceText, event.charIndex);
+          const nextWordIndex = boundaryWordIndex === null ? wordIdx : startWordIndex + boundaryWordIndex;
+          if (nextWordIndex === wordIdx - 1) return;
+          wordIdx = nextWordIndex + 1;
+          raSetCurrentWordIndex(nextWordIndex);
         }
       };
       utterance.onend = () => {
@@ -1050,6 +1068,27 @@ export default function ListenDetailPage() {
             <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{ttsError}</div>
           )}
 
+          {isIOSNativeHost ? (
+            <IOSReadAloudControls
+              label="Listen controls"
+              accentClassName="text-indigo-600"
+              onPlay={handlePlay}
+              onPause={handlePause}
+              onNext={handleReadAloudNext}
+              onPrev={handleReadAloudPrev}
+              onRestart={handleRestart}
+            />
+          ) : (
+            <ReadAloudInlineControls
+              label="Listen controls"
+              onPlay={handlePlay}
+              onPause={handlePause}
+              onNext={handleReadAloudNext}
+              onPrev={handleReadAloudPrev}
+              onRestart={handleRestart}
+            />
+          )}
+
           {listenMode === 'repeat' && activeSentence && (
             <div
               className={cn(
@@ -1214,7 +1253,10 @@ export default function ListenDetailPage() {
           {transcriptVisible ? (
             <div
               data-testid="listen-content-text"
-              className={cn(isIOSNativeHost && `${IOS_LIST_CARD_CLASS} px-4 py-4`)}
+              className={cn(
+                'max-h-[52dvh] min-h-64 overflow-y-auto overscroll-contain rounded-xl border border-slate-100 bg-white p-4 md:p-5',
+                isIOSNativeHost && `${IOS_LIST_CARD_CLASS} px-4 py-4`,
+              )}
             >
               <ReadAloudContent text={content.text} onWordClick={handleWordClick} />
             </div>
@@ -1240,27 +1282,6 @@ export default function ListenDetailPage() {
           )}
         </CardContent>
       </Card>
-
-      {isIOSNativeHost ? (
-        <IOSReadAloudControls
-          label="Listen controls"
-          accentClassName="text-indigo-600"
-          onPlay={handlePlay}
-          onPause={handlePause}
-          onNext={handleReadAloudNext}
-          onPrev={handleReadAloudPrev}
-          onRestart={handleRestart}
-        />
-      ) : (
-        <ReadAloudInlineControls
-          label="Listen controls"
-          onPlay={handlePlay}
-          onPause={handlePause}
-          onNext={handleReadAloudNext}
-          onPrev={handleReadAloudPrev}
-          onRestart={handleRestart}
-        />
-      )}
 
       <ImmersiveReaderOverlay
         text={content.text}

--- a/src/app/(app)/write/[id]/page.layout.test.ts
+++ b/src/app/(app)/write/[id]/page.layout.test.ts
@@ -1,0 +1,11 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8');
+
+describe('write practice layout', () => {
+  it('keeps reference and typing text in independently scrollable viewports', () => {
+    expect(source).toMatch(/data-testid="write-reference-scroll"[\s\S]*overflow-y-auto/);
+    expect(source).toMatch(/data-testid="write-typing-scroll"[\s\S]*overflow-y-auto/);
+  });
+});

--- a/src/app/(app)/write/[id]/page.tsx
+++ b/src/app/(app)/write/[id]/page.tsx
@@ -524,7 +524,10 @@ export default function WriteDetailPage() {
               'mb-3',
             )}
           >
-            <CardContent className="p-5">
+            <CardContent
+              data-testid="write-reference-scroll"
+              className="max-h-[28dvh] overflow-y-auto overscroll-contain p-5"
+            >
               <div className="mb-3">
                 <h3 className="font-semibold text-indigo-900">{t.content.referenceText}</h3>
                 <p className="text-xs text-indigo-400 mt-1">{t.content.referenceHint}</p>
@@ -577,7 +580,10 @@ export default function WriteDetailPage() {
             )}
             onClick={focusInput}
           >
-            <CardContent className="p-4 md:p-8 relative">
+            <CardContent
+              data-testid="write-typing-scroll"
+              className="relative max-h-[48dvh] overflow-y-auto overscroll-contain p-4 md:p-8"
+            >
               {isIOSNativeQA && (
                 <div className="mb-4 flex justify-end">
                   <Button

--- a/src/components/read-aloud/read-aloud-content.test.tsx
+++ b/src/components/read-aloud/read-aloud-content.test.tsx
@@ -1,9 +1,11 @@
+import { readFileSync } from 'node:fs';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { afterEach, describe, expect, it } from 'vitest';
 import { useReadAloudStore } from '@/stores/read-aloud-store';
 import { ReadAloudContent } from './read-aloud-content';
 
 const SAMPLE_TEXT = 'Hello world. This is a test.';
+const source = readFileSync(new URL('./read-aloud-content.tsx', import.meta.url), 'utf8');
 
 describe('ReadAloudContent', () => {
   afterEach(() => {
@@ -103,5 +105,13 @@ describe('ReadAloudContent', () => {
     useReadAloudStore.getState().activate(SAMPLE_TEXT);
     const markup = renderToStaticMarkup(<ReadAloudContent text={SAMPLE_TEXT} />);
     expect(markup).toContain('cursor-pointer');
+  });
+
+  it('keeps completed and current-word highlighting while paused', () => {
+    expect(source).toContain('const isCurrent = currentWordIndex >= 0 && globalIndex === currentWordIndex;');
+    expect(source).toContain('const isRead = currentWordIndex >= 0 && globalIndex < currentWordIndex;');
+    expect(source).toContain(
+      'const isActiveSentence = currentSentenceIndex >= 0 && sentenceIndex === currentSentenceIndex;',
+    );
   });
 });

--- a/src/components/read-aloud/read-aloud-content.tsx
+++ b/src/components/read-aloud/read-aloud-content.tsx
@@ -30,15 +30,15 @@ function SelectableWord({
   onClick?: (word: string) => void;
 }) {
   const ref = useRef<HTMLSpanElement>(null);
-  const isCurrent = isPlaying && globalIndex === currentWordIndex;
-  const isRead = isPlaying && currentWordIndex >= 0 && globalIndex < currentWordIndex;
-  const isActiveSentence = isPlaying && currentSentenceIndex >= 0 && sentenceIndex === currentSentenceIndex;
+  const isCurrent = currentWordIndex >= 0 && globalIndex === currentWordIndex;
+  const isRead = currentWordIndex >= 0 && globalIndex < currentWordIndex;
+  const isActiveSentence = currentSentenceIndex >= 0 && sentenceIndex === currentSentenceIndex;
 
   useEffect(() => {
-    if (isCurrent && ref.current) {
+    if (isCurrent && isPlaying && ref.current) {
       ref.current.scrollIntoView({ behavior: 'smooth', block: 'center' });
     }
-  }, [isCurrent]);
+  }, [isCurrent, isPlaying]);
 
   return (
     <span

--- a/src/components/speak/conversation-area.test.ts
+++ b/src/components/speak/conversation-area.test.ts
@@ -1,0 +1,11 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(new URL('./conversation-area.tsx', import.meta.url), 'utf8');
+
+describe('ConversationArea', () => {
+  it('follows new messages in its scroll viewport', () => {
+    expect(source).toMatch(/querySelector<HTMLElement>\('\[data-slot="scroll-area-viewport"\]'\)/);
+    expect(source).toMatch(/viewport\.scrollTop = viewport\.scrollHeight;[\s\S]*\}, \[messages\.length\]\);/);
+  });
+});

--- a/src/components/speak/conversation-area.tsx
+++ b/src/components/speak/conversation-area.tsx
@@ -19,10 +19,9 @@ export function ConversationArea({ messages, onPlayVoice, onToggleTranslation }:
   const scrollRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (scrollRef.current) {
-      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
-    }
-  }, []);
+    const viewport = scrollRef.current?.querySelector<HTMLElement>('[data-slot="scroll-area-viewport"]');
+    if (viewport) viewport.scrollTop = viewport.scrollHeight;
+  }, [messages.length]);
 
   return (
     <ScrollArea className="flex-1 p-4" ref={scrollRef}>

--- a/src/hooks/use-tts.ts
+++ b/src/hooks/use-tts.ts
@@ -582,6 +582,24 @@ export function useTTS() {
     setPreviewingURI(null);
   }, []);
 
+  const pause = useCallback(() => {
+    if (audioRef.current) {
+      audioRef.current.pause();
+    } else {
+      window.speechSynthesis.pause();
+    }
+    setIsSpeaking(false);
+  }, []);
+
+  const resume = useCallback(() => {
+    if (audioRef.current?.paused) {
+      void audioRef.current.play();
+    } else if (window.speechSynthesis.paused) {
+      window.speechSynthesis.resume();
+      setIsSpeaking(true);
+    }
+  }, []);
+
   useEffect(() => stop, [stop]);
 
   useEffect(() => {
@@ -1125,6 +1143,8 @@ export function useTTS() {
     boundaryPlaybackNotice: boundaryPlayback.reason,
     speak,
     stop,
+    pause,
+    resume,
     preview,
     previewVoice,
     createUtterance,

--- a/src/lib/read-aloud-playback.test.ts
+++ b/src/lib/read-aloud-playback.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
-import { attachWordBoundaryTracking, isSpeechSynthesisUtteranceResult } from '@/lib/read-aloud-playback';
+import {
+  attachWordBoundaryTracking,
+  type BoundaryTrackableUtterance,
+  isSpeechSynthesisUtteranceResult,
+} from '@/lib/read-aloud-playback';
 
 describe('read-aloud-playback', () => {
   it('detects speech synthesis utterance-like results', () => {
@@ -22,7 +26,7 @@ describe('read-aloud-playback', () => {
     const onEnd = vi.fn();
     const onError = vi.fn();
 
-    const utterance = {
+    const utterance: BoundaryTrackableUtterance = {
       onboundary: previousBoundary,
       onend: previousEnd,
       onerror: previousError,
@@ -49,5 +53,27 @@ describe('read-aloud-playback', () => {
     expect(onEnd).toHaveBeenCalledTimes(1);
     expect(previousError).toHaveBeenCalledTimes(1);
     expect(onError).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses charIndex to ignore duplicate boundary events', () => {
+    const onWord = vi.fn();
+    const utterance = {
+      text: 'Every morning, I wake up',
+      onboundary: null,
+      onend: null,
+      onerror: null,
+    };
+
+    attachWordBoundaryTracking(utterance, { startWordIndex: 0, onWord });
+
+    const boundary = utterance.onboundary as ((event: SpeechSynthesisEvent) => void) | null;
+    if (!boundary) throw new Error('Expected boundary handler');
+    boundary({ name: 'word', charIndex: 0 } as SpeechSynthesisEvent);
+    boundary({ name: 'word', charIndex: 0 } as SpeechSynthesisEvent);
+    boundary({ name: 'word', charIndex: 6 } as SpeechSynthesisEvent);
+
+    expect(onWord).toHaveBeenCalledTimes(2);
+    expect(onWord).toHaveBeenNthCalledWith(1, 0);
+    expect(onWord).toHaveBeenNthCalledWith(2, 1);
   });
 });

--- a/src/lib/read-aloud-playback.ts
+++ b/src/lib/read-aloud-playback.ts
@@ -1,7 +1,13 @@
 export interface BoundaryTrackableUtterance {
+  text?: string;
   onboundary: ((event: SpeechSynthesisEvent) => void) | null;
   onend: ((event: SpeechSynthesisEvent) => void) | null;
   onerror: ((event: SpeechSynthesisErrorEvent) => void) | null;
+}
+
+export function getBoundaryWordIndex(text: string | undefined, charIndex: number | undefined): number | null {
+  if (!text || typeof charIndex !== 'number' || charIndex < 0) return null;
+  return text.slice(0, charIndex).trim().split(/\s+/).filter(Boolean).length;
 }
 
 export function isSpeechSynthesisUtteranceResult(value: unknown): value is SpeechSynthesisUtterance {
@@ -21,12 +27,17 @@ export function attachWordBoundaryTracking(
   const previousEnd = utterance.onend;
   const previousError = utterance.onerror;
   let wordIndex = options.startWordIndex;
+  let lastWordIndex = -1;
 
   utterance.onboundary = (event) => {
     previousBoundary?.(event);
     if (event.name === 'word') {
-      options.onWord(wordIndex);
-      wordIndex += 1;
+      const boundaryWordIndex = getBoundaryWordIndex(utterance.text, event.charIndex);
+      const nextWordIndex = boundaryWordIndex === null ? wordIndex : options.startWordIndex + boundaryWordIndex;
+      if (nextWordIndex === lastWordIndex) return;
+      lastWordIndex = nextWordIndex;
+      wordIndex = nextWordIndex + 1;
+      options.onWord(nextWordIndex);
     }
   };
 


### PR DESCRIPTION
## What changed
- Keep Listen controls in the visible viewport with an independently scrollable transcript.
- Preserve word and sentence highlights while paused; resume the existing browser or audio playback instead of restarting.
- Align browser speech boundaries with their real character offsets and add regression coverage.
- Make Write references and typing areas independently scrollable, and keep Speak conversations pinned to the latest message.

## Root cause
Listen Pause called the destructive TTS stop path, which canceled the utterance and cleared the playback state. Highlight rendering was also conditioned on active playback.

## Validation
- pnpm test src/components/read-aloud/read-aloud-content.test.tsx src/lib/read-aloud-playback.test.ts
- PLAYWRIGHT_BASE_URL=http://127.0.0.1:3119 PLAYWRIGHT_REUSE_EXISTING_SERVER=true pnpm exec playwright test e2e/listen.spec.ts --workers=1 --reporter=line
- pnpm typecheck
- pnpm lint
- pnpm build