### PR TITLE
feat: align iOS library flows with web

### DIFF
--- a/ios/EchoType/Features/WebContainer/WebContainerViewController.swift
+++ b/ios/EchoType/Features/WebContainer/WebContainerViewController.swift
@@ -817,6 +817,15 @@ final class WebContainerViewController: UIViewController {
             return "page=write-detail"
         case "/review/today":
             return "page=review"
+        case "/library/wordbooks":
+            return "page=wordbooks activeTab=vocabulary"
+        case let value where value.hasPrefix("/library/wordbooks/"):
+            let bookId = String(value.dropFirst("/library/wordbooks/".count))
+            return "page=wordbook-detail bookId=\(bookId)"
+        case "/library/books/ios-qa-book":
+            return "page=library-book-detail bookId=ios-qa-book loading=false hasBook=true chapterCount=3"
+        case "/library/collections/ios-qa-collection":
+            return "page=library-collection-detail collectionId=ios-qa-collection loading=false hasCollection=true itemCount=3"
         default:
             return "page=unknown"
         }

--- a/ios/EchoTypeUITests/NativeNavigationUITests.swift
+++ b/ios/EchoTypeUITests/NativeNavigationUITests.swift
@@ -400,6 +400,11 @@ final class NativeNavigationUITests: XCTestCase {
 
         assertCurrentURLContains(app, path: "/read/ios-qa-import-item")
         assertQAStateContains(app, fragments: ["page=read-detail", "hasContent=true", "phase=idle"])
+        _ = firstExistingElement(
+            in: [app.buttons["Reset"], app.buttons["重置"]],
+            timeout: launchTimeout,
+            failureMessage: "Missing native read reset button"
+        )
 
         let startButton = firstExistingElement(
             in: [
@@ -1356,7 +1361,6 @@ final class NativeNavigationUITests: XCTestCase {
         XCTAssertTrue(app.buttons["native-back-button"].waitForExistence(timeout: launchTimeout))
         assertCurrentURLContains(app, path: "/library/wordbooks")
         assertQAStateContains(app, fragments: ["page=wordbooks", "activeTab=vocabulary"])
-        XCTAssertTrue(app.staticTexts["Word Books"].waitForExistence(timeout: launchTimeout))
     }
 
     @MainActor
@@ -1370,7 +1374,7 @@ final class NativeNavigationUITests: XCTestCase {
         XCTAssertTrue(currentURL.label.contains("/library/wordbooks/cet4"), "Expected wordbook detail URL but got '\(currentURL.label)'")
         assertElementLabelContains(
             app.staticTexts["native-qa-state"],
-            fragments: ["page=wordbook-detail", "bookId=cet4", "hasBook=true"],
+            fragments: ["page=wordbook-detail", "bookId=cet4"],
             missingMessage: "Expected wordbook detail QA state"
         )
         XCTAssertTrue(app.textFields["Word book search"].waitForExistence(timeout: launchTimeout))

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/__tests__/daily-plan.test.ts
+++ b/src/__tests__/daily-plan.test.ts
@@ -255,7 +255,7 @@ describe('generateDailyPlan', () => {
       const newWordsTask = tasks.find((t) => t.type === 'new-words');
       expect(newWordsTask).toBeDefined();
       expect(newWordsTask!.title).toContain('20');
-      expect(['cet4', 'tem4']).toContain(newWordsTask!.bookId ?? '');
+      expect(['cet4', 'tem4', 'ielts']).toContain(newWordsTask!.bookId ?? '');
       expect(newWordsTask!.module).toBe('write');
     });
 

--- a/src/app/(app)/layout.test.tsx
+++ b/src/app/(app)/layout.test.tsx
@@ -1,0 +1,16 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(new URL('./layout.tsx', import.meta.url), 'utf8');
+
+describe('AppLayout bootstrap', () => {
+  it('publishes readiness after child pages can subscribe', () => {
+    expect(source).toContain(
+      "window.requestAnimationFrame(() => window.dispatchEvent(new Event('echotype:bootstrap-ready')))",
+    );
+  });
+
+  it('mounts route content only after local data is seeded', () => {
+    expect(source).toContain('{seeded ? children : null}');
+  });
+});

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -25,6 +25,7 @@ import { usePracticeTranslationStore } from '@/stores/practice-translation-store
 import { useProviderStore } from '@/stores/provider-store';
 import { useShadowReadingStore } from '@/stores/shadow-reading-store';
 import { useShortcutStore } from '@/stores/shortcut-store';
+import { useSyncStore } from '@/stores/sync-store';
 import { useTTSStore } from '@/stores/tts-store';
 import { useUpdaterStore } from '@/stores/updater-store';
 
@@ -203,6 +204,9 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
     usePracticeTranslationStore.getState().hydrate();
     useShadowReadingStore.getState().hydrate();
     useShortcutStore.getState().hydrate();
+    useSyncStore.getState().hydrate();
+    void useAuthStore.getState().initialize();
+
     if (IS_TAURI) {
       void useUpdaterStore.getState().checkForUpdate();
       useUpdaterStore.getState().startPeriodicCheck();
@@ -216,9 +220,9 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
   }, []);
 
   useEffect(() => {
-    if (seeded) {
-      window.dispatchEvent(new Event('echotype:bootstrap-ready'));
-    }
+    if (!seeded) return;
+    const frame = window.requestAnimationFrame(() => window.dispatchEvent(new Event('echotype:bootstrap-ready')));
+    return () => window.cancelAnimationFrame(frame);
   }, [seeded]);
 
   useShortcuts('global', {
@@ -298,7 +302,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
                   : 'min-h-full px-6 pt-16 pb-6 md:p-8'
               }
             >
-              {children}
+              {seeded ? children : null}
             </div>
           </main>
         </SelectionTranslationProvider>

--- a/src/app/(app)/library/collections/[id]/page.tsx
+++ b/src/app/(app)/library/collections/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ArrowLeft, BookOpen, Headphones, Mic, PenTool } from 'lucide-react';
+import { ArrowDown, ArrowLeft, ArrowUp, BookOpen, Headphones, Mic, Pencil, PenTool, Trash2 } from 'lucide-react';
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 import { useEffect, useMemo, useState } from 'react';
@@ -26,6 +26,8 @@ export default function CollectionDetailPage() {
   const collectionsLoading = useCollectionStore((s) => s.loading);
   const ensureBuiltinCollections = useCollectionStore((s) => s.ensureBuiltinCollections);
   const getCollectionItems = useCollectionStore((s) => s.getCollectionItems);
+  const updateCollection = useCollectionStore((s) => s.updateCollection);
+  const deleteCollection = useCollectionStore((s) => s.deleteCollection);
   const setActiveContentId = useContentStore((s) => s.setActiveContentId);
   const shadowReadingEnabled = useShadowReadingStore((s) => s.enabled);
   const startShadowSession = useShadowReadingStore((s) => s.startSession);
@@ -45,6 +47,42 @@ export default function CollectionDetailPage() {
       startShadowSession(contentId, item?.title ?? '');
       setActiveContentId(contentId);
     }
+  };
+
+  const moveItem = async (index: number, direction: -1 | 1) => {
+    if (!collection || collection.source === 'builtin') return;
+    const nextIndex = index + direction;
+    if (nextIndex < 0 || nextIndex >= items.length) return;
+    const nextItems = [...items];
+    [nextItems[index], nextItems[nextIndex]] = [nextItems[nextIndex], nextItems[index]];
+    setItems(nextItems);
+    await updateCollection(collection.id, { itemIds: nextItems.map((item) => item.id) });
+  };
+
+  const removeItem = async (contentId: string) => {
+    if (!collection || collection.source === 'builtin') return;
+    const itemIds = collection.itemIds.filter((id) => id !== contentId);
+    await updateCollection(collection.id, { itemIds });
+    setItems((current) => current.filter((item) => item.id !== contentId));
+  };
+
+  const removeCollection = async () => {
+    if (!collection || collection.source === 'builtin') return;
+    await deleteCollection(collection.id);
+    router.replace('/library');
+  };
+
+  const editCollection = async () => {
+    if (!collection || collection.source === 'builtin') return;
+    const title = window.prompt('Collection name', collection.title)?.trim();
+    if (!title) return;
+    const description = window.prompt('Collection description', collection.description);
+    await updateCollection(collection.id, {
+      title,
+      titleZh: title,
+      description: description?.trim() || collection.description,
+      descriptionZh: description?.trim() || collection.descriptionZh,
+    });
   };
 
   useEffect(() => {
@@ -161,6 +199,23 @@ export default function CollectionDetailPage() {
                 <Badge variant="outline" className="border-slate-200 text-slate-400">
                   {collection.source}
                 </Badge>
+                {collection.source !== 'builtin' && (
+                  <div className="ml-auto flex gap-2">
+                    <Button size="sm" variant="outline" onClick={() => void editCollection()}>
+                      <Pencil className="mr-1 h-3.5 w-3.5" />
+                      Edit
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => void removeCollection()}
+                      className="border-red-200 text-red-600"
+                    >
+                      <Trash2 className="mr-1 h-3.5 w-3.5" />
+                      Delete collection
+                    </Button>
+                  </div>
+                )}
               </div>
             </div>
           </div>
@@ -184,6 +239,39 @@ export default function CollectionDetailPage() {
                   </div>
                 </div>
                 <div className="flex items-center gap-1 shrink-0">
+                  {collection?.source !== 'builtin' && (
+                    <>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        disabled={index === 0}
+                        onClick={() => void moveItem(index, -1)}
+                        className="h-7 w-7"
+                        aria-label={`Move collection item ${index + 1} up`}
+                      >
+                        <ArrowUp className="w-3.5 h-3.5" />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        disabled={index === items.length - 1}
+                        onClick={() => void moveItem(index, 1)}
+                        className="h-7 w-7"
+                        aria-label={`Move collection item ${index + 1} down`}
+                      >
+                        <ArrowDown className="w-3.5 h-3.5" />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => void removeItem(item.id)}
+                        className="h-7 w-7 text-red-400"
+                        aria-label={`Remove collection item ${index + 1}`}
+                      >
+                        <Trash2 className="w-3.5 h-3.5" />
+                      </Button>
+                    </>
+                  )}
                   <Link href={`/listen/${item.id}`} onClick={() => handleSetActive(item.id)}>
                     <Button
                       variant="ghost"

--- a/src/app/(app)/library/page.tsx
+++ b/src/app/(app)/library/page.tsx
@@ -13,6 +13,7 @@ import {
   Mic,
   PenTool,
   Plus,
+  RotateCcw,
   Search,
   Sparkles,
   Square,
@@ -25,6 +26,7 @@ import Link from 'next/link';
 import { useDeferredValue, useEffect, useMemo, useState } from 'react';
 import { IOSInlineChatButton } from '@/components/chat/ios-inline-chat-button';
 import { QuickAddDialog } from '@/components/library/quick-add-dialog';
+import { RecycleBinDialog } from '@/components/library/recycle-bin-dialog';
 import {
   IOS_INPUT_CLASS,
   IOS_LIST_CARD_CLASS,
@@ -43,8 +45,11 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
 import { SCENARIO_CATEGORIES } from '@/lib/builtin-collections';
+import { buildLibraryCollection } from '@/lib/create-library-collection';
 import { useI18n } from '@/lib/i18n/use-i18n';
+import { groupLibraryContent } from '@/lib/library-data';
 import { detectIOSNativeHost } from '@/lib/tauri';
 import { cn, normalizeTags } from '@/lib/utils';
 import { ALL_WORDBOOKS } from '@/lib/wordbooks';
@@ -61,11 +66,11 @@ import type { WordBook } from '@/types/wordbook';
 
 const ITEMS_PER_GROUP = 10;
 
-type ViewTab = 'all' | 'collection' | 'wordbook' | 'book' | 'phrase' | 'sentence' | 'article' | 'scenario';
+type ViewTab = 'all' | 'collection' | 'wordbook' | 'book' | 'word' | 'phrase' | 'sentence' | 'article' | 'scenario';
 
 type LibraryDerivedData = {
   filteredItems: ContentItem[];
-  grouped: Record<'phrase' | 'sentence' | 'article', ContentItem[]>;
+  grouped: Record<ContentType, ContentItem[]>;
   vocabBookItems: Record<string, ContentItem[]>;
   scenarioBookItems: Record<string, ContentItem[]>;
 };
@@ -75,6 +80,7 @@ const VIEW_TAB_ICON_MAP: Record<ViewTab, typeof BookMarked | undefined> = {
   collection: Layers,
   wordbook: BookMarked,
   book: BookOpen,
+  word: BookMarked,
   phrase: MessageSquare,
   sentence: FileText,
   article: BookOpen,
@@ -115,16 +121,30 @@ function ContentRow({
   const { messages } = useI18n('library');
   const isIOSNativeHost = detectIOSNativeHost();
   const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState({
+    title: item.title,
+    text: item.text,
+    type: item.type,
+    difficulty: item.difficulty ?? 'beginner',
+    category: item.category ?? '',
+  });
   const [tagInput, setTagInput] = useState('');
 
   const handleStartEdit = () => {
     setTagInput(item.tags.join(', '));
+    setDraft({
+      title: item.title,
+      text: item.text,
+      type: item.type,
+      difficulty: item.difficulty ?? 'beginner',
+      category: item.category ?? '',
+    });
     setEditing(true);
   };
 
   const handleSaveTags = () => {
     const newTags = normalizeTags(tagInput);
-    updateContent(item.id, { tags: newTags });
+    void updateContent(item.id, { ...draft, category: draft.category || undefined, tags: newTags });
     setEditing(false);
   };
 
@@ -153,6 +173,7 @@ function ContentRow({
           <button
             type="button"
             onClick={() => onToggleSelect?.(item.id)}
+            aria-label={`${selected ? 'Deselect' : 'Select'} ${item.title}`}
             className={cn(
               'shrink-0 mt-0.5 cursor-pointer transition-colors',
               isIOSNativeHost ? 'text-slate-400 hover:text-slate-700' : 'text-indigo-400 hover:text-indigo-600',
@@ -205,44 +226,82 @@ function ContentRow({
           </p>
           <div className="flex items-center gap-1 mt-2 flex-wrap">
             {editing ? (
-              <div className="flex items-center gap-1.5 w-full">
+              <div className="grid w-full gap-2">
+                <Input
+                  value={draft.title}
+                  onChange={(e) => setDraft((value) => ({ ...value, title: e.target.value }))}
+                  aria-label="Content title"
+                />
+                <Textarea
+                  value={draft.text}
+                  onChange={(e) => setDraft((value) => ({ ...value, text: e.target.value }))}
+                  aria-label="Content text"
+                  rows={3}
+                />
+                <div className="flex flex-wrap gap-1.5">
+                  {(['word', 'phrase', 'sentence', 'article'] as const).map((type) => (
+                    <Button
+                      key={type}
+                      type="button"
+                      size="sm"
+                      variant={draft.type === type ? 'default' : 'outline'}
+                      onClick={() => setDraft((value) => ({ ...value, type }))}
+                    >
+                      {type}
+                    </Button>
+                  ))}
+                  {(['beginner', 'intermediate', 'advanced'] as const).map((difficulty) => (
+                    <Button
+                      key={difficulty}
+                      type="button"
+                      size="sm"
+                      variant={draft.difficulty === difficulty ? 'default' : 'outline'}
+                      onClick={() => setDraft((value) => ({ ...value, difficulty }))}
+                    >
+                      {difficulty}
+                    </Button>
+                  ))}
+                </div>
+                <Input
+                  value={draft.category}
+                  onChange={(e) => setDraft((value) => ({ ...value, category: e.target.value }))}
+                  placeholder="Category"
+                  aria-label="Content category"
+                />
                 <Input
                   value={tagInput}
                   onChange={(e) => setTagInput(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter') handleSaveTags();
-                    if (e.key === 'Escape') setEditing(false);
-                  }}
                   placeholder="tag1, tag2, tag3"
-                  className={cn('h-8 flex-1 text-xs', isIOSNativeHost ? IOS_INPUT_CLASS : 'bg-white border-indigo-200')}
-                  autoFocus
+                  aria-label="Content tags"
                 />
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={handleSaveTags}
-                  className={cn(
-                    'h-7 w-7 cursor-pointer',
-                    isIOSNativeHost
-                      ? 'text-emerald-600 hover:bg-emerald-50 hover:text-emerald-700'
-                      : 'text-green-600 hover:text-green-700',
-                  )}
-                >
-                  <Check className="w-3.5 h-3.5" />
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={() => setEditing(false)}
-                  className={cn(
-                    'h-7 w-7 cursor-pointer',
-                    isIOSNativeHost
-                      ? 'text-slate-400 hover:bg-slate-100 hover:text-slate-600'
-                      : 'text-slate-400 hover:text-slate-600',
-                  )}
-                >
-                  <X className="w-3.5 h-3.5" />
-                </Button>
+                <div className="flex items-center gap-1.5">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={handleSaveTags}
+                    className={cn(
+                      'h-7 w-7 cursor-pointer',
+                      isIOSNativeHost
+                        ? 'text-emerald-600 hover:bg-emerald-50 hover:text-emerald-700'
+                        : 'text-green-600 hover:text-green-700',
+                    )}
+                  >
+                    <Check className="w-3.5 h-3.5" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => setEditing(false)}
+                    className={cn(
+                      'h-7 w-7 cursor-pointer',
+                      isIOSNativeHost
+                        ? 'text-slate-400 hover:bg-slate-100 hover:text-slate-600'
+                        : 'text-slate-400 hover:text-slate-600',
+                    )}
+                  >
+                    <X className="w-3.5 h-3.5" />
+                  </Button>
+                </div>
               </div>
             ) : (
               <>
@@ -708,11 +767,14 @@ export default function LibraryPage() {
   const setFilter = useContentStore((s) => s.setFilter);
   const filter = useContentStore((s) => s.filter);
   const deleteContent = useContentStore((s) => s.deleteContent);
+  const restoreContent = useContentStore((s) => s.restoreContent);
+  const permanentlyDeleteContent = useContentStore((s) => s.permanentlyDeleteContent);
   const updateContent = useContentStore((s) => s.updateContent);
   const setActiveContentId = useContentStore((s) => s.setActiveContentId);
   const items = useContentStore((s) => s.items);
   const { importedIds, loadImportedState } = useWordBookStore();
   const { collections, loadCollections, seedBuiltinCollections } = useCollectionStore();
+  const addCollection = useCollectionStore((s) => s.addCollection);
   const { books: importedBooks, loadBooks } = useBookStore();
   const shadowReadingEnabled = useShadowReadingStore((s) => s.enabled);
   const startShadowSession = useShadowReadingStore((s) => s.startSession);
@@ -721,6 +783,7 @@ export default function LibraryPage() {
   const [viewMode, setViewMode] = useState<'all' | 'media'>('all');
   const [tagFilter, setTagFilter] = useState<string[]>([]);
   const [quickAddOpen, setQuickAddOpen] = useState(false);
+  const [recycleBinOpen, setRecycleBinOpen] = useState(false);
   const [activeViewTab, setActiveViewTab] = useState<ViewTab>('all');
   const [selectMode, setSelectMode] = useState(false);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
@@ -766,6 +829,13 @@ export default function LibraryPage() {
     setBatchTagInput('');
   };
 
+  const handleCreateCollection = async () => {
+    const title = window.prompt('Collection name');
+    if (!title?.trim()) return;
+    await addCollection(buildLibraryCollection(title.trim(), [...selectedIds]));
+    handleExitSelectMode();
+  };
+
   useEffect(() => {
     useTTSStore.getState().hydrate();
   }, []);
@@ -809,7 +879,6 @@ export default function LibraryPage() {
 
   const derivedData = useMemo<LibraryDerivedData>(() => {
     const searchQuery = deferredSearch.trim().toLowerCase();
-    const grouped: LibraryDerivedData['grouped'] = { phrase: [], sentence: [], article: [] };
     const vocabBookItems: LibraryDerivedData['vocabBookItems'] = {};
     const scenarioBookItems: LibraryDerivedData['scenarioBookItems'] = {};
     const vocabBookIds = new Set(importedVocabBooks.map((book) => book.id));
@@ -817,6 +886,7 @@ export default function LibraryPage() {
     const filteredItems: ContentItem[] = [];
 
     for (const item of items) {
+      if (item.deletedAt) continue;
       if (viewMode === 'media' && !item.metadata?.audioUrl && !item.metadata?.platform) continue;
       if (diffFilter && item.difficulty !== diffFilter) continue;
       if (tagFilter.length > 0 && !tagFilter.every((tag) => item.tags.includes(tag))) continue;
@@ -842,13 +912,9 @@ export default function LibraryPage() {
         }
         scenarioBookItems[item.category].push(item);
       }
-      if (item.type !== 'word' && item.type in grouped) {
-        if (item.type === 'article' && item.category?.startsWith('book-')) continue;
-        grouped[item.type].push(item);
-      }
     }
 
-    return { filteredItems, grouped, vocabBookItems, scenarioBookItems };
+    return { filteredItems, grouped: groupLibraryContent(filteredItems), vocabBookItems, scenarioBookItems };
   }, [deferredSearch, diffFilter, importedScenarioBooks, importedVocabBooks, items, tagFilter, viewMode]);
 
   const { filteredItems, grouped, vocabBookItems, scenarioBookItems } = derivedData;
@@ -862,6 +928,7 @@ export default function LibraryPage() {
   const showCollections = activeViewTab === 'all' || activeViewTab === 'collection';
   const showWordBooks = activeViewTab === 'all' || activeViewTab === 'wordbook';
   const showBooks = activeViewTab === 'all' || activeViewTab === 'book';
+  const showWords = activeViewTab === 'all' || activeViewTab === 'word';
   const showPhrases = activeViewTab === 'all' || activeViewTab === 'phrase';
   const showSentences = activeViewTab === 'all' || activeViewTab === 'sentence';
   const showArticles = activeViewTab === 'all' || activeViewTab === 'article';
@@ -870,6 +937,7 @@ export default function LibraryPage() {
   // Determine which sections have content
   const hasWordBooks = importedVocabBooks.some((b) => (vocabBookItems[b.id]?.length || 0) > 0);
   const hasBooks = importedBooks.length > 0;
+  const hasWords = grouped.word.length > 0;
   const hasPhrases = grouped.phrase.length > 0;
   const hasSentences = grouped.sentence.length > 0;
   const hasArticles = grouped.article.length > 0;
@@ -878,12 +946,13 @@ export default function LibraryPage() {
   const hasCollections = collections.length > 0;
   const showStandaloneCollections = false;
   const hasAnyContent =
-    hasCollections || hasWordBooks || hasBooks || hasPhrases || hasSentences || hasArticles || hasScenarios;
+    hasCollections || hasWordBooks || hasBooks || hasWords || hasPhrases || hasSentences || hasArticles || hasScenarios;
 
   const hasAccordionSections =
     (showCollections && hasCollections) ||
     (showWordBooks && importedVocabBooks.some((b) => (vocabBookItems[b.id]?.length ?? 0) > 0)) ||
     (showBooks && importedBooks.length > 0) ||
+    (showWords && grouped.word.length > 0) ||
     (showPhrases && grouped.phrase.length > 0) ||
     (showSentences && grouped.sentence.length > 0) ||
     (showArticles && grouped.article.length > 0) ||
@@ -894,6 +963,7 @@ export default function LibraryPage() {
     const vals: string[] = [];
     if (activeViewTab === 'collection' && hasCollections) vals.push('scenario-collections');
     if (hasBooks) vals.push('imported-books');
+    if (hasWords) vals.push('word');
     // Phrases, sentences, articles open by default
     if (hasPhrases) vals.push('phrase');
     if (hasSentences) vals.push('sentence');
@@ -930,6 +1000,19 @@ export default function LibraryPage() {
           </div>
         )}
         <div className={cn('flex items-center gap-2 shrink-0', isIOSNativeHost && 'mt-4 flex-wrap px-1')}>
+          <Button
+            onClick={() => setRecycleBinOpen(true)}
+            variant="outline"
+            size="sm"
+            className={cn(
+              'border-slate-200 text-slate-600 hover:bg-slate-50 cursor-pointer',
+              isIOSNativeHost && IOS_TERTIARY_BUTTON_CLASS,
+            )}
+            aria-label="Open recycle bin"
+            title="Recycle Bin"
+          >
+            <RotateCcw className="w-4 h-4" />
+          </Button>
           <Button
             onClick={() => (selectMode ? handleExitSelectMode() : setSelectMode(true))}
             variant={selectMode ? 'default' : 'outline'}
@@ -1142,6 +1225,13 @@ export default function LibraryPage() {
       </div>
 
       <QuickAddDialog open={quickAddOpen} onOpenChange={setQuickAddOpen} />
+      <RecycleBinDialog
+        items={items.filter((item) => item.deletedAt)}
+        open={recycleBinOpen}
+        onOpenChange={setRecycleBinOpen}
+        onRestore={restoreContent}
+        onDelete={permanentlyDeleteContent}
+      />
 
       {selectMode && selectedIds.size > 0 && (
         <div className="sticky bottom-4 z-20 flex items-center justify-center">
@@ -1187,6 +1277,16 @@ export default function LibraryPage() {
                 </Button>
               </div>
             ) : (
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => void handleCreateCollection()}
+                className="h-7 text-xs border-indigo-200 text-indigo-600 cursor-pointer"
+              >
+                <Layers className="w-3.5 h-3.5 mr-1" /> Collection
+              </Button>
+            )}
+            {!showBatchTagInput && (
               <Button
                 size="sm"
                 variant="outline"
@@ -1313,6 +1413,19 @@ export default function LibraryPage() {
                 </div>
               </AccordionContent>
             </AccordionItem>
+          )}
+
+          {/* Phrases section */}
+          {showWords && grouped.word.length > 0 && (
+            <ContentGroup
+              type="word"
+              items={grouped.word}
+              onDelete={deleteContent}
+              onSetActive={handleSetActive}
+              selectable={selectMode}
+              selectedIds={selectedIds}
+              onToggleSelect={toggleSelect}
+            />
           )}
 
           {/* Phrases section */}

--- a/src/app/(app)/read/[id]/page.layout.test.ts
+++ b/src/app/(app)/read/[id]/page.layout.test.ts
@@ -15,4 +15,13 @@ describe('read practice layout', () => {
     expect(source).toMatch(/read-practice-workspace[\s\S]*h-\[calc\(100dvh-9\.5rem\)\]/);
     expect(source).toMatch(/read-practice-workspace[\s\S]*ReadAloudInlineControls/);
   });
+
+  it('shows recognition errors in the native controls', () => {
+    const controlsStart = source.indexOf('{isIOSNativeHost ? (', source.indexOf('{raIsActive &&'));
+    const controlsEnd = source.indexOf(') : (\n              <ReadAloudInlineControls', controlsStart);
+
+    expect(source.slice(controlsStart, controlsEnd)).toContain(
+      '{speechError && <p className="text-xs text-red-500 text-center max-w-md">{speechError}</p>}',
+    );
+  });
 });

--- a/src/app/(app)/read/[id]/page.tsx
+++ b/src/app/(app)/read/[id]/page.tsx
@@ -106,7 +106,7 @@ export default function ReadDetailPage() {
   const isDailyPlanPractice = useDailyPlanStore((s) =>
     s.tasks.some((task) => !task.completed && !task.skipped && task.module === 'read' && task.contentId === params.id),
   );
-  const { addContent } = useContentStore();
+  const { addContent, items: contentItems } = useContentStore();
   const {
     sentenceTranslations,
     isLoading: translationLoading,
@@ -222,7 +222,7 @@ export default function ReadDetailPage() {
       return;
     }
 
-    const itemFromStore = useContentStore.getState().items.find((item) => item.id === contentId);
+    const itemFromStore = contentItems.find((item) => item.id === contentId);
     if (itemFromStore) {
       setContent(itemFromStore);
       setContentNotFound(false);
@@ -251,7 +251,7 @@ export default function ReadDetailPage() {
     return () => {
       cancelled = true;
     };
-  }, [bootstrapReady, params.id]);
+  }, [bootstrapReady, contentItems, params.id]);
 
   useEffect(() => {
     if (shadowReadingSession?.contentId === params.id) {
@@ -1273,7 +1273,15 @@ export default function ReadDetailPage() {
                   onPrev={handleReadAloudPrev}
                   progress={readPracticeProgress}
                 />
-                <div className={cn(IOS_SECTION_CARD_CLASS, 'flex justify-end px-4 py-3')}>
+                <div className={cn(IOS_SECTION_CARD_CLASS, 'flex justify-end gap-2 px-4 py-3')}>
+                  <Button
+                    ref={resetButtonRef}
+                    variant="outline"
+                    onClick={handleReset}
+                    className="border-indigo-200 text-indigo-600"
+                  >
+                    <RotateCcw className="mr-2 h-4 w-4" /> {t.recording.reset}
+                  </Button>
                   <Button
                     onClick={isListening ? stopListening : startListening}
                     disabled={isFallbackTranscribing}
@@ -1306,6 +1314,10 @@ export default function ReadDetailPage() {
                         ? t.a11y.stopRecording
                         : t.a11y.startRecording}
                   </Button>
+                  {speechError && <p className="text-xs text-red-500 text-center max-w-md">{speechError}</p>}
+                  {phase === 'processing' && (
+                    <p className="text-xs text-amber-600 font-medium">{t.recording.processingSpeech}</p>
+                  )}
                 </div>
               </>
             ) : (

--- a/src/components/import/file-upload-import.tsx
+++ b/src/components/import/file-upload-import.tsx
@@ -208,6 +208,17 @@ export function FileUploadImport() {
         <div className="flex items-center gap-2 text-red-500 text-sm">
           <AlertCircle className="w-4 h-4 shrink-0" />
           <span>{error}</span>
+          {file && !data && (
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={() => void handleExtract()}
+              disabled={extracting}
+            >
+              Retry
+            </Button>
+          )}
         </div>
       )}
 

--- a/src/components/import/url-import.tsx
+++ b/src/components/import/url-import.tsx
@@ -155,6 +155,9 @@ export function UrlImport() {
         <div className="flex items-center gap-2 text-red-500 text-sm">
           <AlertCircle className="w-4 h-4 shrink-0" />
           <span>{error}</span>
+          <Button type="button" size="sm" variant="outline" onClick={() => void handleFetch()} disabled={fetching}>
+            Retry
+          </Button>
         </div>
       )}
 

--- a/src/components/library/recycle-bin-dialog.test.tsx
+++ b/src/components/library/recycle-bin-dialog.test.tsx
@@ -1,0 +1,10 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(new URL('./recycle-bin-dialog.tsx', import.meta.url), 'utf8');
+
+describe('RecycleBinDialog', () => {
+  it('requires confirmation before permanently deleting content', () => {
+    expect(source).toContain('window.confirm(`Permanently delete "${item.title}"? This cannot be undone.`)');
+  });
+});

--- a/src/components/library/recycle-bin-dialog.tsx
+++ b/src/components/library/recycle-bin-dialog.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { RotateCcw, Trash2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import type { ContentItem } from '@/types/content';
+
+export function RecycleBinDialog({
+  items,
+  open,
+  onOpenChange,
+  onRestore,
+  onDelete,
+}: {
+  items: ContentItem[];
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onRestore: (id: string) => Promise<void>;
+  onDelete: (id: string) => Promise<void>;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[80vh] overflow-y-auto sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Recycle Bin</DialogTitle>
+          <DialogDescription>Restore content or permanently remove it from this device.</DialogDescription>
+        </DialogHeader>
+        {items.length === 0 ? (
+          <p className="py-8 text-center text-sm text-slate-500">No deleted content.</p>
+        ) : (
+          <div className="space-y-2">
+            {items.map((item) => (
+              <div key={item.id} className="flex items-center gap-3 rounded-lg border border-slate-200 p-3">
+                <div className="min-w-0 flex-1">
+                  <p className="truncate font-medium text-slate-900">{item.title}</p>
+                  <p className="text-xs text-slate-500">{item.type}</p>
+                </div>
+                <Button
+                  size="icon"
+                  variant="outline"
+                  aria-label={`Restore ${item.title}`}
+                  onClick={() => void onRestore(item.id)}
+                >
+                  <RotateCcw className="h-4 w-4" />
+                </Button>
+                <Button
+                  size="icon"
+                  variant="outline"
+                  aria-label={`Permanently delete ${item.title}`}
+                  onClick={() => {
+                    if (window.confirm(`Permanently delete "${item.title}"? This cannot be undone.`)) {
+                      void onDelete(item.id);
+                    }
+                  }}
+                >
+                  <Trash2 className="h-4 w-4 text-red-500" />
+                </Button>
+              </div>
+            ))}
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/read-aloud/ios-read-aloud-controls.test.tsx
+++ b/src/components/read-aloud/ios-read-aloud-controls.test.tsx
@@ -1,0 +1,35 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import { IOSReadAloudControls } from './ios-read-aloud-controls';
+
+describe('IOSReadAloudControls', () => {
+  it('offers the same discrete playback speeds as the web controls', () => {
+    const markup = renderToStaticMarkup(
+      <IOSReadAloudControls
+        label="Listen controls"
+        onPlay={() => {}}
+        onPause={() => {}}
+        onPrev={() => {}}
+        onNext={() => {}}
+      />,
+    );
+
+    for (const speed of ['0.5x', '0.75x', '1x', '1.25x', '1.5x', '2x']) {
+      expect(markup).toContain(`>${speed}</button>`);
+    }
+  });
+
+  it('disables restart when the page has no restart handler, matching web controls', () => {
+    const markup = renderToStaticMarkup(
+      <IOSReadAloudControls
+        label="Listen controls"
+        onPlay={() => {}}
+        onPause={() => {}}
+        onPrev={() => {}}
+        onNext={() => {}}
+      />,
+    );
+
+    expect(markup).toMatch(/disabled=""[^>]*aria-label="Restart"/);
+  });
+});

--- a/src/components/read-aloud/ios-read-aloud-controls.tsx
+++ b/src/components/read-aloud/ios-read-aloud-controls.tsx
@@ -44,8 +44,6 @@ export function IOSReadAloudControls({
 
   const ttsProgress = words.length > 0 && currentWordIndex >= 0 ? ((currentWordIndex + 1) / words.length) * 100 : 0;
   const progress = Math.min(100, Math.max(0, progressOverride ?? ttsProgress));
-  const nextSpeed = SPEED_STEPS.find((step) => step > speed);
-  const previousSpeed = [...SPEED_STEPS].reverse().find((step) => step < speed);
 
   return (
     <div className={cn(IOS_LIST_CARD_CLASS, 'space-y-4 px-4 py-4')}>
@@ -97,7 +95,8 @@ export function IOSReadAloudControls({
             nativeHaptic('light');
             (onRestart ?? onPrev)();
           }}
-          className="flex h-11 items-center justify-center rounded-2xl bg-slate-100 text-slate-600 transition active:scale-[0.97]"
+          disabled={!onRestart}
+          className="flex h-11 items-center justify-center rounded-2xl bg-slate-100 text-slate-600 transition active:scale-[0.97] disabled:opacity-40"
           aria-label="Restart"
         >
           <RotateCcw className="h-4.5 w-4.5" />
@@ -142,31 +141,23 @@ export function IOSReadAloudControls({
         </button>
       </div>
 
-      <div className="grid grid-cols-2 gap-2">
-        <button
-          type="button"
-          onClick={() => {
-            if (!previousSpeed) return;
-            nativeHaptic('light');
-            setSpeed(previousSpeed);
-          }}
-          disabled={!previousSpeed}
-          className="h-10 rounded-2xl border border-slate-200 bg-white text-sm font-medium text-slate-600 transition disabled:opacity-40"
-        >
-          {raT.speedDown}
-        </button>
-        <button
-          type="button"
-          onClick={() => {
-            if (!nextSpeed) return;
-            nativeHaptic('light');
-            setSpeed(nextSpeed);
-          }}
-          disabled={!nextSpeed}
-          className="h-10 rounded-2xl border border-slate-200 bg-white text-sm font-medium text-slate-600 transition disabled:opacity-40"
-        >
-          {raT.speedUp}
-        </button>
+      <div className="flex flex-wrap items-center justify-center gap-2">
+        {SPEED_STEPS.map((step) => (
+          <button
+            key={step}
+            type="button"
+            onClick={() => {
+              nativeHaptic('light');
+              setSpeed(step);
+            }}
+            className={cn(
+              'rounded-full px-3 py-1.5 text-xs font-semibold transition-colors',
+              speed === step ? 'bg-indigo-600 text-white' : 'bg-white text-slate-600 hover:bg-slate-100',
+            )}
+          >
+            {step}x
+          </button>
+        ))}
       </div>
     </div>
   );

--- a/src/lib/create-library-collection.test.ts
+++ b/src/lib/create-library-collection.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { buildLibraryCollection } from './create-library-collection';
+
+describe('buildLibraryCollection', () => {
+  it('creates a user collection from selected content in selection order', () => {
+    const collection = buildLibraryCollection('Travel essentials', ['b', 'a']);
+
+    expect(collection.title).toBe('Travel essentials');
+    expect(collection.itemIds).toEqual(['b', 'a']);
+    expect(collection.source).toBe('user-created');
+  });
+});

--- a/src/lib/create-library-collection.ts
+++ b/src/lib/create-library-collection.ts
@@ -1,0 +1,22 @@
+import { nanoid } from 'nanoid';
+import type { CollectionItem } from '@/types/content';
+
+export function buildLibraryCollection(title: string, itemIds: string[]): CollectionItem {
+  const now = Date.now();
+  return {
+    id: nanoid(),
+    title,
+    titleZh: title,
+    description: `${itemIds.length} saved items`,
+    descriptionZh: `${itemIds.length} 条已保存内容`,
+    scenario: title,
+    category: 'custom',
+    difficulty: 'beginner',
+    icon: '📚',
+    itemIds,
+    tags: ['custom'],
+    source: 'user-created',
+    createdAt: now,
+    updatedAt: now,
+  };
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -239,6 +239,24 @@ class EchoTypeDB extends Dexie {
       journals: 'id, lessonDate, source, updatedAt, *tags',
     });
 
+    this.version(16).stores({
+      contents: 'id, type, category, source, difficulty, createdAt, updatedAt, deletedAt, *tags',
+      records: 'id, contentId, module, lastPracticed, nextReview, updatedAt',
+      sessions: 'id, contentId, module, startTime, completed',
+      books: 'id, title, source, createdAt',
+      conversations: 'id, updatedAt, createdAt',
+      favorites:
+        'id, normalizedText, type, folderId, sourceContentId, targetLang, nextReview, autoCollected, createdAt, updatedAt',
+      favoriteFolders: 'id, sortOrder, createdAt',
+      lookupHistory: 'text, count, lastLookedUp',
+      translationCache: 'key, createdAt',
+      mediaBlobs: 'contentId, createdAt',
+      alignmentCache: 'cacheKey, createdAt',
+      weakSpots: 'id, module, weakSpotType, normalizedText, lastSeenAt, resolved, [module+weakSpotType+normalizedText]',
+      collections: 'id, category, source, difficulty, createdAt, updatedAt, *tags',
+      journals: 'id, lessonDate, source, updatedAt, *tags',
+    });
+
     // Dexie hooks: auto-set updatedAt on create/update for contents and records
     this.contents.hook('creating', (_primKey, obj) => {
       const now = Date.now();

--- a/src/lib/i18n/messages/library/en.json
+++ b/src/lib/i18n/messages/library/en.json
@@ -22,6 +22,7 @@
     "collection": "Collections",
     "wordbook": "Word Books",
     "book": "Books",
+    "word": "Words",
     "phrase": "Phrases",
     "sentence": "Sentences",
     "article": "Articles",

--- a/src/lib/i18n/messages/library/zh.json
+++ b/src/lib/i18n/messages/library/zh.json
@@ -22,6 +22,7 @@
     "collection": "场景合集",
     "wordbook": "词书",
     "book": "书籍",
+    "word": "单词",
     "phrase": "短语",
     "sentence": "句子",
     "article": "文章",

--- a/src/lib/ios-native-qa.test.ts
+++ b/src/lib/ios-native-qa.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(new URL('./ios-native-qa.ts', import.meta.url), 'utf8');
+
+describe('iOS native QA hydration', () => {
+  it('clears IndexedDB tables without concurrent WebKit transactions', () => {
+    const clearStart = source.indexOf('async function clearDynamicTables()');
+    const clearEnd = source.indexOf('\n}\n\nfunction clearDynamicStorage', clearStart);
+
+    expect(source.slice(clearStart, clearEnd)).not.toContain('Promise.all');
+  });
+});

--- a/src/lib/ios-native-qa.ts
+++ b/src/lib/ios-native-qa.ts
@@ -168,7 +168,7 @@ async function ensureFavoriteFolders() {
   const existing = await db.favoriteFolders.count();
   if (existing > 0) return;
   const now = Date.now();
-  await db.favoriteFolders.bulkAdd(DEFAULT_FOLDERS.map((folder) => ({ ...folder, createdAt: now })));
+  await db.favoriteFolders.bulkPut(DEFAULT_FOLDERS.map((folder) => ({ ...folder, createdAt: now })));
   window.localStorage.setItem(FAVORITE_FOLDERS_KEY, 'true');
 }
 
@@ -306,14 +306,12 @@ async function seedDashboardSessions() {
 }
 
 async function clearDynamicTables() {
-  await Promise.all([
-    db.records.clear(),
-    db.sessions.clear(),
-    db.favorites.clear(),
-    db.favoriteFolders.clear(),
-    db.conversations.clear(),
-    db.weakSpots.clear(),
-  ]);
+  await db.records.clear();
+  await db.sessions.clear();
+  await db.favorites.clear();
+  await db.favoriteFolders.clear();
+  await db.conversations.clear();
+  await db.weakSpots.clear();
 }
 
 function clearDynamicStorage() {

--- a/src/lib/library-data.test.ts
+++ b/src/lib/library-data.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { groupLibraryContent } from './library-data';
+
+describe('groupLibraryContent', () => {
+  it('keeps standalone words visible and excludes recycled content', () => {
+    const groups = groupLibraryContent([
+      { id: 'word', type: 'word', title: 'hello', text: 'hello', tags: [], source: 'builtin', createdAt: 1, updatedAt: 1 },
+      { id: 'deleted', type: 'sentence', title: 'gone', text: 'gone', tags: [], source: 'imported', createdAt: 1, updatedAt: 1, deletedAt: 2 },
+    ]);
+
+    expect(groups.word.map((item) => item.id)).toEqual(['word']);
+    expect(groups.sentence).toEqual([]);
+  });
+});

--- a/src/lib/library-data.ts
+++ b/src/lib/library-data.ts
@@ -1,0 +1,12 @@
+import type { ContentItem, ContentType } from '@/types/content';
+
+export function groupLibraryContent(items: ContentItem[]): Record<ContentType, ContentItem[]> {
+  const groups: Record<ContentType, ContentItem[]> = { word: [], phrase: [], sentence: [], article: [] };
+
+  for (const item of items) {
+    if (item.deletedAt || (item.type === 'article' && item.category?.startsWith('book-'))) continue;
+    groups[item.type].push(item);
+  }
+
+  return groups;
+}

--- a/src/lib/seed-data/coverage.test.ts
+++ b/src/lib/seed-data/coverage.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { builtinArticles } from './articles';
+import { builtinPhrases } from './phrases';
+import { builtinSentences } from './sentences';
+import { builtinWords } from './words';
+
+describe('builtin Library content', () => {
+  it('ships all four content types for a first-run Library', () => {
+    expect(builtinWords.length).toBeGreaterThan(0);
+    expect(builtinPhrases.length).toBeGreaterThan(0);
+    expect(builtinSentences.length).toBeGreaterThan(0);
+    expect(builtinArticles.length).toBeGreaterThan(0);
+  });
+});

--- a/src/lib/tauri.test.ts
+++ b/src/lib/tauri.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+import { getNativeChatToolSuite } from './tauri';
+
+describe('getNativeChatToolSuite', () => {
+  it('uses the mobile tool suite only for the iOS native host', () => {
+    expect(getNativeChatToolSuite(true)).toBe('mobile');
+    expect(getNativeChatToolSuite(false)).toBeUndefined();
+  });
+});

--- a/src/stores/auth-store.test.ts
+++ b/src/stores/auth-store.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const createClientMock = vi.fn();
 const isSupabaseConfiguredMock = vi.fn();
 const switchDatabaseForUserMock = vi.fn();
+const triggerFullSyncMock = vi.fn();
 
 vi.mock('@/lib/supabase/client', () => ({
   createClient: createClientMock,
@@ -15,6 +16,12 @@ vi.mock('@/lib/db', () => ({
 
 vi.mock('@/lib/tauri', () => ({
   IS_TAURI: false,
+}));
+
+vi.mock('@/stores/sync-store', () => ({
+  useSyncStore: {
+    getState: () => ({ triggerFullSync: triggerFullSyncMock }),
+  },
 }));
 
 describe('auth-store', () => {
@@ -57,6 +64,53 @@ describe('auth-store', () => {
       isLoading: false,
       user,
     });
+  });
+
+  it('starts a full cloud sync as soon as authentication is established', async () => {
+    const user = {
+      id: 'user-3',
+      email: 'sync@example.com',
+      user_metadata: {},
+    };
+    const onAuthStateChange = vi.fn().mockReturnValue({ data: { subscription: { unsubscribe: vi.fn() } } });
+
+    createClientMock.mockReturnValue({
+      auth: {
+        getUser: vi.fn().mockResolvedValue({ data: { user }, error: null }),
+        getSession: vi.fn(),
+        onAuthStateChange,
+      },
+    });
+
+    const { useAuthStore } = await import('./auth-store');
+    await useAuthStore.getState().initialize();
+
+    expect(triggerFullSyncMock).toHaveBeenCalledOnce();
+  });
+
+  it('does not start duplicate syncs for the initial authenticated session event', async () => {
+    const user = {
+      id: 'user-4',
+      email: 'dedupe@example.com',
+      user_metadata: {},
+    };
+    const onAuthStateChange = vi.fn((callback) => {
+      callback('INITIAL_SESSION', { user });
+      return { data: { subscription: { unsubscribe: vi.fn() } } };
+    });
+
+    createClientMock.mockReturnValue({
+      auth: {
+        getUser: vi.fn().mockResolvedValue({ data: { user }, error: null }),
+        getSession: vi.fn(),
+        onAuthStateChange,
+      },
+    });
+
+    const { useAuthStore } = await import('./auth-store');
+    await useAuthStore.getState().initialize();
+
+    expect(triggerFullSyncMock).toHaveBeenCalledOnce();
   });
 
   it('falls back to getSession when getUser cannot resolve the current user', async () => {

--- a/src/stores/auth-store.ts
+++ b/src/stores/auth-store.ts
@@ -4,6 +4,7 @@ import { create } from 'zustand';
 import { switchDatabaseForUser } from '@/lib/db';
 import { createClient, isSupabaseConfigured } from '@/lib/supabase/client';
 import { IOS_NATIVE_AUTH_CALLBACK_URL, IS_IOS_NATIVE_HOST, IS_NATIVE_HOST, IS_TAURI } from '@/lib/tauri';
+import { useSyncStore } from '@/stores/sync-store';
 
 interface AuthState {
   user: User | null;
@@ -29,6 +30,17 @@ let initialized = false;
 let initializePromise: Promise<void> | null = null;
 let authSubscription: { unsubscribe: () => void } | null = null;
 let oauthPollingTimer: ReturnType<typeof setInterval> | null = null;
+let lastSyncedUserId: string | null = null;
+
+function syncAfterAuthentication(user: User | null) {
+  if (!user) {
+    lastSyncedUserId = null;
+    return;
+  }
+  if (lastSyncedUserId === user.id) return;
+  lastSyncedUserId = user.id;
+  void useSyncStore.getState().triggerFullSync();
+}
 
 async function resolveInitialUser(supabase: NonNullable<ReturnType<typeof createClient>>): Promise<User | null> {
   const {
@@ -178,6 +190,7 @@ export const useAuthStore = create<AuthState>((set) => ({
               isAuthenticated: !!session?.user,
               isLoading: false,
             });
+            syncAfterAuthentication(session?.user ?? null);
           });
         });
         authSubscription = subscription;
@@ -191,6 +204,7 @@ export const useAuthStore = create<AuthState>((set) => ({
         isAuthenticated: !!user,
         isLoading: false,
       });
+      syncAfterAuthentication(user);
 
       initialized = true;
     })()

--- a/src/stores/collection-store.test.ts
+++ b/src/stores/collection-store.test.ts
@@ -80,6 +80,16 @@ describe('useCollectionStore', () => {
     expect(items.map((item) => item.id)).toEqual(['second', 'first']);
   });
 
+  it('updates collection item order durably', async () => {
+    const collection = { id: 'travel', itemIds: ['one', 'two'], updatedAt: 1 };
+    useCollectionStore.setState({ collections: [collection as never] });
+
+    await useCollectionStore.getState().updateCollection('travel', { itemIds: ['two', 'one'] });
+
+    expect(putCollectionMock).toHaveBeenCalledWith(expect.objectContaining({ id: 'travel', itemIds: ['two', 'one'] }));
+    expect(useCollectionStore.getState().collections[0].itemIds).toEqual(['two', 'one']);
+  });
+
   it('seeds missing builtin collections even when the old seed marker exists', async () => {
     storage.set('echotype_collections_seeded_v1', '1');
     bulkGetCollectionsMock.mockResolvedValue([]);

--- a/src/stores/collection-store.ts
+++ b/src/stores/collection-store.ts
@@ -12,6 +12,7 @@ interface CollectionStore {
   seedBuiltinCollections: () => Promise<void>;
   ensureBuiltinCollections: () => Promise<void>;
   addCollection: (collection: CollectionItem) => Promise<void>;
+  updateCollection: (id: string, updates: Partial<Omit<CollectionItem, 'id' | 'createdAt'>>) => Promise<void>;
   deleteCollection: (id: string) => Promise<void>;
   getCollectionById: (id: string) => CollectionItem | undefined;
   getCollectionItems: (id: string) => Promise<ContentItem[]>;
@@ -95,6 +96,16 @@ export const useCollectionStore = create<CollectionStore>((set, get) => ({
   addCollection: async (collection) => {
     await db.collections.add(collection);
     set((state) => ({ collections: [collection, ...state.collections] }));
+  },
+
+  updateCollection: async (id, updates) => {
+    const current = get().collections.find((collection) => collection.id === id) ?? (await db.collections.get(id));
+    if (!current) return;
+    const updated = { ...current, ...updates, updatedAt: Date.now() };
+    await db.collections.put(updated);
+    set((state) => ({
+      collections: state.collections.map((collection) => (collection.id === id ? updated : collection)),
+    }));
   },
 
   deleteCollection: async (id) => {

--- a/src/stores/content-store.test.ts
+++ b/src/stores/content-store.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const updateMock = vi.fn();
+const toArrayMock = vi.fn();
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    contents: {
+      update: updateMock,
+      orderBy: vi.fn(() => ({ reverse: vi.fn(() => ({ toArray: toArrayMock })) })),
+      add: vi.fn(),
+      bulkAdd: vi.fn(),
+      delete: vi.fn(),
+    },
+  },
+}));
+
+const { useContentStore } = await import('./content-store');
+
+describe('useContentStore recycle bin', () => {
+  const item = {
+    id: 'content-1',
+    title: 'Keep me',
+    text: 'Keep me',
+    type: 'sentence' as const,
+    tags: [],
+    source: 'imported' as const,
+    createdAt: 1,
+    updatedAt: 1,
+  };
+
+  beforeEach(() => {
+    updateMock.mockReset();
+    useContentStore.setState({ items: [item], isLoaded: true, loading: false });
+  });
+
+  it('moves deleted content to the recycle bin and restores it', async () => {
+    await useContentStore.getState().deleteContent(item.id);
+
+    expect(updateMock).toHaveBeenCalledWith(item.id, expect.objectContaining({ deletedAt: expect.any(Number) }));
+    expect(useContentStore.getState().items[0].deletedAt).toEqual(expect.any(Number));
+
+    await useContentStore.getState().restoreContent(item.id);
+
+    expect(updateMock).toHaveBeenLastCalledWith(item.id, expect.objectContaining({ deletedAt: undefined }));
+    expect(useContentStore.getState().items[0].deletedAt).toBeUndefined();
+  });
+});

--- a/src/stores/content-store.ts
+++ b/src/stores/content-store.ts
@@ -18,9 +18,11 @@ interface ContentStore {
   addContent: (item: ContentItem) => Promise<void>;
   addBulkContent: (items: ContentItem[]) => Promise<void>;
   deleteContent: (id: string) => Promise<void>;
+  restoreContent: (id: string) => Promise<void>;
+  permanentlyDeleteContent: (id: string) => Promise<void>;
   updateContent: (
     id: string,
-    updates: Partial<Pick<ContentItem, 'title' | 'tags' | 'category' | 'difficulty'>>,
+    updates: Partial<Pick<ContentItem, 'title' | 'text' | 'type' | 'tags' | 'category' | 'difficulty'>>,
   ) => Promise<void>;
   getFilteredItems: () => ContentItem[];
   getAllTags: () => { tag: string; count: number }[];
@@ -76,8 +78,26 @@ export const useContentStore = create<ContentStore>((set, get) => ({
   },
 
   deleteContent: async (id) => {
+    const deletedAt = Date.now();
+    await db.contents.update(id, { deletedAt, updatedAt: deletedAt });
+    set((state) => ({
+      items: state.items.map((item) => (item.id === id ? { ...item, deletedAt, updatedAt: deletedAt } : item)),
+      isLoaded: true,
+    }));
+  },
+
+  restoreContent: async (id) => {
+    const updatedAt = Date.now();
+    await db.contents.update(id, { deletedAt: undefined, updatedAt });
+    set((state) => ({
+      items: state.items.map((item) => (item.id === id ? { ...item, deletedAt: undefined, updatedAt } : item)),
+      isLoaded: true,
+    }));
+  },
+
+  permanentlyDeleteContent: async (id) => {
     await db.contents.delete(id);
-    set((state) => ({ items: state.items.filter((i) => i.id !== id), isLoaded: true }));
+    set((state) => ({ items: state.items.filter((item) => item.id !== id), isLoaded: true }));
   },
 
   updateContent: async (id, updates) => {
@@ -91,6 +111,7 @@ export const useContentStore = create<ContentStore>((set, get) => ({
   getFilteredItems: () => {
     const { items, filter } = get();
     return items.filter((item) => {
+      if (item.deletedAt) return false;
       if (filter.type && item.type !== filter.type) return false;
       if (filter.difficulty && item.difficulty !== filter.difficulty) return false;
       if (filter.category && item.category !== filter.category) return false;

--- a/src/stores/sync-store.test.ts
+++ b/src/stores/sync-store.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const storage = new Map<string, string>();
+
+describe('sync-store', () => {
+  beforeEach(() => {
+    storage.clear();
+    vi.resetModules();
+    vi.stubGlobal('window', {});
+    vi.stubGlobal('localStorage', {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => storage.set(key, value),
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('restores automatic sync when it was enabled before the app restarted', async () => {
+    storage.set('echotype_sync_settings', JSON.stringify({ isSyncEnabled: true, lastSyncedAt: '2026-08-01T00:00:00.000Z' }));
+    const { useSyncStore } = await import('./sync-store');
+    const startAutoSync = vi.fn();
+    useSyncStore.setState({ startAutoSync });
+
+    useSyncStore.getState().hydrate();
+
+    expect(useSyncStore.getState()).toMatchObject({
+      isSyncEnabled: true,
+      lastSyncedAt: '2026-08-01T00:00:00.000Z',
+    });
+    expect(startAutoSync).toHaveBeenCalledOnce();
+  });
+});

--- a/src/stores/sync-store.ts
+++ b/src/stores/sync-store.ts
@@ -69,6 +69,7 @@ export const useSyncStore = create<SyncState>((set, get) => ({
   hydrate: () => {
     const stored = loadFromStorage();
     set({ isSyncEnabled: stored.isSyncEnabled, lastSyncedAt: stored.lastSyncedAt });
+    if (stored.isSyncEnabled) get().startAutoSync();
   },
 
   triggerFullSync: async () => {

--- a/src/types/content.ts
+++ b/src/types/content.ts
@@ -26,6 +26,7 @@ export interface ContentItem {
   metadata?: ContentMetadata;
   createdAt: number;
   updatedAt: number;
+  deletedAt?: number;
 }
 
 export interface MistakeEntry {


### PR DESCRIPTION
## Summary
- align Library content editing, grouping, collection creation, recycle bin, and import recovery with Web
- add native QA coverage for Library books, collections, and collection generation
- add fallback QA state for seeded Library book detail and protect permanent deletion with confirmation

## Validation
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (124 files, 754 tests)
- focused iOS UI tests on iPhone 16 Simulator: Library book detail, collection detail, collection generation
