### PR TITLE
fix: inline practice translations and punctuation input (v1.4.1)

### DIFF
--- a/docs/releases/v1.4.1.md
+++ b/docs/releases/v1.4.1.md
@@ -1,0 +1,20 @@
+# EchoType v1.4.1
+
+## 中文
+
+- Type 译文直接放在对应英文句子下方，取消重复翻译卡片，完整参考原文可折叠。
+- Listen 和 Read 使用句下翻译，保留原文选词播放与阅读高亮。
+- 修复常用标点输入：兼容直/弯引号、全角标点、破折号及双向省略号输入，原始学习资料保持不变。
+- 修复输入法和软键盘通过输入事件提交字符时被漏接的问题，并避免重复计入预编辑文本。
+- 课程/单词本 Type 同步标点兼容规则；修复错词复习的译文位置。
+
+本次发布 Desktop：macOS Apple Silicon、Windows x64、Linux x64。不会清除或迁移学习数据；不包含 iOS 安装包。
+
+## English
+
+- Place translations below their English sentences in Type, Listen and Read without duplicate translation cards. Full typing reference text is collapsible.
+- Accept common typographic/fullwidth punctuation, dash variants and ellipses while preserving source materials.
+- Handle committed input and composition events from input methods and software keyboards without counting preedit text twice.
+- Apply punctuation compatibility to course/wordbook typing and align translations correctly during error-word review.
+
+Desktop release for Apple Silicon macOS, Windows x64 and Linux x64. No learning-data reset or migration; no iOS package.

--- a/docs/superpowers/plans/2026-09-11-inline-practice-translation.md
+++ b/docs/superpowers/plans/2026-09-11-inline-practice-translation.md
@@ -1,0 +1,27 @@
+# Inline practice translation implementation
+
+Goal: remove duplicate translation surfaces and unblock apostrophe typing without changing materials.
+
+- Add reducer regression tests in `src/hooks/use-typing-reducer.test.ts`: type ASCII `That's` against `That’s`, reverse the pair, verify errors still shake. Run `pnpm exec vitest run src/hooks/use-typing-reducer.test.ts` before and after the minimal comparison change.
+- Add tested sentence alignment in `src/lib/practice-translation.ts`: match normalized source words monotonically, retaining actual source indices and skipping unmatched translations. Test missing/repeated sentences and smart punctuation with Vitest.
+- In Write detail, collapse the optional reference using native `details`, remove the duplicated translation card and insert translations at matched source character ends in the typing display. Keep loading/retry inside the practice surface.
+- Extend `ReadAloudContent` to put each translation after its end word. Wire Listen and Read to source-aware ranges; preserve hidden transcript behavior, click-to-play and original formatting.
+- Run targeted tests, TypeScript and Biome, then browser checks for quote typing and inline translation at desktop and mobile sizes. Leave the branch uncommitted for user review.
+
+## Verification
+
+- Completed inline Type, Listen and Read changes; Speak already uses message-local translation.
+- Four quote regressions failed before the comparison fix, then passed. Twelve targeted unit tests pass, including repeated/missing sentence alignment and error-review offsets.
+- Five Chromium end-to-end tests pass: full screenshot article typed using ASCII apostrophe at 1440px and 375px, translation toggles, Listen/Read sentence pairs and error-word review.
+- TypeScript passes; changed production files pass Biome with existing warnings (Listen hook dependencies, selectable-word semantics and an unused suppression). No unsafe lint fixes applied.
+- Independent review caught error-review offsets; fixed by aligning against current reducer words instead of original article text and covered by browser regression.
+- Screenshots inspected at `/tmp/echotype-inline-type-1440.png` and `/tmp/echotype-inline-type-375.png`. Translation responses in browser tests are fixtures; live translation quality was not evaluated.
+- No desktop/iOS package build or native-device verification. Shared web implementation only. No commit, MR or release.
+
+## Follow-up: common punctuation input
+
+- Added shared punctuation compatibility to article and wordbook/course typing: quote variants, fullwidth ASCII punctuation, dash/minus variants, full stop and bidirectional ellipsis. Preserve source text and reject different punctuation.
+- Article typing now accepts committed input events as well as printable keydown. Composition preedit is ignored, committed text is consumed once, modifier/dead keys are not swallowed. The input remains hidden and uncontrolled.
+- Partial ellipsis is tracked independently and cleared on word retry/reset. Paused/shaking reducers reject batched input as well as keydown.
+- Reproduced five missing punctuation cases and the missing input-event path before fixes. Reverse smart ellipsis and course matching also failed before their fixes.
+- Targeted unit suite expanded to 23 passing tests. Browser suite now covers original layouts, full keyboard punctuation, no-keydown input and composition events. Synthetic composition checks are not native iOS hardware validation.

--- a/docs/superpowers/specs/2026-09-11-inline-practice-translation-design.md
+++ b/docs/superpowers/specs/2026-09-11-inline-practice-translation-design.md
@@ -1,0 +1,11 @@
+# Inline practice translations
+
+User direction: translations belong below the original, without a duplicate card; accept ordinary apostrophes when materials use smart punctuation. Existing authorization delegates design decisions and implementation.
+
+Keep the existing Tailwind, fonts, colors and native host integration. Type's actual character display is the original: show sentence translations directly below it, keep cursor feedback and one hidden input, and collapse the optional full reference. Do not change stored content, scoring rules for genuinely wrong characters, or translation settings/cache/retry.
+
+Listen and Read should reuse the word-aware reading view with inline sentence translations and preserve word playback/highlighting. Speak already renders translations below messages and stays unchanged. Missing or unmatched translations must never hide original words or shift later translations onto the wrong sentence.
+
+Alternatives rejected: shrinking the duplicate cards still separates context; side-by-side panes fail on phones. Inline sentence pairs work across web, desktop and the iOS web host without native layout forks.
+
+Verify straight/curly quote equivalence in both directions, real errors, partial/repeated sentence alignment, and browser layout at desktop and 375px. No release or remote changes in this task.

--- a/e2e/inline-practice-translation.spec.ts
+++ b/e2e/inline-practice-translation.spec.ts
@@ -1,0 +1,103 @@
+import { expect, test } from '@playwright/test';
+
+const source = 'Yesterday I finished the pagination API and reviewed two pull requests. Today I am focusing on a slow list endpoint. The p95 latency is about two seconds, so I will add an index and check for N+1 queries. I am blocked on staging access. If I get access this morning, I can ship a fix today. That’s it from me.';
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem('echotype_practice_translation', JSON.stringify({ visibility: { write: true, read: true, listen: true } }));
+  });
+  await page.route('**/api/translate/free', (route) => route.fulfill({ json: { translations: ['昨天我完成了分页 API，并审查了两个拉取请求。', '今天我在处理一个响应较慢的列表接口。', 'p95 延迟约为两秒，所以我会添加索引并检查 N+1 查询。', '我目前被预发布环境的访问权限问题卡住了。', '如果今天早上拿到权限，我今天就能发布修复。', '我说完了。'] } }));
+  await page.goto('/dashboard');
+  await page.locator('main[data-seeded="true"]').waitFor({ timeout: 60000 });
+  await page.evaluate(async (text) => {
+    await new Promise<void>((resolve, reject) => {
+      const request = indexedDB.open('echotype:anonymous');
+      request.onerror = () => reject(request.error);
+      request.onsuccess = () => {
+        const db = request.result;
+        const tx = db.transaction('contents', 'readwrite');
+        tx.objectStore('contents').put({ id: 'inline-translation-test', title: 'Inline translation test', text, type: 'article', source: 'imported', tags: [], createdAt: Date.now(), updatedAt: Date.now() });
+        tx.objectStore('contents').put({ id: 'punctuation-test', title: 'Punctuation test', text: '“That’s it”—wait… (OK)? [yes] {no}: a/b \\ @#$%^&*_+=|~`! 1–2; x<y>z...', type: 'article', source: 'imported', tags: [], createdAt: Date.now(), updatedAt: Date.now() });
+        tx.oncomplete = () => { db.close(); resolve(); };
+        tx.onerror = () => reject(tx.error);
+      };
+    });
+  }, source);
+});
+
+for (const width of [1440, 375]) {
+  test(`type pairs stay in the typing surface and ASCII apostrophe completes at ${width}px`, async ({ page }) => {
+    await page.setViewportSize({ width, height: 900 });
+    await page.goto('/write/inline-translation-test');
+    const surface = page.getByTestId('write-typing-scroll');
+    await expect(surface.getByTestId('write-inline-translation')).toHaveCount(6);
+    await page.getByRole('button', { name: 'Translation', exact: true }).click();
+    await expect(surface.getByTestId('write-inline-translation')).toHaveCount(0);
+    await page.getByRole('button', { name: 'Translation', exact: true }).click();
+    await expect(surface.getByTestId('write-inline-translation')).toHaveCount(6);
+    await expect(page.locator('details')).not.toHaveAttribute('open');
+    expect(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth)).toBe(true);
+    await surface.scrollIntoViewIfNeeded();
+    await page.screenshot({ path: `/tmp/echotype-inline-type-${width}.png` });
+    await page.getByRole('textbox', { name: 'Typing input' }).focus();
+    await page.keyboard.type(source.replace('’', "'"), { delay: 2 });
+    await expect(surface).not.toBeVisible();
+    await expect(page.getByText('100%', { exact: true }).first()).toBeVisible();
+  });
+}
+
+for (const module of ['listen', 'read']) {
+  test(`${module} places translations inside original text`, async ({ page }) => {
+    await page.goto(`/${module}/inline-translation-test`);
+    const text = page.getByTestId('read-aloud-content');
+    await expect(text.getByTestId('read-inline-translation')).toHaveCount(6);
+    await expect(text.getByText('That’s', { exact: true })).toHaveCount(1);
+  });
+}
+
+test('error review does not reuse full-article translation offsets', async ({ page }) => {
+  await page.goto('/write/inline-translation-test');
+  const input = page.getByRole('textbox', { name: 'Typing input' });
+  await input.focus();
+  await page.keyboard.type('x');
+  await expect(page.locator('.animate-shake')).toBeVisible();
+  await expect(page.locator('.animate-shake')).not.toBeVisible();
+  await page.keyboard.type(source.replace('’', "'"), { delay: 2 });
+  await page.getByRole('button', { name: 'Review Error Words' }).click();
+  const surface = page.getByTestId('write-typing-scroll');
+  await expect(surface).toContainText('Yesterday');
+  await expect(surface.getByTestId('write-inline-translation')).toHaveCount(0);
+});
+
+test('input events without printable keydown can complete typing', async ({ page }) => {
+  await page.goto('/write/inline-translation-test');
+  await page.getByRole('textbox', { name: 'Typing input' }).focus();
+  await page.keyboard.insertText(source);
+  await expect(page.getByTestId('write-typing-scroll')).not.toBeVisible();
+});
+
+test('common keyboard punctuation completes typographic source text', async ({ page }) => {
+  await page.goto('/write/punctuation-test');
+  await page.getByRole('textbox', { name: 'Typing input' }).focus();
+  await page.keyboard.type('"That\'s it"-wait... (OK)? [yes] {no}: a/b \\ @#$%^&*_+=|~`! 1-2; x<y>z...', { delay: 3 });
+  await expect(page.getByTestId('write-typing-scroll')).not.toBeVisible();
+  await expect(page.getByText('100%', { exact: true }).first()).toBeVisible();
+});
+
+test('composition commits punctuation once, without consuming preedit or modifiers', async ({ page }) => {
+  await page.goto('/write/punctuation-test');
+  const input = page.getByRole('textbox', { name: 'Typing input' });
+  await input.focus();
+  await page.keyboard.press('Shift');
+  await input.evaluate((element: HTMLInputElement) => {
+    element.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
+    element.value = 'wrong preedit';
+    element.dispatchEvent(new InputEvent('input', { bubbles: true, isComposing: true, data: element.value }));
+    element.value = '“';
+    element.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true, data: '“' }));
+    element.dispatchEvent(new InputEvent('input', { bubbles: true, data: '“' }));
+  });
+  await page.keyboard.insertText('That’s it”—wait… (OK)? [yes] {no}: a/b \\ @#$%^&*_+=|~`! 1–2; x<y>z…');
+  await expect(page.getByTestId('write-typing-scroll')).not.toBeVisible();
+  await expect(page.getByText('100%', { exact: true }).first()).toBeVisible();
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "echotype",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "private": true,
   "scripts": {
     "preinstall": "npx only-allow pnpm",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -868,7 +868,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "echotype"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "portpicker",
  "reqwest 0.12.28",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echotype"
-version = "1.4.0"
+version = "1.4.1"
 description = "EchoType - Learn English by Listening, Speaking, Reading & Writing"
 authors = ["EchoType"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicosResworksql/tauri-apps/tauri-v2/packages/tauri-utils/schema.json",
   "productName": "EchoType",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "identifier": "com.echotype.desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/app/(app)/listen/[id]/page.tsx
+++ b/src/app/(app)/listen/[id]/page.tsx
@@ -36,6 +36,7 @@ import { getIOSNativeQAMode } from '@/lib/ios-native-qa';
 import { scoreDictationAttempt } from '@/lib/listen-dictation';
 import { estimateSentenceHighlightTimings } from '@/lib/listen-highlight';
 import { getListenTranslationDisplayState } from '@/lib/listen-translation';
+import { alignPracticeTranslations } from '@/lib/practice-translation';
 import {
   attachWordBoundaryTracking,
   getBoundaryWordIndex,
@@ -1258,7 +1259,26 @@ export default function ListenDetailPage() {
                 isIOSNativeHost && `${IOS_LIST_CARD_CLASS} px-4 py-4`,
               )}
             >
-              <ReadAloudContent text={content.text} onWordClick={handleWordClick} />
+              <ReadAloudContent
+                text={content.text}
+                onWordClick={handleWordClick}
+                showTranslation={!!translationDisplayState?.sentenceTranslations?.length}
+                sentenceTranslations={alignPracticeTranslations(
+                  content.text,
+                  translationDisplayState?.sentenceTranslations,
+                )}
+              />
+              {translationDisplayState && (
+                <TranslationDisplay
+                  translation={
+                    translationDisplayState.sentenceTranslations?.length ? null : translationDisplayState.translation
+                  }
+                  isLoading={translationDisplayState.isLoading}
+                  show={true}
+                  error={translationDisplayState.error}
+                  onRetry={retryTranslation}
+                />
+              )}
             </div>
           ) : (
             <div
@@ -1268,17 +1288,6 @@ export default function ListenDetailPage() {
               <p className="text-sm font-medium text-slate-700">{t.hidden.transcriptHidden}</p>
               <p className="mt-2 text-xs text-slate-500">{t.hidden.keepListening}</p>
             </div>
-          )}
-
-          {translationDisplayState && (
-            <TranslationDisplay
-              translation={translationDisplayState.translation}
-              sentenceTranslations={translationDisplayState.sentenceTranslations}
-              isLoading={translationDisplayState.isLoading}
-              show={true}
-              error={translationDisplayState.error}
-              onRetry={retryTranslation}
-            />
           )}
         </CardContent>
       </Card>

--- a/src/app/(app)/read/[id]/page.tsx
+++ b/src/app/(app)/read/[id]/page.tsx
@@ -34,7 +34,6 @@ import { useShortcuts } from '@/hooks/use-shortcuts';
 import { useTranslation } from '@/hooks/use-translation';
 import { useTTS } from '@/hooks/use-tts';
 import { getAlignmentCache, setAlignmentCache } from '@/lib/alignment-cache';
-import { type ContentBlock, splitContentBlocks } from '@/lib/content-format';
 import { savePracticeSession } from '@/lib/daily-plan-progress';
 import { db } from '@/lib/db';
 import enReadDetail from '@/lib/i18n/messages/read-detail/en.json';
@@ -47,6 +46,7 @@ import {
   type WordResult,
 } from '@/lib/levenshtein';
 import { estimateSentenceHighlightTimings } from '@/lib/listen-highlight';
+import { alignPracticeTranslations } from '@/lib/practice-translation';
 import { attachWordBoundaryTracking, isSpeechSynthesisUtteranceResult } from '@/lib/read-aloud-playback';
 import { matchesShortcutEvent } from '@/lib/shortcut-utils';
 import { joinSpeechTranscripts } from '@/lib/speech-feedback';
@@ -118,58 +118,10 @@ export default function ReadDetailPage() {
     shouldPrefetch: true,
   });
 
-  const translatedBlocks: Array<{ block: ContentBlock; translations: string[] }> = useMemo(() => {
-    const blocks = splitContentBlocks(content?.text || '');
-    if (!sentenceTranslations?.length) {
-      return blocks.map((block) => ({ block, translations: [] as string[] }));
-    }
-
-    let sentenceIndex = 0;
-
-    const grouped = blocks.map((block) => {
-      const translations: string[] = [];
-      let consumedWords = 0;
-
-      while (sentenceIndex < sentenceTranslations.length && consumedWords < block.wordCount) {
-        const sentence = sentenceTranslations[sentenceIndex];
-        const sentenceWords = sentence.original.split(/\s+/).filter(Boolean).length;
-
-        if (translations.length > 0 && consumedWords + sentenceWords > block.wordCount) {
-          break;
-        }
-
-        translations.push(sentence.translation);
-        consumedWords += sentenceWords;
-        sentenceIndex += 1;
-      }
-
-      return { block, translations };
-    });
-
-    while (sentenceIndex < sentenceTranslations.length && grouped.length > 0) {
-      grouped[grouped.length - 1].translations.push(sentenceTranslations[sentenceIndex].translation);
-      sentenceIndex += 1;
-    }
-
-    return grouped;
-  }, [content?.text, sentenceTranslations]);
-
-  const readAloudSentenceTranslations = useMemo(() => {
-    if (!sentenceTranslations?.length) return null;
-
-    let startWordIndex = 0;
-
-    return sentenceTranslations.map((sentence) => {
-      const wordCount = sentence.original.split(/\s+/).filter(Boolean).length;
-      const entry = {
-        startWordIndex,
-        endWordIndex: startWordIndex + Math.max(wordCount - 1, 0),
-        translation: sentence.translation,
-      };
-      startWordIndex += wordCount;
-      return entry;
-    });
-  }, [sentenceTranslations]);
+  const readAloudSentenceTranslations = useMemo(
+    () => alignPracticeTranslations(content?.text ?? '', sentenceTranslations),
+    [content?.text, sentenceTranslations],
+  );
 
   const referenceWords = useMemo(
     () =>
@@ -1203,38 +1155,13 @@ export default function ReadDetailPage() {
                 isIOSNativeHost && `${IOS_LIST_CARD_CLASS} px-4 py-4`,
               )}
             >
-              {raIsActive ? (
+              {raIsActive || (showTranslation && readAloudSentenceTranslations.length > 0) ? (
                 <ReadAloudContent
                   text={content.text}
                   onWordClick={handleReadAloudWordClick}
                   showTranslation={showTranslation}
                   sentenceTranslations={readAloudSentenceTranslations}
                 />
-              ) : showTranslation && sentenceTranslations && sentenceTranslations.length > 0 ? (
-                <div className="space-y-4">
-                  {translatedBlocks.map(({ block, translations }) => (
-                    <div key={block.id} className="space-y-1.5">
-                      <div
-                        className={
-                          block.kind === 'title'
-                            ? 'text-2xl font-semibold text-indigo-900 leading-tight whitespace-pre-wrap'
-                            : block.kind === 'label'
-                              ? 'text-xs font-semibold tracking-[0.18em] text-indigo-400 whitespace-pre-wrap'
-                              : block.kind === 'quote'
-                                ? 'border-l-2 border-indigo-200 pl-4 text-lg italic leading-relaxed text-indigo-700 whitespace-pre-wrap'
-                                : 'text-lg leading-relaxed text-indigo-800 whitespace-pre-wrap'
-                        }
-                      >
-                        {block.text}
-                      </div>
-                      {translations.length > 0 && (
-                        <p className="text-sm text-indigo-400/80 leading-relaxed pl-0.5 whitespace-pre-wrap">
-                          {translations.join('\n')}
-                        </p>
-                      )}
-                    </div>
-                  ))}
-                </div>
               ) : (
                 <FormattedContentText
                   text={content.text}

--- a/src/app/(app)/write/[id]/page.tsx
+++ b/src/app/(app)/write/[id]/page.tsx
@@ -7,7 +7,7 @@ import { useParams, useRouter } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react';
 import { CrossModuleNav } from '@/components/shared/cross-module-nav';
 import { FormattedContentText } from '@/components/shared/formatted-content-text';
-import { IOS_LIST_CARD_CLASS, IOS_SECTION_CARD_CLASS } from '@/components/shared/ios-native-ui';
+import { IOS_SECTION_CARD_CLASS } from '@/components/shared/ios-native-ui';
 import { PageSpinner } from '@/components/shared/page-spinner';
 import { PracticeCompleteBanner } from '@/components/shared/practice-complete-banner';
 import { RecommendationPanel } from '@/components/shared/recommendation-panel';
@@ -26,6 +26,7 @@ import { db } from '@/lib/db';
 import enWriteDetail from '@/lib/i18n/messages/write-detail/en.json';
 import zhWriteDetail from '@/lib/i18n/messages/write-detail/zh.json';
 import { getIOSNativeQAMode } from '@/lib/ios-native-qa';
+import { alignPracticeTranslations } from '@/lib/practice-translation';
 import { matchesShortcutEvent } from '@/lib/shortcut-utils';
 import { detectIOSNativeHost, reportNativeQAState } from '@/lib/tauri';
 import { cn } from '@/lib/utils';
@@ -41,7 +42,7 @@ import type { ContentItem } from '@/types/content';
 const WRITE_DETAIL_LOCALES = { en: enWriteDetail, zh: zhWriteDetail } as const;
 
 const charColorMap = {
-  pending: 'text-slate-400',
+  pending: 'text-slate-600',
   correct: 'text-green-600',
   wrong: 'text-red-500 bg-red-50',
 };
@@ -68,6 +69,7 @@ export default function WriteDetailPage() {
   const [bootstrapReady, setBootstrapReady] = useState(false);
   const [state, dispatch] = useReducer(typingReducer, getInitialState());
   const inputRef = useRef<HTMLInputElement>(null);
+  const composingRef = useRef(false);
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const shakeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const cursorRef = useRef<HTMLSpanElement>(null);
@@ -91,6 +93,17 @@ export default function WriteDetailPage() {
     visible: showTranslation,
     shouldPrefetch: true,
   });
+
+  const inlineTranslations = useMemo(
+    () =>
+      new Map(
+        alignPracticeTranslations(state.words.join(' '), sentenceTranslations).map((entry) => [
+          entry.endCharIndex,
+          entry.translation,
+        ]),
+      ),
+    [state.words, sentenceTranslations],
+  );
 
   useEffect(() => {
     if (showTranslation && content?.text) fetchTranslation();
@@ -249,19 +262,29 @@ export default function WriteDetailPage() {
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
       if (state.mode === 'finished' || state.mode === 'paused' || state.isShaking) return;
-      e.preventDefault();
+      if (composingRef.current || e.nativeEvent.isComposing || e.key === 'Dead' || e.key === 'Process') return;
+      if (e.metaKey || (e.ctrlKey && !e.getModifierState('AltGraph'))) return;
 
       if (e.key === 'Escape' && state.mode === 'typing') {
+        e.preventDefault();
         dispatch({ type: 'PAUSE' });
         return;
       }
 
       if (e.key.length === 1) {
+        e.preventDefault();
         dispatch({ type: 'KEY_PRESS', key: e.key });
       }
     },
     [state.mode, state.isShaking],
   );
+
+  const commitInput = (input: HTMLInputElement) => {
+    const value = input.value;
+    input.value = '';
+    if (state.mode === 'finished' || state.mode === 'paused' || state.isShaking) return;
+    for (const key of value) dispatch({ type: 'KEY_PRESS', key: /\s/.test(key) ? ' ' : key });
+  };
 
   useEffect(() => {
     function handleGlobalKey(e: KeyboardEvent) {
@@ -518,20 +541,11 @@ export default function WriteDetailPage() {
 
       {state.mode !== 'finished' ? (
         <div className="relative">
-          <Card
-            className={cn(
-              isIOSNativeHost ? IOS_SECTION_CARD_CLASS : 'bg-indigo-50/50 border-indigo-100 shadow-sm',
-              'mb-3',
-            )}
-          >
-            <CardContent
-              data-testid="write-reference-scroll"
-              className="max-h-[28dvh] overflow-y-auto overscroll-contain p-5"
-            >
-              <div className="mb-3">
-                <h3 className="font-semibold text-indigo-900">{t.content.referenceText}</h3>
-                <p className="text-xs text-indigo-400 mt-1">{t.content.referenceHint}</p>
-              </div>
+          <details className="mb-3 rounded-xl bg-indigo-50/50 px-4">
+            <summary className="cursor-pointer py-3 text-sm font-medium text-indigo-900 focus-visible:outline-indigo-600">
+              {t.content.referenceText}
+            </summary>
+            <div data-testid="write-reference-scroll" className="max-h-[28dvh] overflow-y-auto overscroll-contain p-5">
               <FormattedContentText
                 text={content.text}
                 paragraphClassName="text-base leading-relaxed text-indigo-800"
@@ -539,38 +553,8 @@ export default function WriteDetailPage() {
                 labelClassName="text-xs font-semibold tracking-[0.18em] text-indigo-400"
                 quoteClassName="border-l-2 border-indigo-200 pl-4 text-base italic leading-relaxed text-indigo-700"
               />
-            </CardContent>
-          </Card>
-
-          {showTranslation && sentenceTranslations && sentenceTranslations.length > 0 ? (
-            <Card
-              className={cn(
-                isIOSNativeHost ? IOS_LIST_CARD_CLASS : 'bg-indigo-50/50 border-indigo-100 shadow-sm',
-                'mb-3',
-              )}
-            >
-              <CardContent className="p-4 space-y-2">
-                {sentenceTranslations.map((st, i) => (
-                  <div key={i}>
-                    <p className="text-sm leading-relaxed text-indigo-800 whitespace-pre-wrap">{st.original}</p>
-                    <p className="text-xs text-indigo-400/80 leading-relaxed mt-0.5 pl-0.5 whitespace-pre-wrap">
-                      {st.translation}
-                    </p>
-                  </div>
-                ))}
-              </CardContent>
-            </Card>
-          ) : showTranslation && translationLoading ? (
-            <TranslationDisplay translation={null} isLoading={true} show={true} error={translationError} />
-          ) : showTranslation && translationError ? (
-            <TranslationDisplay
-              translation={null}
-              isLoading={false}
-              show={true}
-              error={translationError}
-              onRetry={retryTranslation}
-            />
-          ) : null}
+            </div>
+          </details>
 
           <Card
             className={cn(
@@ -625,15 +609,48 @@ export default function WriteDetailPage() {
                       >
                         {char}
                       </span>
-                      {isParagraphBreak && <span className="block h-6 w-full" />}
+                      {showTranslation && inlineTranslations.has(idx) && (
+                        <span
+                          data-testid="write-inline-translation"
+                          className="block mb-4 mt-1 font-sans text-sm leading-relaxed tracking-normal text-slate-600 select-text"
+                        >
+                          {inlineTranslations.get(idx)}
+                        </span>
+                      )}
+                      {isParagraphBreak && !(showTranslation && inlineTranslations.has(idx - 1)) && (
+                        <span className="block h-6 w-full" />
+                      )}
                     </span>
                   );
                 })}
               </div>
 
+              <TranslationDisplay
+                translation={null}
+                isLoading={translationLoading}
+                show={showTranslation}
+                error={translationError}
+                onRetry={retryTranslation}
+              />
+
               <input
                 ref={inputRef}
                 onKeyDown={handleKeyDown}
+                onInput={(event) => {
+                  if (!composingRef.current && !(event.nativeEvent as InputEvent).isComposing)
+                    commitInput(event.currentTarget);
+                }}
+                onCompositionStart={() => {
+                  composingRef.current = true;
+                }}
+                onCompositionEnd={(event) => {
+                  composingRef.current = false;
+                  commitInput(event.currentTarget);
+                }}
+                autoCapitalize="off"
+                autoCorrect="off"
+                autoComplete="off"
+                spellCheck={false}
                 className="opacity-0 absolute -z-10 w-0 h-0"
                 aria-label={t.typing.inputLabel}
               />

--- a/src/components/read-aloud/read-aloud-content.tsx
+++ b/src/components/read-aloud/read-aloud-content.tsx
@@ -84,7 +84,7 @@ function SentenceBlock({
   isPlaying,
   getSentenceIndex,
   onWordClick,
-  translation,
+  translations,
 }: {
   block: ContentBlock;
   currentSentenceIndex: number;
@@ -92,7 +92,7 @@ function SentenceBlock({
   isPlaying: boolean;
   getSentenceIndex: (globalWordIndex: number) => number;
   onWordClick?: (word: string) => void;
-  translation: string | null;
+  translations: Map<number, string>;
 }) {
   return (
     <div>
@@ -123,12 +123,19 @@ function SentenceBlock({
                   onClick={onWordClick}
                 />
                 {localIndex < block.words.length - 1 ? ' ' : null}
+                {translations.has(globalIndex) && (
+                  <span
+                    data-testid="read-inline-translation"
+                    className="block mt-1 mb-3 text-sm leading-relaxed text-slate-600"
+                  >
+                    {translations.get(globalIndex)}
+                  </span>
+                )}
               </span>
             );
           })}
         </div>
       </div>
-      {translation && <p className="text-sm text-indigo-400 leading-relaxed mt-1 pl-0.5">{translation}</p>}
     </div>
   );
 }
@@ -148,22 +155,13 @@ export function ReadAloudContent({ text, onWordClick, showTranslation, sentenceT
     [sentences],
   );
 
-  const getTranslationForBlock = useCallback(
-    (block: ContentBlock): string | null => {
-      if (!showTranslation || !sentenceTranslations?.length) return null;
-      const translations = sentenceTranslations.filter(
-        (t) => t.startWordIndex >= block.wordStart && t.startWordIndex <= block.wordEnd,
-      );
-      if (translations.length === 0) return null;
-      return translations.map((t) => t.translation).join(' ');
-    },
-    [showTranslation, sentenceTranslations],
+  const translations = new Map(
+    showTranslation ? sentenceTranslations?.map((entry) => [entry.endWordIndex, entry.translation]) : [],
   );
 
   return (
     <div className="space-y-4" data-testid="read-aloud-content">
       {contentBlocks.map((block) => {
-        const translation = getTranslationForBlock(block);
         return (
           <SentenceBlock
             key={block.id}
@@ -173,7 +171,7 @@ export function ReadAloudContent({ text, onWordClick, showTranslation, sentenceT
             isPlaying={isPlaying}
             getSentenceIndex={getSentenceIndex}
             onWordClick={onWordClick}
-            translation={translation}
+            translations={translations}
           />
         );
       })}

--- a/src/components/translation/translation-bar.tsx
+++ b/src/components/translation/translation-bar.tsx
@@ -4,6 +4,7 @@ import { Languages } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import translationBarOptions from '@/lib/i18n/messages/translation-bar/options.json';
+import { useLanguageStore } from '@/stores/language-store';
 import { usePracticeTranslationStore } from '@/stores/practice-translation-store';
 import { useTTSStore } from '@/stores/tts-store';
 import type { PracticeModule } from '@/types/translation';
@@ -13,6 +14,7 @@ interface TranslationBarProps {
 }
 
 export function TranslationBar({ module }: TranslationBarProps) {
+  const language = useLanguageStore((s) => s.interfaceLanguage);
   const showTranslation = usePracticeTranslationStore((s) => s.isVisible(module));
   const toggleTranslation = usePracticeTranslationStore((s) => s.toggle);
   const targetLang = useTTSStore((s) => s.targetLang);
@@ -23,6 +25,8 @@ export function TranslationBar({ module }: TranslationBarProps) {
       <Button
         variant="ghost"
         size="icon"
+        aria-label={language === 'zh' ? '翻译' : 'Translation'}
+        aria-pressed={showTranslation}
         className={`h-8 w-8 cursor-pointer ${showTranslation ? 'text-indigo-600 bg-indigo-50' : 'text-indigo-400'}`}
         onClick={() => toggleTranslation(module)}
       >

--- a/src/hooks/use-typing-reducer.test.ts
+++ b/src/hooks/use-typing-reducer.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { getInitialState, typingReducer } from './use-typing-reducer';
+
+describe('typing punctuation', () => {
+  it.each([
+    ['That’s', "That's"],
+    ["That's", 'That’s'],
+    ['‘Hello’', "'Hello'"],
+    ['“Hello”', '"Hello"'],
+    ['Wait—really…', 'Wait-really...'],
+    ['Wait...really?', 'Wait…really?'],
+    ['1–2 −3', '1-2 -3'],
+    ['Hello，world！（OK？）', 'Hello,world!(OK?)'],
+    ['a: [b] {c} <d> / \\ @#$%^&*_+=|~`;', 'a： ［b］ ｛c｝ ＜d＞ ／ ＼ ＠＃＄％＾＆＊＿＋＝｜～｀；'],
+    ['.,!?;:()[]{}<>/\\@#$%^&*_+=|~`-', '.,!?;:()[]{}<>/\\@#$%^&*_+=|~`-'],
+  ])('accepts equivalent quotes in %s', (text, input) => {
+    let state = typingReducer(getInitialState(), { type: 'INIT', text });
+    for (const key of input) state = typingReducer(state, { type: 'KEY_PRESS', key });
+    expect(state.mode).toBe('finished');
+    expect(state.errorCount).toBe(0);
+    expect(state.words.join(' ')).toBe(text);
+  });
+
+  it('still rejects a genuinely different character', () => {
+    const state = typingReducer(getInitialState(), { type: 'INIT', text: 'a' });
+    expect(typingReducer(state, { type: 'KEY_PRESS', key: 'b' }).isShaking).toBe(true);
+  });
+  it('does not finish an ellipsis after a single dot', () => {
+    let state = typingReducer(getInitialState(), { type: 'INIT', text: '…' });
+    state = typingReducer(state, { type: 'KEY_PRESS', key: '.' });
+    expect(state.mode).toBe('typing');
+    expect(state.errorCount).toBe(0);
+    for (const key of '..') state = typingReducer(state, { type: 'KEY_PRESS', key });
+    expect(state.mode).toBe('finished');
+    expect(state.accuracy).toBe(100);
+  });
+  it('does not accept ellipsis for a single period', () => {
+    const state = typingReducer(getInitialState(), { type: 'INIT', text: '.' });
+    expect(typingReducer(state, { type: 'KEY_PRESS', key: '…' }).isShaking).toBe(true);
+  });
+});

--- a/src/hooks/use-typing-reducer.ts
+++ b/src/hooks/use-typing-reducer.ts
@@ -1,3 +1,5 @@
+import { normalizeTypingPunctuation } from '@/lib/practice-translation';
+
 export interface TypingState {
   mode: 'idle' | 'typing' | 'paused' | 'finished';
   words: string[];
@@ -5,6 +7,7 @@ export interface TypingState {
   currentCharIndex: number;
   charStates: ('pending' | 'correct' | 'wrong')[];
   inputBuffer: string;
+  pendingSymbol: string;
   errorCount: number;
   correctCount: number;
   totalKeystrokes: number;
@@ -40,6 +43,7 @@ function getInitialState(): TypingState {
     currentCharIndex: 0,
     charStates: [],
     inputBuffer: '',
+    pendingSymbol: '',
     errorCount: 0,
     correctCount: 0,
     totalKeystrokes: 0,
@@ -95,7 +99,7 @@ export function typingReducer(state: TypingState, action: TypingAction): TypingS
     }
 
     case 'KEY_PRESS': {
-      if (state.mode === 'finished') return state;
+      if (state.mode === 'finished' || state.mode === 'paused' || state.isShaking) return state;
 
       const newState = { ...state };
       if (newState.mode === 'idle') {
@@ -147,13 +151,25 @@ export function typingReducer(state: TypingState, action: TypingAction): TypingS
         };
       }
 
-      if (action.key === expectedChar) {
+      const expectedSymbol = expectedChar === undefined ? '' : normalizeTypingPunctuation(expectedChar);
+      const typedSymbol = state.pendingSymbol + normalizeTypingPunctuation(action.key);
+      if (expectedSymbol.startsWith(typedSymbol) && typedSymbol !== expectedSymbol) {
+        return { ...newState, pendingSymbol: typedSymbol, correctCount: newState.correctCount + 1 };
+      }
+      // A smart keyboard can commit one ellipsis for three literal source dots.
+      const sourceDots =
+        !state.pendingSymbol &&
+        action.key === '…' &&
+        currentWord.slice(state.currentCharIndex, state.currentCharIndex + 3) === '...';
+      const consumedChars = sourceDots ? 3 : 1;
+      if ((expectedSymbol && typedSymbol === expectedSymbol) || sourceDots) {
+        newState.pendingSymbol = '';
         // Correct character
         const globalIdx = getGlobalCharIndex(state.words, state.currentWordIndex, state.currentCharIndex);
         const newCharStates = [...state.charStates];
-        newCharStates[globalIdx] = 'correct';
+        for (let offset = 0; offset < consumedChars; offset++) newCharStates[globalIdx + offset] = 'correct';
 
-        const nextCharIndex = state.currentCharIndex + 1;
+        const nextCharIndex = state.currentCharIndex + consumedChars;
         const isLastCharOfWord = nextCharIndex === currentWord.length;
         const isLastWord = state.currentWordIndex === state.words.length - 1;
 
@@ -219,6 +235,7 @@ export function typingReducer(state: TypingState, action: TypingAction): TypingS
         currentCharIndex: 0,
         inputBuffer: '',
         isShaking: false,
+        pendingSymbol: '',
       };
     }
 

--- a/src/lib/practice-translation.test.ts
+++ b/src/lib/practice-translation.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { alignPracticeTranslations } from './practice-translation';
+
+describe('practice translation alignment', () => {
+  it('uses source indices, including untranslated and repeated sentences', () => {
+    const result = alignPracticeTranslations('Title\n\nHello. Hello. That’s it.', [
+      { original: 'Hello.', translation: '你好一' },
+      { original: 'Not present.', translation: '忽略' },
+      { original: 'Hello.', translation: '你好二' },
+      { original: "That's it.", translation: '就是这样' },
+    ]);
+    expect(result.map(({ startWordIndex, endWordIndex, endCharIndex }) => [startWordIndex, endWordIndex, endCharIndex]))
+      .toEqual([[1, 1, 11], [2, 2, 18], [3, 4, 29]]);
+  });
+  it('does not attach invented text to the original', () => {
+    expect(alignPracticeTranslations('Hello.', [{ original: 'Goodbye.', translation: '再见' }])).toEqual([]);
+    expect(alignPracticeTranslations('Hello.', null)).toEqual([]);
+  });
+  it('realigns error-word review without reusing original character offsets', () => {
+    expect(alignPracticeTranslations('World!', [
+      { original: 'Hello.', translation: '你好' },
+      { original: 'World!', translation: '世界' },
+    ])).toEqual([{ startWordIndex: 0, endWordIndex: 0, endCharIndex: 5, translation: '世界' }]);
+  });
+});

--- a/src/lib/practice-translation.ts
+++ b/src/lib/practice-translation.ts
@@ -1,0 +1,39 @@
+/** Compare typographic quote variants without rewriting learning materials. */
+export function normalizePracticeQuotes(text: string): string {
+  return text.replace(/[‘’ʼ＇]/g, "'").replace(/[“”＂]/g, '"');
+}
+
+/** Keyboard equivalents for punctuation only; letters, accents and case stay strict. */
+export function normalizeTypingPunctuation(text: string): string {
+  return normalizePracticeQuotes(text)
+    .replace(/[！-／：-＠［-｀｛-～]/g, (char) => String.fromCharCode(char.charCodeAt(0) - 0xfee0))
+    .replace(/[‐‑‒–—−]/g, '-')
+    .replace(/。/g, '.')
+    .replace(/…/g, '...');
+}
+
+export function alignPracticeTranslations(
+  text: string,
+  sentences: Array<{ original: string; translation: string }> | null | undefined,
+) {
+  const words = text.split(/\s+/).filter(Boolean);
+  const normalized = words.map(normalizePracticeQuotes);
+  const ends: number[] = [];
+  let offset = 0;
+  for (const word of words) {
+    ends.push(offset + word.length - 1);
+    offset += word.length + 1;
+  }
+  let cursor = 0;
+  return (sentences ?? []).flatMap((sentence) => {
+    const target = normalizePracticeQuotes(sentence.original).split(/\s+/).filter(Boolean);
+    if (!target.length) return [];
+    for (let start = cursor; start <= words.length - target.length; start++) {
+      if (!target.every((word, index) => normalized[start + index] === word)) continue;
+      const end = start + target.length - 1;
+      cursor = end + 1;
+      return [{ startWordIndex: start, endWordIndex: end, endCharIndex: ends[end], translation: sentence.translation }];
+    }
+    return [];
+  });
+}

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = '1.4.0';
+export const APP_VERSION = '1.4.1';

--- a/src/lib/wordbook-write-target.test.ts
+++ b/src/lib/wordbook-write-target.test.ts
@@ -37,6 +37,11 @@ describe('resolveWordBookWriteTarget', () => {
 });
 
 describe('isWordBookWriteMatch', () => {
+  it('accepts common typographic and fullwidth punctuation in course typing', () => {
+    expect(isWordBookWriteMatch('Wait... (OK)? 1-2', 'Wait… （OK）？ 1–2')).toBe(true);
+    expect(isWordBookWriteMatch('x＋y＝z！', 'x+y=z!')).toBe(true);
+    expect(isWordBookWriteMatch('Stop!', 'Stop?')).toBe(false);
+  });
   it('treats straight and curly apostrophes as the same typing answer', () => {
     expect(isWordBookWriteMatch("Los Angeles'", "Los Angeles’")).toBe(true);
     expect(isWordBookWriteMatch('Los Angeles’', "Los Angeles'")).toBe(true);

--- a/src/lib/wordbook-write-target.ts
+++ b/src/lib/wordbook-write-target.ts
@@ -1,3 +1,4 @@
+import { normalizeTypingPunctuation } from '@/lib/practice-translation';
 import type { ContentItem } from '@/types/content';
 
 export interface WordBookWriteTarget {
@@ -20,7 +21,7 @@ export function resolveWordBookWriteTarget(item: ContentItem): WordBookWriteTarg
 }
 
 export function normalizeWordBookWriteText(text: string): string {
-  return text.replace(/[‘’]/g, "'").replace(/[“”]/g, '"').trim().toLowerCase();
+  return normalizeTypingPunctuation(text).trim().toLowerCase();
 }
 
 export function normalizeWordBookWriteChar(char: string): string {


### PR DESCRIPTION
# EchoType v1.4.1

## 中文

- Type 译文直接放在对应英文句子下方，取消重复翻译卡片，完整参考原文可折叠。
- Listen 和 Read 使用句下翻译，保留原文选词播放与阅读高亮。
- 修复常用标点输入：兼容直/弯引号、全角标点、破折号及双向省略号输入，原始学习资料保持不变。
- 修复输入法和软键盘通过输入事件提交字符时被漏接的问题，并避免重复计入预编辑文本。
- 课程/单词本 Type 同步标点兼容规则；修复错词复习的译文位置。

本次发布 Desktop：macOS Apple Silicon、Windows x64、Linux x64。不会清除或迁移学习数据；不包含 iOS 安装包。

## English

- Place translations below their English sentences in Type, Listen and Read without duplicate translation cards. Full typing reference text is collapsible.
- Accept common typographic/fullwidth punctuation, dash variants and ellipses while preserving source materials.
- Handle committed input and composition events from input methods and software keyboards without counting preedit text twice.
- Apply punctuation compatibility to course/wordbook typing and align translations correctly during error-word review.

Desktop release for Apple Silicon macOS, Windows x64 and Linux x64. No learning-data reset or migration; no iOS package.
