### PR TITLE
fix: resolve Windows startup crash from Node entry path (#105)

### DIFF
--- a/.github/workflows/startup-desktop.yml
+++ b/.github/workflows/startup-desktop.yml
@@ -1,0 +1,130 @@
+name: Startup - Desktop and Web
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: startup-desktop-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  desktop:
+    name: Startup ${{ matrix.os }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            bundle: nsis
+          - os: macos-15
+            bundle: app
+          - os: ubuntu-22.04
+            bundle: deb
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Linux desktop dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev patchelf xvfb dbus-x11
+      - run: pnpm install --frozen-lockfile
+      - run: node --test scripts/ci/startup-smoke.test.mjs
+      - run: pnpm exec playwright install --with-deps chromium
+      - name: Prepare production resources and bundled Node
+        shell: bash
+        run: pnpm build:tauri
+      - name: Sidecar regression tests with bundled Node
+        shell: bash
+        run: |
+          if [ "$RUNNER_OS" = Windows ]; then
+            ECHOTYPE_TEST_NODE="$(cygpath -w "$PWD/src-tauri/binaries/node.exe")"
+          else
+            ECHOTYPE_TEST_NODE="$PWD/src-tauri/binaries/node"
+          fi
+          export ECHOTYPE_TEST_NODE
+          cargo test --locked --manifest-path src-tauri/Cargo.toml --lib
+      - name: Build unsigned test bundle (no release publishing)
+        shell: bash
+        run: pnpm exec tauri build --bundles ${{ matrix.bundle }} --config '{"build":{"beforeBuildCommand":""},"bundle":{"createUpdaterArtifacts":false}}'
+      - name: Install and launch Windows bundle from Unicode path
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $installer = Get-ChildItem src-tauri/target/release/bundle/nsis/*.exe | Select-Object -First 1
+          if (-not $installer) { throw 'NSIS installer missing' }
+          $installDir = Join-Path $env:RUNNER_TEMP 'EchoType startup 中文'
+          $install = Start-Process -FilePath $installer.FullName -ArgumentList @('/S', "/D=$installDir") -PassThru
+          if (-not $install.WaitForExit(180000)) { $install.Kill(); throw 'Installer timed out' }
+          if ($install.ExitCode -ne 0) { throw "Installer failed: $($install.ExitCode)" }
+          $app = Join-Path $installDir 'echotype.exe'
+          if (-not (Test-Path $app)) { throw "Installed app missing: $app" }
+          node scripts/ci/startup-smoke.mjs $app
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+      - name: Launch macOS app bundle from Unicode path
+        if: runner.os == 'macOS'
+        run: |
+          APP_DIR="$RUNNER_TEMP/EchoType startup 中文.app"
+          ditto src-tauri/target/release/bundle/macos/EchoType.app "$APP_DIR"
+          node scripts/ci/startup-smoke.mjs "$APP_DIR/Contents/MacOS/echotype"
+      - name: Install and launch Linux deb
+        if: runner.os == 'Linux'
+        run: |
+          sudo dpkg -i src-tauri/target/release/bundle/deb/*.deb
+          xvfb-run -a dbus-run-session -- node scripts/ci/startup-smoke.mjs /usr/bin/echotype
+      - name: Save test installers and screenshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: startup-${{ matrix.os }}
+          retention-days: 7
+          path: |
+            startup-artifacts/
+            src-tauri/target/release/bundle/nsis/*.exe
+            src-tauri/target/release/bundle/deb/*.deb
+          if-no-files-found: warn
+
+  web:
+    name: Production Web startup
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: node --test scripts/ci/startup-smoke.test.mjs
+      - run: pnpm exec playwright install --with-deps chromium
+      - run: pnpm build
+      - name: Launch production server and render application
+        env:
+          SMOKE_PORT: 54576
+        run: node scripts/ci/startup-smoke.mjs node node_modules/next/dist/bin/next start --hostname 127.0.0.1 --port 54576
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: startup-web
+          path: startup-artifacts/
+          retention-days: 7

--- a/.github/workflows/startup-ios.yml
+++ b/.github/workflows/startup-ios.yml
@@ -1,0 +1,89 @@
+name: iOS Startup
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  simulator-startup:
+    name: iOS Simulator Launch
+    runs-on: macos-15
+    timeout-minutes: 40
+    env:
+      NEXT_TELEMETRY_DISABLED: '1'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Build this commit's web app
+        run: pnpm build
+      - name: Prepare simulator and project
+        run: |
+          set -euo pipefail
+          brew list xcodegen >/dev/null 2>&1 || brew install xcodegen
+          (cd ios && xcodegen generate)
+          xcodebuild -version
+          xcrun simctl list devices available --json > "$RUNNER_TEMP/simulators.json"
+          simulator_id=$(node -e 'const fs = require("fs"); const list = JSON.parse(fs.readFileSync(process.argv[1], "utf8")); const device = Object.entries(list.devices).filter(([runtime]) => runtime.includes("iOS")).flatMap(([, devices]) => devices).find(d => d.isAvailable && d.name.startsWith("iPhone")); if (!device) throw new Error("No available iPhone simulator"); process.stdout.write(device.udid);' "$RUNNER_TEMP/simulators.json")
+          echo "SIMULATOR_ID=$simulator_id" >> "$GITHUB_ENV"
+          xcrun simctl boot "$simulator_id"
+          xcrun simctl bootstatus "$simulator_id" -b
+      - name: Launch and test native app against local production build
+        env:
+          TEST_RUNNER_ECHOTYPE_UI_TEST_WEB_ORIGIN: http://127.0.0.1:3005
+          TEST_RUNNER_ECHOTYPE_UI_TEST_LOCAL_WEB_ORIGIN: http://127.0.0.1:3005
+        run: |
+          set -euo pipefail
+          pnpm start --hostname 127.0.0.1 --port 3005 > "$RUNNER_TEMP/ios-web.log" 2>&1 &
+          web_pid=$!
+          trap 'kill "$web_pid" 2>/dev/null || true' EXIT
+          ready=false
+          for _ in {1..60}; do
+            if curl --fail --silent http://127.0.0.1:3005/dashboard >/dev/null; then
+              ready=true
+              break
+            fi
+            kill -0 "$web_pid"
+            sleep 2
+          done
+          if [ "$ready" != true ]; then
+            cat "$RUNNER_TEMP/ios-web.log"
+            exit 1
+          fi
+          xcodebuild test \
+            -project ios/EchoTypeiOS.xcodeproj \
+            -scheme EchoType \
+            -destination "platform=iOS Simulator,id=$SIMULATOR_ID" \
+            -parallel-testing-enabled NO \
+            -resultBundlePath "$RUNNER_TEMP/ios-startup.xcresult" \
+            -only-testing:EchoTypeTests \
+            -only-testing:EchoTypeUITests/StartupUITests \
+            -only-testing:EchoTypeUITests/NativeNavigationUITests/testBottomTabsNavigateAcrossPrimaryModules \
+            CODE_SIGNING_ALLOWED=NO 2>&1 | tee "$RUNNER_TEMP/ios-xcodebuild.log"
+      - name: Upload simulator test results and logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-startup-results
+          retention-days: 7
+          path: |
+            ${{ runner.temp }}/ios-startup.xcresult
+            ${{ runner.temp }}/ios-xcodebuild.log
+            ${{ runner.temp }}/ios-web.log
+            ${{ runner.temp }}/simulators.json

--- a/.github/workflows/startup-ios.yml
+++ b/.github/workflows/startup-ios.yml
@@ -46,6 +46,9 @@ jobs:
           xcrun simctl bootstatus "$simulator_id" -b
       - name: Launch and test native app against local production build
         env:
+          # Hosted unit tests run inside the app itself, before XCUIApplication
+          # UI-test overrides are applied. Keep that initial launch local too.
+          TEST_RUNNER_ECHOTYPE_WEB_URL: http://127.0.0.1:3005/dashboard
           TEST_RUNNER_ECHOTYPE_UI_TEST_WEB_ORIGIN: http://127.0.0.1:3005
           TEST_RUNNER_ECHOTYPE_UI_TEST_LOCAL_WEB_ORIGIN: http://127.0.0.1:3005
         run: |

--- a/docs/design/issue-105-windows-startup.md
+++ b/docs/design/issue-105-windows-startup.md
@@ -1,0 +1,12 @@
+# Issue 105: Windows sidecar entry path
+
+Issue: https://github.com/Talljack/echo-type/issues/105
+
+Tauri resource paths can use Windows verbatim prefixes. Passing that full path as Node's entry argument triggers the reporter's EISDIR error before the server starts. The existing command already sets its working directory to the standalone folder. Use the relative entry `server.js` instead; retain the executable path, working directory, IPv4 binding and production environment unchanged. No new dependencies, storage changes or release version bump.
+
+Regression coverage:
+- Command inspection requires exactly `server.js` and preserves the working directory and environment. It failed against the old absolute-argument implementation before the fix.
+- A real Node process runs a fixture from a canonicalized directory with spaces and Unicode. On Windows canonicalization produces the verbatim path implicated in the report.
+- Windows-only command tests cover verbatim drive and UNC paths.
+
+Validation on macOS: `cargo test --manifest-path src-tauri/Cargo.toml --lib`, `cargo check --manifest-path src-tauri/Cargo.toml --release`, touched-file rustfmt and diff checks passed. Windows-specific tests and the installed Windows app have not been run locally. Before shipping, run the same Rust tests on Windows with Node installed (or set `ECHOTYPE_TEST_NODE` to the bundled node.exe), then verify the packaged installer starts from a path with spaces/Unicode. No package has been published by this change.

--- a/docs/design/startup-verification.md
+++ b/docs/design/startup-verification.md
@@ -1,0 +1,21 @@
+# Startup verification
+
+Pull requests and main pushes run `.github/workflows/startup-desktop.yml` and `startup-ios.yml`. No release is created; no signing or production secrets are used.
+
+| Target | Automated proof |
+| --- | --- |
+| Windows hosted runner | Rust regressions with bundled Node; unsigned NSIS build and installation into a Unicode/space path; installed process survives, local HTTP responds, Chromium renders dashboard/library |
+| macOS 15 hosted runner | Same Rust regressions; unsigned app bundle launched from a Unicode/space path; process/HTTP/Chromium checks |
+| Ubuntu 22.04 hosted runner | Same Rust regressions; deb installed and executable launched under Xvfb; process/HTTP/Chromium checks |
+| Web | Production build and server, actual dashboard/library headings in Chromium, no uncaught page errors |
+| iOS simulator | Native app built from source against this commit's local production Web server; three cold launches, actual WKWebView dashboard content, native navigation and unit tests |
+
+Desktop/Web observation lasts 60 seconds after readiness, beyond issue 105's original timeout. Ports must be unused before launch, preventing unrelated local servers from falsely passing. The smoke harness has tests for readiness, occupied ports, early exit and HTTP failures. Its cleanup only targets the process tree it launches.
+
+Artifacts preserve page screenshots and Windows/Linux test installers; iOS preserves XCTest results, screenshots and logs. Process output is available in Actions logs. Use the installer from the tested commit, not an older release with the same version number.
+
+## Limits
+
+Desktop screenshots and page assertions come from a separate Chromium instance against the app's sidecar, not the embedded native WebView. These jobs prove packaged-process startup and server/page health, not full native-window rendering or interaction. The iOS tests do check content inside WKWebView. Unsigned CI bundles do not certify Gatekeeper/SmartScreen, release signing, physical devices, every OS version/architecture, microphones, or third-party AI services. Treat any job that has not run or failed as unverified, never as a pass.
+
+To reproduce the harness locally: `node --test scripts/ci/startup-smoke.test.mjs`. Do not point the launch probe at an already-running user application. For application smoke checks use an isolated environment with a free port and an installed Playwright Chromium.

--- a/docs/superpowers/plans/2026-09-10-startup-verification.md
+++ b/docs/superpowers/plans/2026-09-10-startup-verification.md
@@ -1,0 +1,26 @@
+# Cross-platform startup verification implementation plan
+
+> **For agentic workers:** Use executing-plans for desktop/Web and a bounded iOS worker. Steps use checkbox syntax for tracking.
+
+**Goal:** Verify production startup on Windows, macOS, Linux, Web and the iOS simulator without publishing releases.
+
+**Architecture:** Independent pull-request workflows with read-only repository permissions build the current commit. Desktop jobs install/open actual bundles and probe their local server while checking process survival. Web checks use the production server. iOS uses native simulator UI tests. Artifacts preserve diagnostics; no release secrets are required.
+
+**Tech Stack:** GitHub Actions, Rust tests, Node process/HTTP checks, Playwright, Xcode simulator.
+
+### Desktop and Web
+
+- [ ] Add `scripts/ci/startup-smoke.mjs`: accept an executable and args, reject an occupied port, launch without a shell, wait at most 30 seconds for HTTP success, check dashboard and library in Chromium, observe the process for 60 seconds, kill only the spawned process tree in cleanup.
+- [ ] Add `scripts/ci/startup-smoke.test.mjs`: exercise successful fixture server, immediate exit, occupied port and HTTP failure with short test deadlines. Run `node --test scripts/ci/startup-smoke.test.mjs`.
+- [ ] Add `.github/workflows/startup-desktop.yml`: Windows/macOS/Linux build matrix, `cargo test --locked --manifest-path src-tauri/Cargo.toml --lib`, unsigned packaging, real bundle launch, failure logs/screenshots and installer artifacts. Windows installs NSIS into a path with spaces and Chinese; Linux installs deb under Xvfb; macOS opens the bundle executable.
+- [ ] Add a production Web job using `pnpm build` and the same browser startup probe with `next start`.
+
+### iOS
+
+- [ ] Add `.github/workflows/startup-ios.yml` and focused simulator tests, reusing native project conventions. Test local current-commit web content, not the deployed site.
+
+### Verification and delivery
+
+- [ ] Run local smoke harness tests and existing Rust tests. Validate workflow syntax.
+- [ ] Commit scoped changes and push the existing MR branch. Observe each GitHub job; distinguish runner/billing/network blockers from code failures.
+- [ ] Document actual results and remaining limits: hosted OS versions, no physical-device certification, no guarantee of every machine or external AI service.

--- a/ios/EchoType/App/RootViewController.swift
+++ b/ios/EchoType/App/RootViewController.swift
@@ -229,7 +229,6 @@ final class RootViewController: UIViewController {
     private var controllersByTab: [Tab: WebContainerViewController] = [:]
     private var buttonsByTab: [Tab: TabButton] = [:]
     private var currentTab: Tab?
-    private var tabsToPrewarm: [Tab] = []
     private let initialManagedPath: String = AppConfig.initialPath
 
     override func viewDidLoad() {
@@ -239,7 +238,6 @@ final class RootViewController: UIViewController {
         setupLayout()
         setupTabs()
         selectTab(initialTab(), animated: false)
-        scheduleTabPrewarming()
     }
 
     override var preferredStatusBarStyle: UIStatusBarStyle {
@@ -352,9 +350,10 @@ final class RootViewController: UIViewController {
             }
             controllersByTab[tab] = controller
 
-            // Non-entry tabs are prewarmed after the first screen is mounted.
-            // Their loading overlay stays disabled so a tab switch never
-            // covers the transition with a native Loading card.
+            // Load non-entry tabs only when selected. Eager loading starts five
+            // web bootstraps against the same IndexedDB before seeding finishes,
+            // which can leave the visible page blank after a transaction error.
+            // Keep the loading overlay disabled during subsequent tab switches.
             if tab != entryTab {
                 controller.setLoadingOverlayEnabled(false)
             }
@@ -363,24 +362,6 @@ final class RootViewController: UIViewController {
             button.addTarget(self, action: #selector(handleTabTapped(_:)), for: .touchUpInside)
             buttonsByTab[tab] = button
             tabStackView.addArrangedSubview(button)
-        }
-    }
-
-    private func scheduleTabPrewarming() {
-        let entryTab = initialTab()
-        tabsToPrewarm = Tab.allCases.filter { $0 != entryTab }
-        prewarmNextTab()
-    }
-
-    private func prewarmNextTab() {
-        guard !tabsToPrewarm.isEmpty else { return }
-        let tab = tabsToPrewarm.removeFirst()
-        controllersByTab[tab]?.loadViewIfNeeded()
-
-        // Keep WebKit startup work spread across the run loop so the visible
-        // entry page remains responsive during app launch.
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) { [weak self] in
-            self?.prewarmNextTab()
         }
     }
 

--- a/ios/EchoType/Features/WebContainer/WebContainerViewController.swift
+++ b/ios/EchoType/Features/WebContainer/WebContainerViewController.swift
@@ -24,6 +24,7 @@ final class WebContainerViewController: UIViewController {
     private let qaStateMarkerLabel = UILabel()
     private var navigationBarHeightConstraint: NSLayoutConstraint?
     private var navigationTitleCenterYConstraint: NSLayoutConstraint?
+    private var hasRegisteredWebViewObservers = false
     private lazy var webView: WKWebView = {
         let contentController = WKUserContentController()
         contentController.add(self, name: "echoTypeBridge")
@@ -313,14 +314,19 @@ final class WebContainerViewController: UIViewController {
         webView.addObserver(self, forKeyPath: #keyPath(WKWebView.canGoBack), options: .new, context: nil)
         webView.addObserver(self, forKeyPath: #keyPath(WKWebView.title), options: .new, context: nil)
         webView.addObserver(self, forKeyPath: #keyPath(WKWebView.url), options: .new, context: nil)
+        hasRegisteredWebViewObservers = true
         updateNavigationChrome()
     }
 
     deinit {
-        webView.removeObserver(self, forKeyPath: #keyPath(WKWebView.canGoBack))
-        webView.removeObserver(self, forKeyPath: #keyPath(WKWebView.title))
-        webView.removeObserver(self, forKeyPath: #keyPath(WKWebView.url))
-        webView.configuration.userContentController.removeScriptMessageHandler(forName: "echoTypeBridge")
+        // An unvisited tab never constructs its lazy WebView or registers KVO.
+        // Touching it during deinit would create delegates to a deallocating self.
+        if hasRegisteredWebViewObservers {
+            webView.removeObserver(self, forKeyPath: #keyPath(WKWebView.canGoBack))
+            webView.removeObserver(self, forKeyPath: #keyPath(WKWebView.title))
+            webView.removeObserver(self, forKeyPath: #keyPath(WKWebView.url))
+            webView.configuration.userContentController.removeScriptMessageHandler(forName: "echoTypeBridge")
+        }
     }
 
     override func observeValue(

--- a/ios/EchoTypeTests/SpeechRecognitionServiceTests.swift
+++ b/ios/EchoTypeTests/SpeechRecognitionServiceTests.swift
@@ -4,6 +4,17 @@ import WebKit
 
 final class SpeechRecognitionServiceTests: XCTestCase {
     @MainActor
+    func testUnvisitedTabCanBeReleasedWithoutLoadingItsWebView() {
+        weak var releasedController: WebContainerViewController?
+        autoreleasepool {
+            let controller = WebContainerViewController(initialPath: "/library", rootPath: "/library")
+            releasedController = controller
+            XCTAssertFalse(controller.isViewLoaded)
+        }
+        XCTAssertNil(releasedController, "Releasing an unvisited tab must not construct or retain a WebView")
+    }
+
+    @MainActor
     func testLocalTabsShareTheirEphemeralWebsiteDataStore() throws {
         let previous = ProcessInfo.processInfo.environment["ECHOTYPE_WEB_URL"]
         setenv("ECHOTYPE_WEB_URL", "http://127.0.0.1:3005/favorites", 1)

--- a/ios/EchoTypeUITests/StartupUITests.swift
+++ b/ios/EchoTypeUITests/StartupUITests.swift
@@ -1,0 +1,51 @@
+import XCTest
+
+/// Starts the real native host against the current commit's web build, not a fixture or production deployment.
+final class StartupUITests: XCTestCase {
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    @MainActor
+    func testRepeatedColdLaunchRendersDashboardAndRemainsAlive() throws {
+        let configuredOrigin = try XCTUnwrap(
+            ProcessInfo.processInfo.environment["ECHOTYPE_UI_TEST_WEB_ORIGIN"],
+            "Set TEST_RUNNER_ECHOTYPE_UI_TEST_WEB_ORIGIN to the locally built web server"
+        )
+        let origin = try XCTUnwrap(URL(string: configuredOrigin))
+        XCTAssertTrue(["localhost", "127.0.0.1"].contains(origin.host ?? ""), "Startup CI must test this commit locally")
+
+        let app = XCUIApplication()
+        app.launchEnvironment["ECHOTYPE_WEB_URL"] = origin.appendingPathComponent("dashboard").absoluteString
+        defer { app.terminate() }
+
+        for attempt in 1...3 {
+            app.launch()
+            XCTAssertEqual(app.state, .runningForeground)
+            let dashboard = app.staticTexts["native-qa-state"]
+            let rendered = XCTNSPredicateExpectation(
+                predicate: NSPredicate(format: "exists == true AND label CONTAINS %@", "page=dashboard"),
+                object: dashboard
+            )
+            XCTAssertEqual(XCTWaiter.wait(for: [rendered], timeout: 45), .completed,
+                           "The dashboard JS must execute inside WKWebView, not just display native chrome")
+            XCTAssertTrue(app.buttons["native-tab-today"].isHittable)
+
+            if attempt == 1 {
+                // Observe longer than the reported desktop startup timeout; detect a delayed native/WebView crash.
+                let deadline = Date().addingTimeInterval(65)
+                while Date() < deadline {
+                    XCTAssertEqual(app.state, .runningForeground)
+                    XCTAssertTrue(dashboard.exists)
+                    RunLoop.current.run(until: Date().addingTimeInterval(1))
+                }
+            }
+
+            let screenshot = XCTAttachment(screenshot: app.screenshot())
+            screenshot.name = "startup-\(attempt)"
+            screenshot.lifetime = .keepAlways
+            add(screenshot)
+            app.terminate()
+        }
+    }
+}

--- a/ios/EchoTypeUITests/StartupUITests.swift
+++ b/ios/EchoTypeUITests/StartupUITests.swift
@@ -49,6 +49,15 @@ final class StartupUITests: XCTestCase {
                     XCTAssertTrue(heading.exists)
                     RunLoop.current.run(until: Date().addingTimeInterval(1))
                 }
+
+                // Unvisited tabs must still load their real web content on demand.
+                app.buttons["native-tab-materials"].tap()
+                let importContent = app.webViews.buttons.matching(
+                    NSPredicate(format: "label IN %@", ["Import Content", "导入内容"])
+                ).firstMatch
+                XCTAssertTrue(importContent.waitForExistence(timeout: 30), "The lazily loaded Library must render")
+                app.buttons["native-tab-today"].tap()
+                XCTAssertTrue(heading.waitForExistence(timeout: 15), "Returning to Today must preserve the rendered dashboard")
             }
 
             let screenshot = XCTAttachment(screenshot: app.screenshot())

--- a/ios/EchoTypeUITests/StartupUITests.swift
+++ b/ios/EchoTypeUITests/StartupUITests.swift
@@ -24,11 +24,20 @@ final class StartupUITests: XCTestCase {
             XCTAssertEqual(app.state, .runningForeground)
             let dashboard = app.staticTexts["native-qa-state"]
             let rendered = XCTNSPredicateExpectation(
-                predicate: NSPredicate(format: "exists == true AND label CONTAINS %@", "page=dashboard"),
+                // The native shell fabricates page=dashboard before loading. These stats
+                // are reported only by the dashboard React effect after hydration.
+                predicate: NSPredicate(
+                    format: "exists == true AND label CONTAINS %@ AND label CONTAINS %@ AND label CONTAINS %@",
+                    "page=dashboard", "totalContent=", "totalSessions="
+                ),
                 object: dashboard
             )
             XCTAssertEqual(XCTWaiter.wait(for: [rendered], timeout: 45), .completed,
                            "The dashboard JS must execute inside WKWebView, not just display native chrome")
+            let heading = app.webViews.staticTexts.matching(
+                NSPredicate(format: "label IN %@", ["What to practice today", "今天练什么"])
+            ).firstMatch
+            XCTAssertTrue(heading.waitForExistence(timeout: 15), "Actual dashboard content must render in WKWebView")
             XCTAssertTrue(app.buttons["native-tab-today"].isHittable)
 
             if attempt == 1 {
@@ -37,6 +46,7 @@ final class StartupUITests: XCTestCase {
                 while Date() < deadline {
                     XCTAssertEqual(app.state, .runningForeground)
                     XCTAssertTrue(dashboard.exists)
+                    XCTAssertTrue(heading.exists)
                     RunLoop.current.run(until: Date().addingTimeInterval(1))
                 }
             }

--- a/ios/README.md
+++ b/ios/README.md
@@ -45,7 +45,13 @@ For command-line UI tests, use the `TEST_RUNNER_` prefix so Xcode forwards the o
 TEST_RUNNER_ECHOTYPE_UI_TEST_WEB_ORIGIN=http://127.0.0.1:3005 xcodebuild test -project EchoTypeiOS.xcodeproj -scheme EchoType -destination 'platform=iOS Simulator,name=iPhone 16 Pro' -parallel-testing-enabled NO
 ```
 
-## Scope
+## Startup CI
+
+`.github/workflows/startup-ios.yml` builds the web app from the same commit and serves it on loopback, then builds and launches the native app in an iPhone simulator. It runs native unit tests, a three-launch dashboard smoke test (including a 65-second liveness check), and the five-tab navigation test. No production web deployment, Apple signing credentials, or release publication is involved. Logs, screenshots, and the Xcode result bundle are uploaded as `ios-startup-results` even when tests fail.
+
+The workflow regenerates the Xcode project from `project.yml`, so new test files are included. For local startup tests, run `xcodegen generate` first and use the `TEST_RUNNER_ECHOTYPE_UI_TEST_WEB_ORIGIN` override documented above. The startup test deliberately requires a loopback origin to avoid accidentally validating the deployed site instead of your changes. Simulator checks do not cover physical-device installation, signing, hardware microphone behavior, or every iOS version.
+
+## Feature Scope
 
 Today settings, LearningUnit/Lesson courses (`/learn`) and the pronunciation studio reuse the same web implementation as desktop. Five native tabs provide Today (`/dashboard`), Courses (`/learn`), Materials (`/library`), Review (`/review`) and Notes (`/favorites`). Courses owns legacy skill and pronunciation deep links; Notes includes expressions (`/journal`); Review owns `/review/today`, `/favorites/review` and `/weak-spots`. Each tab preserves its own WebView and supplies section back navigation. Same-origin links across sections select the destination tab, preserve the clicked URL's query, and leave the source page available for restoration. Root navigation drops route-specific queries such as `lesson`. Native QA fixture routes default to the local server on port 3005. Updating source and building the shell does **not** publish web changes: installed production iOS apps receive them after the website is deployed. New native navigation changes require an updated iOS binary as well. Local/unsigned builds are not TestFlight releases.
 

--- a/ios/README.md
+++ b/ios/README.md
@@ -47,6 +47,8 @@ TEST_RUNNER_ECHOTYPE_UI_TEST_WEB_ORIGIN=http://127.0.0.1:3005 xcodebuild test -p
 
 ## Startup CI
 
+Native tabs initialize on first selection instead of eagerly starting five web bootstraps against the same database. This keeps first-run database seeding on the visible screen from competing with hidden tabs; previously selected tabs remain mounted for restoration. Startup UI tests also check that the Library renders when first selected and that returning to Today restores its content.
+
 `.github/workflows/startup-ios.yml` builds the web app from the same commit and serves it on loopback, then builds and launches the native app in an iPhone simulator. It runs native unit tests, a three-launch dashboard smoke test (including a 65-second liveness check), and the five-tab navigation test. No production web deployment, Apple signing credentials, or release publication is involved. Logs, screenshots, and the Xcode result bundle are uploaded as `ios-startup-results` even when tests fail.
 
 The workflow regenerates the Xcode project from `project.yml`, so new test files are included. For local startup tests, run `xcodegen generate` first and use the `TEST_RUNNER_ECHOTYPE_UI_TEST_WEB_ORIGIN` override documented above. The startup test deliberately requires a loopback origin to avoid accidentally validating the deployed site instead of your changes. Simulator checks do not cover physical-device installation, signing, hardware microphone behavior, or every iOS version.

--- a/scripts/ci/startup-smoke.mjs
+++ b/scripts/ci/startup-smoke.mjs
@@ -51,20 +51,28 @@ export async function runSmoke(executable, args, options = {}) {
     if (!ready) throw new Error(`App not ready within ${timeoutMs}ms`);
     assertAlive();
     if (browser) {
-      const { chromium } = await import('@playwright/test');
+      const { chromium, expect } = await import('@playwright/test');
       browserProcess = await chromium.launch();
-      const page = await browserProcess.newPage();
+      const page = await browserProcess.newPage({ locale: 'en-US' });
       const errors = [];
       page.on('pageerror', (error) => errors.push(error.message));
       await mkdir('startup-artifacts', { recursive: true });
       for (const route of ['/dashboard', '/library']) {
-        const response = await page.goto(`${origin}${route}`, { waitUntil: 'networkidle', timeout: 30000 });
-        if (!response?.ok()) throw new Error(`${route}: HTTP ${response?.status()}`);
-        await page.locator('main').waitFor({ state: 'visible' });
-        if ((await page.locator('main').innerText()).trim().length < 20) {
-          throw new Error(`${route}: empty application content`);
+        try {
+          const response = await page.goto(`${origin}${route}`, { waitUntil: 'domcontentloaded', timeout: 30000 });
+          if (!response?.ok()) throw new Error(`${route}: HTTP ${response?.status()}`);
+          // IndexedDB initialization can outlive network idle. Wait for real
+          // application content rather than inspecting the loading skeleton.
+          const heading = route === '/dashboard' ? 'What to practice today' : 'Content Library';
+          await expect(page.getByRole('heading', { name: heading, exact: true })).toBeVisible({ timeout: 30000 });
+          await expect
+            .poll(async () => (await page.locator('main').innerText()).trim().length, {
+              timeout: 30000,
+            })
+            .toBeGreaterThan(20);
+        } finally {
+          await page.screenshot({ path: `startup-artifacts${route}.png`, fullPage: true });
         }
-        await page.screenshot({ path: `startup-artifacts${route}.png`, fullPage: true });
       }
       if (errors.length) throw new Error(`Browser errors: ${errors.join('; ')}`);
     }

--- a/scripts/ci/startup-smoke.mjs
+++ b/scripts/ci/startup-smoke.mjs
@@ -1,0 +1,103 @@
+import { spawn, spawnSync } from 'node:child_process';
+import { mkdir } from 'node:fs/promises';
+import { createServer } from 'node:net';
+import { resolve } from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+import { pathToFileURL } from 'node:url';
+
+// CI-only probe. Never attach to an existing local user session/server.
+export async function runSmoke(executable, args, options = {}) {
+  const { port = 54576, timeoutMs = 30000, observeMs = 60000, browser = false } = options;
+  const reservation = createServer();
+  await new Promise((accept, reject) => {
+    reservation.once('error', () => reject(new Error(`Port ${port} occupied before launch`)));
+    reservation.listen(port, '127.0.0.1', accept);
+  });
+  await new Promise((accept) => reservation.close(accept));
+  const child = spawn(executable, args, {
+    stdio: 'inherit',
+    detached: process.platform !== 'win32',
+    env: { ...process.env, PORT: String(port), HOSTNAME: '127.0.0.1', NODE_ENV: 'production' },
+  });
+  let spawnError;
+  child.on('error', (error) => {
+    spawnError = error;
+  });
+  const assertAlive = () => {
+    if (spawnError) throw spawnError;
+    if (child.exitCode !== null || child.signalCode !== null) {
+      throw new Error(`App exited: code=${child.exitCode}, signal=${child.signalCode}`);
+    }
+  };
+  const origin = `http://127.0.0.1:${port}`;
+  let browserProcess;
+  try {
+    const deadline = Date.now() + timeoutMs;
+    let ready = false;
+    while (Date.now() < deadline) {
+      assertAlive();
+      try {
+        const response = await fetch(origin, { signal: AbortSignal.timeout(1000) });
+        await response.body?.cancel();
+        if (response.ok) {
+          ready = true;
+          break;
+        }
+      } catch {
+        /* wait for the application's own server */
+      }
+      await delay(100);
+    }
+    if (!ready) throw new Error(`App not ready within ${timeoutMs}ms`);
+    assertAlive();
+    if (browser) {
+      const { chromium } = await import('@playwright/test');
+      browserProcess = await chromium.launch();
+      const page = await browserProcess.newPage();
+      const errors = [];
+      page.on('pageerror', (error) => errors.push(error.message));
+      await mkdir('startup-artifacts', { recursive: true });
+      for (const route of ['/dashboard', '/library']) {
+        const response = await page.goto(`${origin}${route}`, { waitUntil: 'networkidle', timeout: 30000 });
+        if (!response?.ok()) throw new Error(`${route}: HTTP ${response?.status()}`);
+        await page.locator('main').waitFor({ state: 'visible' });
+        if ((await page.locator('main').innerText()).trim().length < 20) {
+          throw new Error(`${route}: empty application content`);
+        }
+        await page.screenshot({ path: `startup-artifacts${route}.png`, fullPage: true });
+      }
+      if (errors.length) throw new Error(`Browser errors: ${errors.join('; ')}`);
+    }
+    const until = Date.now() + observeMs;
+    while (Date.now() < until) {
+      assertAlive();
+      const response = await fetch(origin, { signal: AbortSignal.timeout(2000) });
+      await response.body?.cancel();
+      if (!response.ok) throw new Error(`Server stopped responding: HTTP ${response.status}`);
+      await delay(Math.min(1000, Math.max(1, until - Date.now())));
+    }
+    assertAlive();
+    console.log(
+      `PASS: ${executable}; HTTP ready, app alive for ${observeMs}ms${browser ? ', dashboard/library rendered' : ''}`,
+    );
+  } finally {
+    await browserProcess?.close();
+    if (child.pid) {
+      if (process.platform === 'win32') {
+        spawnSync('taskkill', ['/pid', String(child.pid), '/T', '/F'], { stdio: 'inherit' });
+      } else {
+        try {
+          process.kill(-child.pid, 'SIGKILL');
+        } catch {
+          /* already exited */
+        }
+      }
+    }
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  const [executable, ...args] = process.argv.slice(2);
+  if (!executable) throw new Error('Usage: node startup-smoke.mjs <executable> [args...]');
+  await runSmoke(executable, args, { port: Number(process.env.SMOKE_PORT || 54576), browser: true });
+}

--- a/scripts/ci/startup-smoke.test.mjs
+++ b/scripts/ci/startup-smoke.test.mjs
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import { createServer } from 'node:net';
+import test from 'node:test';
+import { runSmoke } from './startup-smoke.mjs';
+
+async function freePort() {
+  const server = createServer();
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const port = server.address().port;
+  await new Promise((resolve) => server.close(resolve));
+  return port;
+}
+
+const fixture = (port, status = 200) => [
+  '-e',
+  `require('http').createServer((req,res)=>{res.writeHead(${status});res.end('EchoType')}).listen(${port},'127.0.0.1')`,
+];
+
+test('real server becomes ready and stays alive', async () => {
+  const port = await freePort();
+  await runSmoke(process.execPath, fixture(port), { port, observeMs: 200, timeoutMs: 2000 });
+});
+
+test('an early exit cannot pass even with exit code zero', async () => {
+  await assert.rejects(
+    runSmoke(process.execPath, ['-e', 'process.exit(0)'], { port: await freePort(), timeoutMs: 1000 }),
+    /exited/,
+  );
+});
+
+test('an unrelated listener cannot satisfy readiness', async () => {
+  const server = createServer();
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  try {
+    await assert.rejects(runSmoke(process.execPath, [], { port: server.address().port }), /occupied/);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
+test('HTTP errors fail readiness', async () => {
+  const port = await freePort();
+  await assert.rejects(runSmoke(process.execPath, fixture(port, 500), { port, timeoutMs: 400 }), /not ready/);
+});

--- a/src-tauri/src/sidecar.rs
+++ b/src-tauri/src/sidecar.rs
@@ -1,5 +1,5 @@
 use std::net::TcpListener;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::{Duration, Instant};
 use tauri::{AppHandle, Manager};
@@ -136,27 +136,40 @@ fn wait_for_server(port: u16, timeout: Duration) -> Result<(), Box<dyn std::erro
     }
 }
 
-/// Start the Next.js standalone server and return the port
-pub fn start_server(app: &AppHandle) -> Result<u16, Box<dyn std::error::Error>> {
-    let port = find_server_port()?;
-    let node_path = get_node_binary_path(app)?;
-    let server_path = get_server_path(app)?;
-
+fn server_command(
+    node_path: &Path,
+    server_path: &Path,
+    port: u16,
+) -> Result<Command, Box<dyn std::error::Error>> {
     // Set the working directory to the standalone directory
     let working_dir = server_path
         .parent()
         .ok_or("Invalid server path")?
         .to_path_buf();
 
-    // Spawn the server process
-    let mut child = Command::new(&node_path)
-        .arg(&server_path)
+    let mut command = Command::new(node_path);
+    command
+        // Tauri can return a Windows verbatim path (\\?\...). Node cannot
+        // resolve that form as its entry script (#105). The working directory
+        // already identifies the standalone bundle, so keep the entry relative.
+        .arg("server.js")
         .current_dir(&working_dir)
         .env("PORT", port.to_string())
         // Bind explicitly to IPv4. On Windows, `localhost` may resolve to ::1
         // while the readiness probe and WebView use 127.0.0.1.
         .env("HOSTNAME", "127.0.0.1")
-        .env("NODE_ENV", "production")
+        .env("NODE_ENV", "production");
+    Ok(command)
+}
+
+/// Start the Next.js standalone server and return the port
+pub fn start_server(app: &AppHandle) -> Result<u16, Box<dyn std::error::Error>> {
+    let port = find_server_port()?;
+    let node_path = get_node_binary_path(app)?;
+    let server_path = get_server_path(app)?;
+
+    // Spawn the server process
+    let mut child = server_command(&node_path, &server_path, port)?
         .spawn()
         .map_err(|e| format!("Failed to start server: {}. Node path: {:?}", e, node_path))?;
 
@@ -173,6 +186,94 @@ pub fn start_server(app: &AppHandle) -> Result<u16, Box<dyn std::error::Error>> 
         Err(e) => {
             let _ = child.kill();
             Err(e)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::OsStr;
+
+    #[test]
+    fn node_starts_from_a_canonical_directory_with_spaces_and_unicode() {
+        let root = std::env::temp_dir().join(format!(
+            "echotype-105-{}-{} 空格",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir(&root).unwrap();
+        struct Cleanup(PathBuf);
+        impl Drop for Cleanup {
+            fn drop(&mut self) {
+                let _ = std::fs::remove_file(self.0.join("server.js"));
+                let _ = std::fs::remove_dir(&self.0);
+            }
+        }
+        let _cleanup = Cleanup(root.clone());
+        std::fs::write(
+            root.join("server.js"),
+            "if (process.env.PORT !== '12345' || process.env.HOSTNAME !== '127.0.0.1' || process.env.NODE_ENV !== 'production') process.exit(1); console.log('sidecar-started');",
+        ).unwrap();
+        // canonicalize produces a verbatim path on Windows, like resource_dir().
+        let server = root.join("server.js").canonicalize().unwrap();
+        let node = std::env::var_os("ECHOTYPE_TEST_NODE")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from("node"));
+        let output = server_command(&node, &server, 12345)
+            .unwrap()
+            .output()
+            .expect("Node.js must be installed to run the sidecar startup regression");
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout).trim(),
+            "sidecar-started"
+        );
+    }
+
+    #[test]
+    fn entry_argument_is_relative_to_the_standalone_directory() {
+        let root = std::env::temp_dir().join("EchoType test 中文");
+        let node = root.join("binaries").join("node");
+        let server = root.join("standalone").join("server.js");
+        let command = server_command(&node, &server, 12345).unwrap();
+        assert_eq!(command.get_program(), node.as_os_str());
+        assert_eq!(
+            command.get_args().collect::<Vec<_>>(),
+            [OsStr::new("server.js")]
+        );
+        assert_eq!(command.get_current_dir(), server.parent());
+        let envs = command
+            .get_envs()
+            .collect::<std::collections::HashMap<_, _>>();
+        assert_eq!(envs[OsStr::new("PORT")], Some(OsStr::new("12345")));
+        assert_eq!(envs[OsStr::new("HOSTNAME")], Some(OsStr::new("127.0.0.1")));
+        assert_eq!(envs[OsStr::new("NODE_ENV")], Some(OsStr::new("production")));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_verbatim_drive_and_unc_paths_never_reach_node_arguments() {
+        for root in [
+            r"\\?\C:\Users\Test User\EchoType",
+            r"\\?\UNC\server\share\EchoType",
+        ] {
+            let root = PathBuf::from(root);
+            let node = root.join("binaries").join("node.exe");
+            let server = root.join("standalone").join("server.js");
+            let command = server_command(&node, &server, 12345).unwrap();
+            assert_eq!(
+                command.get_args().collect::<Vec<_>>(),
+                [OsStr::new("server.js")]
+            );
+            assert_eq!(command.get_current_dir(), server.parent());
         }
     }
 }


### PR DESCRIPTION
## Summary
Fixes #105.

Use relative `server.js` when launching the bundled Node sidecar to avoid Windows verbatim-path resolution failures. Executable, working directory and environment remain unchanged.

Add automated startup checks on pull requests and main pushes for Windows, macOS, Linux, production Web and native iOS simulator.

## Issues found and fixed by verification
- iOS eagerly preloaded four hidden WebViews while the visible tab initialized the same IndexedDB; fresh simulator comparison reproduced a blank dashboard. Load tabs on first selection instead, preserving loaded tab state.
- Releasing an unvisited iOS tab constructed its lazy WebView during deinitialization and crashed. Pair observer cleanup with an explicit registration flag.
- Regression tests observed both original iOS failures before the fixes. No relaxed rendering assertions or timeout increases.

## Final validation: 560168c
All startup checks passed on the current head:
- Windows: bundled Node regression tests, NSIS build/install into a Unicode/space path, installed process and local server alive for 60 seconds, dashboard/library rendered in Chromium.
- macOS: bundled app launched from a Unicode/space path; same process/server/browser checks.
- Linux: deb installed, executable launched under Xvfb; same checks.
- Web: production server and actual dashboard/library headings, no uncaught page errors, 60-second health observation.
- iOS simulator: native unit and UI checks including three cold launches, real WKWebView dashboard content, 65-second survival, first Library load and return to Today.
- Standard lint, typecheck and build checks passed.

Desktop/Web: https://github.com/Talljack/echo-type/actions/runs/34490025606
iOS: https://github.com/Talljack/echo-type/actions/runs/34490025466

Artifacts include screenshots, Windows/Linux test installers and iOS XCTest results/logs. Local smoke-harness tests also pass.

## Scope and limits
Desktop page checks use separate Chromium against the bundled sidecar, not full embedded-window interaction. iOS uses an actual simulator WKWebView. These checks do not certify every OS/version/architecture, physical hardware, production signing, SmartScreen/Gatekeeper or external AI services. See docs/design/startup-verification.md.

No data migration, version bump, release publishing or merge performed.
